### PR TITLE
Fix syntax errors in oauth controller/specs

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -20,15 +20,15 @@ class Api::V0::ApiController < ApplicationController
 
   def scramble_program
     render json: {
-      "current": {
-        "name": "TNoodle-WCA-0.10.0",
-        "information": "#{root_url}regulations/scrambles/",
-        "download": "#{root_url}regulations/scrambles/tnoodle/TNoodle-WCA-0.10.0.jar"
+      "current" => {
+        "name" => "TNoodle-WCA-0.10.0",
+        "information" => "#{root_url}regulations/scrambles/",
+        "download" => "#{root_url}regulations/scrambles/tnoodle/TNoodle-WCA-0.10.0.jar"
       },
-      "allowed": [
+      "allowed" => [
         "TNoodle-WCA-0.10.0"
       ],
-      "history": [
+      "history" => [
         "TNoodle-0.7.4",       # 2013-01-01
         "TNoodle-0.7.5",       # 2013-02-26
         "TNoodle-0.7.8",       # 2013-04-26

--- a/WcaOnRails/spec/requests/oauth/oauth_spec.rb
+++ b/WcaOnRails/spec/requests/oauth/oauth_spec.rb
@@ -63,7 +63,7 @@ describe "oauth api" do
 
   def verify_access_token(access_token)
     integration_session.reset! # posting to oauth_token_path littered our state
-    get api_v0_me_path, nil, { "Authorization": "Bearer #{access_token}" }
+    get api_v0_me_path, nil, { "Authorization" => "Bearer #{access_token}" }
     expect(response).to be_success
     json = JSON.parse(response.body)
     expect(json['me']['email']).to eq(user.email)


### PR DESCRIPTION
Did the oauth specs work for you, @jfly? I can't remember `{"foo": "bar"}` being valid syntax for maps. Maybe it is for Ruby 2.2+?