### PR TITLE
Fix build with pandoc >= 1.14.

### DIFF
--- a/regulations/pdf.py
+++ b/regulations/pdf.py
@@ -33,6 +33,9 @@ class pdf():
 
 \setcounter{secnumdepth}{-1}
 
+\providecommand{\\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
 \\title{WCA Regulations and Guidelines}
 \\author{WCA Regulations Committee}
 \date{\\vspace{-1em}}


### PR DESCRIPTION
Pandoc >= 1.14 introduced the `\tightlist` command when generating lists.
The declaration must be added when using a custom Latex template : see the "Backward compatibility" section here : https://github.com/jgm/pandoc/pull/1571.

Closes #334 ;)