### PR TITLE
Added a check pass to the regulations build system.

### DIFF
--- a/regulations/make.py
+++ b/regulations/make.py
@@ -62,6 +62,7 @@ with open(languages_file, "r") as fileHandle:
 
 languages = languageData.keys()
 
+max_lang_width = len(max(languages, key=len))
 
 # Script Parameters
 
@@ -210,7 +211,10 @@ def buildLanguage(args, language):
 
   pdfName = languageData[language]["pdf"]
 
-  html.html(language, buildDir, pdfName + ".pdf", isTranslation=isTranslation, verbose=args.verbose)
+  srcDir = "translations/" + language if isTranslation else "wca-regulations"
+
+  print "%s Generating HTML in %s" % (("[" + language + "]").ljust(max_lang_width + 2), buildDir)
+  html.html(language, srcDir, buildDir, pdfName + ".pdf", isTranslation=isTranslation, verbose=args.verbose)
 
   if args.pdf:
     pdf.pdf(


### PR DESCRIPTION
This is related to cubing/wca-regulations#319.
We want guidelines refering to non-existent regulations to have the "SEPARATE" label.
This commit adds a check pass before each html build, displaying a warning for any missing or misused "SEPARATE" label.

Right now the output looks like this : 
```
...
[portuguese-brazilian] Warnings for the Guidelines :
[portuguese-brazilian] - 6a+ does not match a regulation, please change "[SEPARADO]" to "[SEPARATE][SEPARADO]".
...
[english]              Warnings for the Guidelines :
[english]              - 4b4+ does not match a regulation, please change "[ADDITION]" to "[SEPARATE][ADDITION]".
[english]              - 5c+ does not match a regulation, please change "[REMINDER]" to "[SEPARATE][REMINDER]".
[english]              - D1c+ does not match a regulation, please change "[REMINDER]" to "[SEPARATE][REMINDER]".
[english]              Generating HTML in ./build/regulations/
[russian]              Warnings for the Guidelines :
[russian]              - 4b4+ does not match a regulation, please change "[ДОПОЛНЕНИЕ]" to "[SEPARATE][ДОПОЛНЕНИЕ]".
[russian]              - 6a+ does not match a regulation, please change "[ВЫДЕЛЕНО]" to "[SEPARATE][ВЫДЕЛЕНО]".
...
[russian]              Generating HTML in ./build/regulations/translations/russian/
...
```

A lot of translations are missing (or translated) the labels, so right now the output of the regulations build is kind of big :s

How does it look ?