### PR TITLE
Harden HTTPS

### DIFF
--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -145,6 +145,8 @@ bash "build nginx" do
     ./configure --sbin-path=/usr/local/sbin --with-http_ssl_module --with-http_auth_request_module --with-http_gzip_static_module --conf-path=/etc/nginx/nginx.conf --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log
     make
     sudo make install
+    # at the same time we generate the Diffie-Hellman parameters
+    openssl dhparam -out /etc/nginx/dh4096.pem -outform PEM -2 4096
     EOH
 
   # Don't build nginx if we've already built it.

--- a/chef/site-cookbooks/wca/templates/wca_https.conf.erb
+++ b/chef/site-cookbooks/wca/templates/wca_https.conf.erb
@@ -1,36 +1,29 @@
-ssl on;
-
-
-### (gagz) 
-# I've read and followed this guide for my server
+### 
+# Following this :
 # https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
-# I'm reproducing it here.
 ###
 
+# Enable SSL
+ssl on;
 
-# private key (should be generated locally and not by our CA)
+# Private key (should be generated locally and not by our CA)
 ssl_certificate_key <%= @repo_root %>/secrets/<%= @server_name %>.key;
 
 # Signed certificate + intermediates certificates
 ssl_certificate <%= @repo_root %>/secrets/<%= @server_name %>.chained.crt;
 
-# strong DH parameters
-# the DH file is generated using the above command (takes about 20 minutes)
+# Strong DH parameters
+# The DH file is generated using the above command (takes about 20 minutes)
 # root@wca# openssl dhparam -out dh4096.pem -outform PEM -2 4096
 ssl_dhparam /etc/nginx/dh4096.pem;
-
 
 # Recommended security settings from https://wiki.mozilla.org/Security/Server_Side_TLS
 ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 
-
 ### CIPHERS
 # See https://wiki.mozilla.org/Security/Server_Side_TLS
 
-# old value by jeremy
-#ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK';
-
-# (gagz) new value (recommended by mozilla for "interdemdiate compatibility")
+# Recommended by mozilla for "interdemdiate compatibility"
 # Firefox 1, Chrome 1, IE 7, Opera 5, Safari 1, Windows XP IE8, Android 2.3, Java 7
 ssl_ciphers "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
 
@@ -39,27 +32,25 @@ ssl_session_timeout 5m;
 ssl_session_cache shared:SSL:5m;
 
 
-# Enable this if you want HSTS (recommended)
-# (gagz) we don't need the preload here as its usage is for HSTS proload list
-# kept up to date by chrome, and in which we would have to register.
-# The IncludeSubdomains is great bu dangerous : if at some point we have
+# Enable HSTS for the website and its subdomains, and check the preload list.
+# The includeSubdomains is great but dangerous : if at some point we have
 # a subdomain hosted on another server, we'd have to make sure they have a correct
-# SSL cert, because the domain will be HSTS-ed... Anyway, we shoudln't have this
+# SSL cert, because the domain will be HSTS-ed... Anyway, we shouldn't have this
 # problem.
 add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
 
-# (gagz) enables ssl stapling
+# Enable ssl stapling
 ssl_stapling on;
 ssl_stapling_verify on;
 
-# verify chain of trust of OCSP response using Root CA and Intermediate certs
+# Verify chain of trust of OCSP response using Root CA and Intermediate certs
+# -> disabled until we get the correct root and Intermediate CAs
 #ssl_trusted_certificate /path/to/root_CA_cert_plus_intermediates;
 
+# OCSP resolver config
 resolver 208.67.222.222 208.67.220.220 valid=300s;
 resolver_timeout 5s;
 
-# (gagz) I have this one enabled on my server, but it prevents
-# websites from being loaded into a fram or an iframe, and we
+# This would prevent our website from being loaded on a frame or an iframe, but we
 # actually have our prereg form loaded on some external sites...
 #add_header X-Frame-Options DENY;
-

--- a/chef/site-cookbooks/wca/templates/wca_https.conf.erb
+++ b/chef/site-cookbooks/wca/templates/wca_https.conf.erb
@@ -1,15 +1,65 @@
 ssl on;
 
-# From https://sslmate.com/help/getting_started
+
+### (gagz) 
+# I've read and followed this guide for my server
+# https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
+# I'm reproducing it here.
+###
+
+
+# private key (should be generated locally and not by our CA)
 ssl_certificate_key <%= @repo_root %>/secrets/<%= @server_name %>.key;
+
+# Signed certificate + intermediates certificates
 ssl_certificate <%= @repo_root %>/secrets/<%= @server_name %>.chained.crt;
+
+# strong DH parameters
+# the DH file is generated using the above command (takes about 20 minutes)
+# root@wca# openssl dhparam -out dh4096.pem -outform PEM -2 4096
+ssl_dhparam /etc/nginx/dh4096.pem;
+
 
 # Recommended security settings from https://wiki.mozilla.org/Security/Server_Side_TLS
 ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK';
+
+
+### CIPHERS
+# See https://wiki.mozilla.org/Security/Server_Side_TLS
+
+# old value by jeremy
+#ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK';
+
+# (gagz) new value (recommended by mozilla for "interdemdiate compatibility")
+# Firefox 1, Chrome 1, IE 7, Opera 5, Safari 1, Windows XP IE8, Android 2.3, Java 7
+ssl_ciphers "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
+
 ssl_prefer_server_ciphers on;
 ssl_session_timeout 5m;
 ssl_session_cache shared:SSL:5m;
 
+
 # Enable this if you want HSTS (recommended)
+# (gagz) we don't need the preload here as its usage is for HSTS proload list
+# kept up to date by chrome, and in which we would have to register.
+# The IncludeSubdomains is great bu dangerous : if at some point we have
+# a subdomain hosted on another server, we'd have to make sure they have a correct
+# SSL cert, because the domain will be HSTS-ed... Anyway, we shoudln't have this
+# problem.
 add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
+
+# (gagz) enables ssl stapling
+ssl_stapling on;
+ssl_stapling_verify on;
+
+# verify chain of trust of OCSP response using Root CA and Intermediate certs
+#ssl_trusted_certificate /path/to/root_CA_cert_plus_intermediates;
+
+resolver 208.67.222.222 208.67.220.220 valid=300s;
+resolver_timeout 5s;
+
+# (gagz) I have this one enabled on my server, but it prevents
+# websites from being loaded into a fram or an iframe, and we
+# actually have our prereg form loaded on some external sites...
+#add_header X-Frame-Options DENY;
+


### PR DESCRIPTION
Adding DH Prime, using "intermediate compatibility" from Mozilla, enabling HSTS and OCSP stappling.