### PR TITLE
Use raise instead of throw for raising exceptions

### DIFF
--- a/WcaOnRails/app/controllers/admin/avatars_controller.rb
+++ b/WcaOnRails/app/controllers/admin/avatars_controller.rb
@@ -19,7 +19,7 @@ module Admin
           when "defer"
             # do nothing!
           else
-            throw "Unrecognized avatar action #{v}"
+            raise "Unrecognized avatar action #{v}"
           end
         end
       end

--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -131,7 +131,7 @@ class RegistrationsController < ApplicationController
       end
       flash[:warning] = "#{"Registration".pluralize(registrations.length)} deleted"
     else
-      throw "Unrecognized action #{params[:registrations_action]}"
+      raise "Unrecognized action #{params[:registrations_action]}"
     end
     redirect_to competition_edit_registrations_path(@competition)
   end

--- a/WcaOnRails/app/models/country.rb
+++ b/WcaOnRails/app/models/country.rb
@@ -16,7 +16,7 @@ class Country
   end
 
   def self.find(id)
-    ALL_COUNTRIES_BY_ID[id] or throw "Unrecognized country id"
+    ALL_COUNTRIES_BY_ID[id] or raise "Unrecognized country id"
   end
 
   def self.find_by_id(id)

--- a/WcaOnRails/app/models/event.rb
+++ b/WcaOnRails/app/models/event.rb
@@ -28,7 +28,7 @@ class Event
   end
 
   def self.find(id)
-    ALL_EVENTS_BY_ID[id] or throw "Unrecognized event id"
+    ALL_EVENTS_BY_ID[id] or raise "Unrecognized event id"
   end
 
   def self.find_by_id(id)

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -17,7 +17,7 @@ class Round
   end
 
   def self.find(id)
-    @@all_by_id[id] or throw "Unrecognized round id"
+    @@all_by_id[id] or raise "Unrecognized round id"
   end
 
   def self.find_by_id(id)

--- a/WcaOnRails/config/unicorn.rb
+++ b/WcaOnRails/config/unicorn.rb
@@ -8,7 +8,7 @@ allowed_environments = {
 }
 rack_env = ENV['RACK_ENV']
 if !allowed_environments[rack_env]
-  throw "Unrecognized RACK_ENV: #{rack_env}, must be one of #{allowed_environments.keys.join ', '}"
+  raise "Unrecognized RACK_ENV: #{rack_env}, must be one of #{allowed_environments.keys.join ', '}"
 end
 if rack_env == "development"
   listen 3000

--- a/WcaOnRails/lib/solve_time.rb
+++ b/WcaOnRails/lib/solve_time.rb
@@ -9,7 +9,7 @@ class SolveTime
     wca_value = @wca_value
     # Special cases.
     if wca_value < -2
-      throw "Unrecognized wca_value: #{wca_value}"
+      raise "Unrecognized wca_value: #{wca_value}"
     elsif wca_value == -2
       return "DNS"
     elsif wca_value == -1


### PR DESCRIPTION
throw/catch is used for control flow in Ruby, raise/rescue is used
for exceptions. See http://phrogz.net/programmingruby/tut_exceptions.html. `throw` is basically Ruby's `goto` and `catch` is used to set the labels.

```
thirb(main):001:0> throw "foo"
ArgumentError: uncaught throw "foo"
	from (irb):1:in `throw'
	from (irb):1
	from /Users/tim/.rbenv/versions/2.1.5/bin/irb:11:in `<main>'
```