### PR TITLE
Created a long overdue custom simple_form type for events.

### DIFF
--- a/WcaOnRails/app/inputs/events_picker_input.rb
+++ b/WcaOnRails/app/inputs/events_picker_input.rb
@@ -1,0 +1,24 @@
+class EventsPickerInput < SimpleForm::Inputs::Base
+  def input(wrapper_options)
+    merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
+
+    allowed_events = @options[:allowed_events]
+    selected_events = @options[:selected_events]
+    template.content_tag(:span) do
+      allowed_events.each do |event|
+        checked_value = "1"
+        unchecked_value = "0"
+        check_box = ActionView::Helpers::Tags::CheckBox.new("#{@builder.object_name}[#{attribute_name}]", event.id, template, checked_value, unchecked_value, merged_input_options.merge(checked: selected_events.include?(event)))
+        template.concat template.content_tag(:span,
+          template.content_tag(:label,
+            (
+              check_box.render +
+              template.content_tag(:span, "", class: "cubing-icon icon-#{event.id}", data: { toggle: "tooltip", placement: "top" }, title: event.name )
+            ),
+            for: check_box.send(:tag_id),
+          ),
+        class: "event-checkbox" + (merged_input_options[:disabled] ? " disabled" : ""))
+      end
+    end
+  end
+end

--- a/WcaOnRails/app/views/competitions/edit.html.erb
+++ b/WcaOnRails/app/views/competitions/edit.html.erb
@@ -256,21 +256,9 @@
           Event.all_deprecated,
         ]
       ] %>
-      <% event_groups.each do |label, always_show, selected_events, available_events| %>
+      <% event_groups.each do |label, always_show, selected_events, allowed_events| %>
         <% if always_show || !selected_events.empty? %>
-          <div class="form-group">
-            <label class="col-sm-2 control-label"><%= label %></label>
-            <div class="col-sm-9">
-              <% available_events.each do |event| %>
-                <span class="event-checkbox">
-                  <label>
-                    <%= check_box "competition[event_ids]", event.id, { checked: selected_events.include?(event) } %>
-                    <span class="cubing-icon icon-<%= event.id %>" data-toggle="tooltip" data-placement="top" title="<%= event.name %>"></span>
-                  </label>
-                </span>
-              <% end %>
-            </div>
-          </div>
+          <%= f.input :event_ids, as: :events_picker, allowed_events: allowed_events, selected_events: selected_events, label: label %>
         <% end %>
       <% end %>
     <% end %>

--- a/WcaOnRails/app/views/registrations/edit.html.erb
+++ b/WcaOnRails/app/views/registrations/edit.html.erb
@@ -28,24 +28,7 @@
       <%= f.input :countryId, collection: Country.all, value_method: :id, label_method: :name %>
     <% end %>
 
-    <div class="form-group <%= @registration.errors.has_key?(:events) ? "has-error" : "" %>">
-      <label class="col-sm-2 control-label">Events</label>
-      <div class="col-sm-9">
-        <% @registration.competition.events.each do |event| %>
-          <span class="event-checkbox">
-            <label>
-              <%= check_box "registration[event_ids]", event.id, { checked: @registration.events.include?(event) } %>
-              <span class="cubing-icon icon-<%= event.id %>" data-toggle="tooltip" data-placement="top" title="<%= event.name %>"></span>
-            </label>
-          </span>
-        <% end %>
-        <% if @registration.errors.has_key?(:events) %>
-          <span class="help-block">
-            <%= @registration.errors[:events].join(" ") %>
-          </span>
-        <% end %>
-      </div>
-    </div>
+    <%= f.input :event_ids, as: :events_picker, allowed_events: @competition.events, selected_events: @registration.events %>
 
     <%= f.input :guests %>
     <%= f.input :comments %>

--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -82,24 +82,8 @@
             file: :horizontal_file_input,
             boolean: :horizontal_boolean
         }  do |f| %>
-          <div class="form-group <%= @registration.errors.has_key?(:events) ? "has-error" : "" %>">
-            <label class="col-sm-2 control-label">Events</label>
-            <div class="col-sm-9">
-              <% @competition.events.each do |event| %>
-                <span class="event-checkbox <%= !@registration.new_record? ? "disabled" : "" %>">
-                  <label>
-                    <%= check_box "registration[event_ids]", event.id, { checked: @registration.events.include?(event), disabled: !@registration.new_record? } %>
-                    <span class="cubing-icon icon-<%= event.id %>" data-toggle="tooltip" data-placement="top" title="<%= event.name %>"></span>
-                  </label>
-                </span>
-              <% end %>
-              <% if @registration.errors.has_key?(:events) %>
-                <span class="help-block">
-                  <%= @registration.errors[:events].join(" ") %>
-                </span>
-              <% end %>
-            </div>
-          </div>
+
+          <%= f.input :event_ids, as: :events_picker, allowed_events: @competition.events, selected_events: @registration.events, disabled: !@registration.new_record? %>
 
           <%= f.input :guests, disabled: !@registration.new_record? %>
           <%= f.input :comments, disabled: !@registration.new_record? %>

--- a/WcaOnRails/config/locales/simple_form.en.yml
+++ b/WcaOnRails/config/locales/simple_form.en.yml
@@ -11,6 +11,8 @@ en:
     error_notification:
       default_message: "Please review the problems below:"
     labels:
+      defaults:
+        event_ids: "Events"
       competition:
         id: "ID"
     hints:


### PR DESCRIPTION
This allows us to add a for= to the corresponding label, which is necessary for
Windows 10 Edge and apparently for other browsers as well. This fixes #367.