### PR TITLE
Do not escape rss content wrapped in CDATA

### DIFF
--- a/WcaOnRails/app/views/posts/rss.xml.builder
+++ b/WcaOnRails/app/views/posts/rss.xml.builder
@@ -8,7 +8,9 @@ xml.rss :version => "2.0", "xmlns:dc" => "http://purl.org/dc/elements/1.1/" do
     for post in @posts
       xml.item do
         xml.title post.title
-        xml.description cdata_section(md(post.body))
+        xml.description do
+          xml << cdata_section(md(post.body))
+        end
         xml.pubDate post.created_at.to_s(:rfc822)
         xml.tag! "dc:creator", post.author.name
 

--- a/WcaOnRails/spec/requests/rss_spec.rb
+++ b/WcaOnRails/spec/requests/rss_spec.rb
@@ -24,10 +24,10 @@ describe "rss" do
     end
 
     it "returns all descriptions converted to HTML and wrapped in CDATA" do
-      descriptions = xml_contents_at('rss/channel/item/description')
+      descriptions = xml_nodes_at('rss/channel/item/description')
 
-      expect(descriptions).to eq ["<![CDATA[<p><a href=\"http://google.de\">link</a></p>\n]]>",
-                                  "<![CDATA[<p>foo <strong>a</strong></p>\n]]>"]
+      expect(descriptions.map(&:to_xml)).to eq ["<description>\n<![CDATA[<p><a href=\"http://google.de\">link</a></p>\n]]>      </description>",
+                                                "<description>\n<![CDATA[<p>foo <strong>a</strong></p>\n]]>      </description>"]
     end
 
     it "returns all publication dates as rfc822" do
@@ -41,7 +41,11 @@ describe "rss" do
     Oga.parse_xml(last_response.body)
   end
 
+  def xml_nodes_at(xpath)
+    xml_response.xpath(xpath)
+  end
+
   def xml_contents_at(xpath)
-    xml_response.xpath(xpath).map(&:inner_text)
+    xml_nodes_at(xpath).map(&:text)
   end
 end


### PR DESCRIPTION
This should fix #145.

`curl https://www.worldcubeassociation.org/rss.xml` currently results in the following:

```
<description>&lt;![CDATA[&lt;p&gt;The &lt;a href="https://www.worldcubeassociation.org/results/c.php?i=BrisbaneSpring2015"&gt;Brisbane Spring 2015&lt;/a&gt; will take place on September 19, 2015 in Brisbane, Australia. Check out the &lt;a href="http://www.speedcubing.com.au"&gt;Brisbane Spring 2015 website&lt;/a&gt; for more information and registration.&lt;/p&gt;
]]&gt;</description>
```