### PR TITLE
Generate HTML from Markdown in RSS feed

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -62,6 +62,7 @@ group :test do
   gem 'guard-rspec'
   gem 'launchy'
   gem 'capybara'
+  gem 'oga' # XML parsing library introduced for testing RSS feed
 end
 
 group :production do

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -37,7 +37,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
+    ansi (1.5.0)
     arel (6.0.0)
+    ast (2.1.0)
     autoprefixer-rails (5.2.1)
       execjs
       json
@@ -171,6 +173,9 @@ GEM
     notiffany (0.0.6)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    oga (1.2.3)
+      ast
+      ruby-ll (~> 2.1)
     orm_adapter (0.5.0)
     pluginator (1.3.0)
     pre-commit (0.23.0)
@@ -238,6 +243,9 @@ GEM
       rspec-mocks (~> 3.2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
+    ruby-ll (2.1.2)
+      ansi
+      ast
     sass (3.4.16)
     sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -336,6 +344,7 @@ DEPENDENCIES
   mail_form
   mysql2
   newrelic_rpm
+  oga
   pre-commit
   rails (= 4.2.1)
   recaptcha

--- a/WcaOnRails/app/views/posts/rss.xml.builder
+++ b/WcaOnRails/app/views/posts/rss.xml.builder
@@ -8,7 +8,7 @@ xml.rss :version => "2.0", "xmlns:dc" => "http://purl.org/dc/elements/1.1/" do
     for post in @posts
       xml.item do
         xml.title post.title
-        xml.description post.body
+        xml.description cdata_section(md(post.body))
         xml.pubDate post.created_at.to_s(:rfc822)
         xml.tag! "dc:creator", post.author.name
 

--- a/WcaOnRails/spec/factories/posts.rb
+++ b/WcaOnRails/spec/factories/posts.rb
@@ -3,6 +3,13 @@ FactoryGirl.define do
     body { Faker::Lorem.paragraph }
     title { Faker::Hacker.say_something_smart }
     slug { title.parameterize }
+    sticky false
     author
+
+    trait :sticky do
+      sticky true
+    end
+
+    factory :sticky_post, traits: [:sticky]
   end
 end

--- a/WcaOnRails/spec/requests/rss_spec.rb
+++ b/WcaOnRails/spec/requests/rss_spec.rb
@@ -1,12 +1,47 @@
 require "rails_helper"
 
 describe "rss" do
-  include Capybara::DSL
+  include Rack::Test::Methods
 
-  it 'rss smoke test' do
-    post = FactoryGirl.create :post, created_at: Time.now
-    sticky_post = FactoryGirl.create :post, sticky: true, created_at: 1.hours.ago
-    get rss_path, format: :xml
-    expect(response).to be_success
+  let!(:post_1) { FactoryGirl.create :post,
+                                     body: 'foo **a**',
+                                     title: 'bar',
+                                     created_at: DateTime.new(2014, 3, 12, 12, 32, 42) }
+  let!(:post_2) { FactoryGirl.create :sticky_post,
+                                     body: '[link](http://google.de)',
+                                     title: 'sticky post',
+                                     created_at: DateTime.new(2014, 3, 14, 11, 18, 00) }
+
+  describe "posts" do
+    before do
+      get rss_path, format: :xml
+    end
+
+    it "returns all titles" do
+      titles = xml_contents_at('rss/channel/item/title')
+
+      expect(titles).to eq ['sticky post', 'bar']
+    end
+
+    it "returns all descriptions converted to HTML and wrapped in CDATA" do
+      descriptions = xml_contents_at('rss/channel/item/description')
+
+      expect(descriptions).to eq ["<![CDATA[<p><a href=\"http://google.de\">link</a></p>\n]]>",
+                                  "<![CDATA[<p>foo <strong>a</strong></p>\n]]>"]
+    end
+
+    it "returns all publication dates as rfc822" do
+      pub_dates = xml_contents_at('rss/channel/item/pubDate')
+
+      expect(pub_dates).to eq ['Fri, 14 Mar 2014 11:18:00 +0000', 'Wed, 12 Mar 2014 12:32:42 +0000']
+    end
+  end
+
+  def xml_response
+    Oga.parse_xml(last_response.body)
+  end
+
+  def xml_contents_at(xpath)
+    xml_response.xpath(xpath).map(&:inner_text)
   end
 end


### PR DESCRIPTION
According to http://stackoverflow.com/a/10099772 you can use `CDATA` or escape the generated HTML in RSS feeds. I looked at http://devblog.avdi.org/feed/ and http://www.smashingmagazine.com/feed/ and both use CDATA for "escaping", so I just went with it.

This should fix #127.