### PR TITLE
Fixed issue #287.

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -147,12 +147,17 @@ class Competition < ActiveRecord::Base
   # remember all the places in our database that refer to competition ids, and
   # update them. We can get rid of all this once we're done with
   # https://github.com/cubing/worldcubeassociation.org/issues/91.
+  # 2015-12-31: Added some stuff regarding competition_delegates and
+  # competition_organizers tables. We need to delete some lines there
+  # if we change the competition's id. -Pedro
   after_save :update_results_when_id_changes
   def update_results_when_id_changes
     if id_change
       Result.where(competitionId: id_was).update_all(competitionId: id)
       Registration.where(competitionId: id_was).update_all(competitionId: id)
       Scramble.where(competitionId: id_was).update_all(competitionId: id)
+      CompetitionDelegate.where(competition_id: id_was).destroy_all
+      CompetitionOrganizer.where(competition_id: id_was).destroy_all
     end
   end
 

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -16,6 +16,14 @@ FactoryGirl.define do
     website "https://www.worldcubeassociation.org"
     showAtAll true
 
+    trait :with_delegate do
+      delegates { [ FactoryGirl.create(:delegate) ] }
+    end
+
+    trait :with_organizer do
+      organizers { [ FactoryGirl.create(:user) ] }
+    end
+
     factory :competition_with_delegates do
       after(:create) do |comp|
         comp.delegates << FactoryGirl.create(:delegate)

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -192,6 +192,16 @@ RSpec.describe Competition do
       competition.update_attribute(:id, "NewID2015")
       expect(scramble1.reload.competitionId).to eq "NewID2015"
     end
+
+    it "updates the fields in competition_delegates and competition_organizers" do
+      comp = FactoryGirl.create(:competition, :with_delegate, :with_organizer)
+      old_comp_id = comp.id
+      comp.update_attribute(:id, "NewID2015")
+      cmp_del = CompetitionDelegate.find_by(competition_id: old_comp_id)
+      cmp_org = CompetitionOrganizer.find_by(competition_id: old_comp_id)
+      expect(cmp_del).to eq nil
+      expect(cmp_org).to eq nil
+    end
   end
 
   describe "when deleting a competition" do


### PR DESCRIPTION
Deletes the competition_organizers and competition_delegates lines when we change a competition's id. We were creating "duplicated" lines, with both the old and new competition_id

@jfly 
@timhabermaas 
I tried update_all instead of destroy_all, but it would say I was trying to create a duplicate entry.