### PR TITLE
Additional validations when confirming a competition. Fixes #179.

### DIFF
--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -12,6 +12,7 @@ FactoryGirl.define do
 
     eventSpecs "333 333oh"
     venue "My backyard"
+    venueAddress "My backyard street"
     website "https://www.worldcubeassociation.org"
     showAtAll true
   end

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -213,4 +213,34 @@ RSpec.describe Competition do
       expect(CompetitionOrganizer.find_by_id(cd.id)).to be_nil
     end
   end
+
+  describe "when confirming" do
+    let(:competition) { FactoryGirl.build :competition }
+
+    it "works" do
+      competition.isConfirmed = true
+      expect(competition).to be_valid
+    end
+
+    [:cityName, :countryId, :venue, :venueAddress, :website, :latitude, :longitude].each do |field|
+      it "requires #{field}" do
+        competition.public_send "#{field}=", ""
+        competition.isConfirmed = true
+        expect(competition).not_to be_valid
+      end
+    end
+
+    it "must have at least one event" do
+      competition.eventSpecs = ""
+      competition.isConfirmed = true
+      expect(competition).not_to be_valid
+    end
+
+    it "requires both dates" do
+      competition.start_date = ""
+      competition.end_date = ""
+      competition.isConfirmed = true
+      expect(competition).not_to be_valid
+    end
+  end
 end


### PR DESCRIPTION
I accidentally closed https://github.com/cubing/worldcubeassociation.org/pull/193, so I recreated it here.

@timhabermaas, if you could take another look, thanks!