### PR TITLE
Markdown support for posts

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -27,6 +27,7 @@ gem 'doorkeeper'
 gem 'newrelic_rpm'
 gem 'wice_grid'
 gem 'strip_attributes'
+gem 'redcarpet'
 
 gem 'system'
 gem 'unicorn'

--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -29,6 +29,9 @@ gem 'wice_grid'
 gem 'strip_attributes'
 gem 'redcarpet'
 
+# TODO remove me after all posts have been updated to markdown
+gem 'reverse_markdown'
+
 gem 'system'
 gem 'unicorn'
 

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -207,6 +207,8 @@ GEM
     ref (1.0.5)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
+    reverse_markdown (0.6.0)
+      nokogiri
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
@@ -321,6 +323,7 @@ DEPENDENCIES
   rails (= 4.2.1)
   recaptcha
   redcarpet
+  reverse_markdown
   rspec-rails
   sass-rails
   sdoc

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -203,6 +203,7 @@ GEM
       ffi (>= 0.5.0)
     rdoc (4.2.0)
     recaptcha (0.4.0)
+    redcarpet (3.2.0)
     ref (1.0.5)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
@@ -319,6 +320,7 @@ DEPENDENCIES
   pre-commit
   rails (= 4.2.1)
   recaptcha
+  redcarpet
   rspec-rails
   sass-rails
   sdoc
@@ -338,4 +340,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.10.2
+   1.10.5

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -22,4 +22,8 @@ module ApplicationHelper
       recaptcha_error: "alert-danger"
     }[flash_type.to_sym] || flash_type.to_s
   end
+
+  def md(content)
+    Redcarpet::Markdown.new(Redcarpet::Render::HTML.new).render(content).html_safe
+  end
 end

--- a/WcaOnRails/app/views/posts/_post.html.erb
+++ b/WcaOnRails/app/views/posts/_post.html.erb
@@ -22,6 +22,6 @@
     <div>
       <em>Announced by <%= post.author.name %> on <%= local_time(post.created_at) %></em>
     </div>
-    <%= post.body.html_safe %>
+    <%=md post.body %>
   </div>
 </div>

--- a/WcaOnRails/lib/tasks/posts_to_markdown.rake
+++ b/WcaOnRails/lib/tasks/posts_to_markdown.rake
@@ -1,0 +1,12 @@
+namespace :WcaOnRails do
+  namespace :posts do
+    # TODO remove me after all posts have been updated to markdown
+    task :migrate_to_markdown => :environment do
+      Post.transaction do
+        Post.all.each do |post|
+          post.update_attributes(body: ReverseMarkdown.convert(post.body))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This should close #100. Could someone review it?

I'm not sure whether converting old posts to markdown format is desirable. If not, you can simply cherry pick the first commit.