### PR TITLE
Updating text on edit page when the competition is visible already.

### DIFF
--- a/WcaOnRails/app/views/competitions/edit.html.erb
+++ b/WcaOnRails/app/views/competitions/edit.html.erb
@@ -43,7 +43,7 @@
     <% else %>
       <% if is_actually_confirmed && @competition.showAtAll? %>
         <div class="alert alert-success">
-          This competition is publicly visible and locked for editing. If you need to make a change, contact the <%= mail_to_wca_board %> to unlock it.
+          This competition is publicly visible and locked for editing. If you need to make a change, contact the <%= mail_to_wca_board %>.
         </div>
       <% elsif is_actually_confirmed && !@competition.showAtAll? %>
         <div class="alert alert-warning">


### PR DESCRIPTION
As requested by Olivér via e-mail:

"Dear Team,

The Board has decided not to unlock any confirmed competitions after they have been announced, but we will make the changes as requested by the delegates.

For this reason, we would like to change the text from "If you need to make a change, contact the Board to unlock it." to "If you need to make a change, contact the Board." to avoid confusions.

Thank you for your work!

Kind Regards,
Olivér Perge"