### PR TITLE
Fixing the date check for competitions too close

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -306,4 +306,9 @@ class Competition < ActiveRecord::Base
     (latitude != 0 && longitude != 0)
   end
 
+  def dangerously_close_to?(c)
+    days_until = (c.start_date - self.start_date).to_i
+    self.kilometers_to(c) <= NEARBY_DISTANCE_KM_DANGER && days_until.abs < NEARBY_DAYS_DANGER
+  end
+
 end

--- a/WcaOnRails/app/views/competitions/edit.html.erb
+++ b/WcaOnRails/app/views/competitions/edit.html.erb
@@ -158,10 +158,10 @@
                   <td>Location</td>
                   <td>Distance</td>
                 </tr>
+                <% days_until = (c.start_date - @competition.start_date).to_i %>
                 <% nearby_competitions.each do |c| %>
-                  <tr class="<%= @competition.kilometers_to(c) <= Competition::NEARBY_DISTANCE_KM_DANGER && (c.start_date - @competition.start_date).to_i < Competition::NEARBY_DAYS_DANGER ? "danger" : "" %>">
-                    <td class="text-nowrap"><%= link_to c.name, admin_edit_competition_path(c.id) %></td>                
-                    <% days_until = (c.start_date - @competition.start_date).to_i %>
+                  <tr class="<%= @competition.kilometers_to(c) <= Competition::NEARBY_DISTANCE_KM_DANGER && days_until.abs < Competition::NEARBY_DAYS_DANGER ? "danger" : "" %>">
+                    <td class="text-nowrap"><%= link_to c.name, admin_edit_competition_path(c.id) %></td>
                     <td><%= c.delegates.map(&:name).to_sentence %></td>
                     <td data-toggle="tooltip" data-placement="top" data-container="body" title="<%= c.name %> starts on <%= c.start_date %>">
                       <%= days_until.abs %> <%="day".pluralize(days_until) %> <%= days_until < 0 ? "before" : "after" %>

--- a/WcaOnRails/app/views/competitions/edit.html.erb
+++ b/WcaOnRails/app/views/competitions/edit.html.erb
@@ -158,13 +158,13 @@
                   <td>Location</td>
                   <td>Distance</td>
                 </tr>
-                <% days_until = (c.start_date - @competition.start_date).to_i %>
                 <% nearby_competitions.each do |c| %>
-                  <tr class="<%= @competition.kilometers_to(c) <= Competition::NEARBY_DISTANCE_KM_DANGER && days_until.abs < Competition::NEARBY_DAYS_DANGER ? "danger" : "" %>">
+                  <tr class="<%= @competition.dangerously_close_to?(c) ? "danger" : "" %>">
                     <td class="text-nowrap"><%= link_to c.name, admin_edit_competition_path(c.id) %></td>
                     <td><%= c.delegates.map(&:name).to_sentence %></td>
                     <td data-toggle="tooltip" data-placement="top" data-container="body" title="<%= c.name %> starts on <%= c.start_date %>">
-                      <%= days_until.abs %> <%="day".pluralize(days_until) %> <%= days_until < 0 ? "before" : "after" %>
+                    <% days_until = (c.start_date - @competition.start_date).to_i %>  
+                    <%= days_until.abs %> <%="day".pluralize(days_until) %> <%= days_until < 0 ? "before" : "after" %>
                     </td>
                     <td><%= c.cityName %>, <%= c.countryId %></td>
                     <td class="text-nowrap"><%= link_to "#{@competition.kilometers_to(c).round(2)} km", "https://www.google.com/maps/dir/#{c.latitude_degrees},#{c.longitude_degrees}/#{@competition.latitude_degrees},#{@competition.longitude_degrees}/", target: "_blank" %></td>


### PR DESCRIPTION
Added .abs to the "days_until" thing. Competitions which were before the current one have a negativa value for this, so it was always <= 30.