### PR TITLE
Cache bundler on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.2.3
 before_install: cd WcaOnRails/


### PR DESCRIPTION
This should speed up the travis runs by not running `bundle install` every time. See http://docs.travis-ci.com/user/caching/#Bundler.