### PR TITLE
Move teams to separate tables

### DIFF
--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -92,7 +92,7 @@ wca.datetimepicker = function(){
       $this.addClass('alert-danger');
     }
   });
-}
+};
 
 $(function() {
   $('.dropdown-toggle').dropdownHover();

--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -45,10 +45,7 @@ wca.cancelPendingAjaxAndAjax = function(id, options) {
   return wca._pendingAjaxById[id];
 };
 
-$(function() {
-  $('.dropdown-toggle').dropdownHover();
-  $('form.are-you-sure').areYouSure();
-
+wca.datetimepicker = function(){
   // Copied (and modified by jfly) from
   // https://github.com/zpaulovics/datetimepicker-rails
   // We're using keepOpen: true here to allow the user to
@@ -95,6 +92,13 @@ $(function() {
       $this.addClass('alert-danger');
     }
   });
+}
+
+$(function() {
+  $('.dropdown-toggle').dropdownHover();
+  $('form.are-you-sure').areYouSure();
+
+  wca.datetimepicker();
 
   $('.datetimerange').each(function() {
     var $inputGroups = $(this).find('.date_picker.form-control');

--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -77,7 +77,7 @@ wca.datetimepicker = function(){
   // (see https://github.com/cubing/worldcubeassociation.org/issues/376#issuecomment-180547289).
   // Also, 'input' gets too annoying, because it flashes at every stroke until you have
   // a valid date typed.
-  $datetimepicker.on('blur', function() {
+  $datetimepicker.off('blur.wcaDateValidation').on('blur.wcaDateValidation', function() {
     var $this = $(this);
     var datetimepicker = $this.data("DateTimePicker");
     var val = $this.val();

--- a/WcaOnRails/app/assets/stylesheets/application.css.scss
+++ b/WcaOnRails/app/assets/stylesheets/application.css.scss
@@ -44,4 +44,5 @@
 @import "collapsible-panels";
 @import "avatars";
 @import "polls";
+@import "teams";
 

--- a/WcaOnRails/app/assets/stylesheets/teams.scss
+++ b/WcaOnRails/app/assets/stylesheets/teams.scss
@@ -3,6 +3,9 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 .members {
+  border-top: 1px solid #888;
+  padding-top: 2px;
+
   input.date_picker.form-control {
     width: 120px;
   }
@@ -10,7 +13,4 @@
   div.selectize-control {
     width: 280px;
   }
-
-  border-top: 1px solid #888;
-  padding-top: 2px;
 }

--- a/WcaOnRails/app/assets/stylesheets/teams.scss
+++ b/WcaOnRails/app/assets/stylesheets/teams.scss
@@ -1,0 +1,24 @@
+// Place all the styles related to the teams controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+
+.members {
+  input.date_picker.form-control {
+    width: 150px;
+  }
+
+  div {
+    display: table-cell;
+  }
+
+  div.selectize-input {
+    width: 90%;
+  }
+
+  div.selectize-control {
+    width: 250px
+  }
+
+  border-top: 1px solid #888;
+  padding-top: 2px;
+}

--- a/WcaOnRails/app/assets/stylesheets/teams.scss
+++ b/WcaOnRails/app/assets/stylesheets/teams.scss
@@ -1,5 +1,5 @@
 .members {
-  border-top: 1px solid #888;
+  border-top: 1px solid $gray;
   padding-top: 2px;
 
   input.date_picker.form-control {
@@ -12,5 +12,5 @@
 }
 
 .past-member {
-  background-color: #fc0;
+  background-color: $past-member;
 }

--- a/WcaOnRails/app/assets/stylesheets/teams.scss
+++ b/WcaOnRails/app/assets/stylesheets/teams.scss
@@ -12,5 +12,5 @@
 }
 
 .past-member {
-  background-color: $past-member;
+  background-color: $past-member-color;
 }

--- a/WcaOnRails/app/assets/stylesheets/teams.scss
+++ b/WcaOnRails/app/assets/stylesheets/teams.scss
@@ -14,3 +14,7 @@
     width: 280px;
   }
 }
+
+.past-member {
+  background-color: #fc0;
+}

--- a/WcaOnRails/app/assets/stylesheets/teams.scss
+++ b/WcaOnRails/app/assets/stylesheets/teams.scss
@@ -1,7 +1,3 @@
-// Place all the styles related to the teams controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
-
 .members {
   border-top: 1px solid #888;
   padding-top: 2px;

--- a/WcaOnRails/app/assets/stylesheets/teams.scss
+++ b/WcaOnRails/app/assets/stylesheets/teams.scss
@@ -4,19 +4,11 @@
 
 .members {
   input.date_picker.form-control {
-    width: 150px;
-  }
-
-  div {
-    display: table-cell;
-  }
-
-  div.selectize-input {
-    width: 90%;
+    width: 120px;
   }
 
   div.selectize-control {
-    width: 250px
+    width: 280px;
   }
 
   border-top: 1px solid #888;

--- a/WcaOnRails/app/assets/stylesheets/variables.scss
+++ b/WcaOnRails/app/assets/stylesheets/variables.scss
@@ -1,2 +1,4 @@
 // ***** Overriding Bootstrap variables ****
 $link-color: #f60;
+
+$past-member: #fecd55;

--- a/WcaOnRails/app/assets/stylesheets/variables.scss
+++ b/WcaOnRails/app/assets/stylesheets/variables.scss
@@ -2,3 +2,4 @@
 $link-color: #f60;
 
 $past-member: #fecd55;
+

--- a/WcaOnRails/app/assets/stylesheets/variables.scss
+++ b/WcaOnRails/app/assets/stylesheets/variables.scss
@@ -1,5 +1,5 @@
 // ***** Overriding Bootstrap variables ****
 $link-color: #f60;
 
-$past-member: #fecd55;
+$past-member-color: #fecd55;
 

--- a/WcaOnRails/app/controllers/teams_controller.rb
+++ b/WcaOnRails/app/controllers/teams_controller.rb
@@ -43,7 +43,7 @@ class TeamsController < ApplicationController
     team_params = params.require(:team).permit(:name, :description, :friendly_id, team_members_attributes: [:id, :team_id, :user_id, :start_date, :end_date, :team_leader, :_destroy])
     if team_params[:team_members_attributes]
       team_params[:team_members_attributes].each do |member|
-        member.second.merge!(:current_user => current_user.id)
+        member.second.merge!(current_user: current_user.id)
       end
     end
     return team_params

--- a/WcaOnRails/app/controllers/teams_controller.rb
+++ b/WcaOnRails/app/controllers/teams_controller.rb
@@ -1,0 +1,45 @@
+class TeamsController < ApplicationController
+  before_action :authenticate_user!
+  before_action -> { redirect_unless_user(:can_edit_users?) }
+
+  def index
+    @teams = Team.all
+  end
+
+  def new
+    @team = Team.new
+  end
+
+  def create
+    @team = Team.new(team_params)
+    if @team.save
+      flash[:success] = "Created new team"
+      redirect_to edit_team_path(@team)
+    else
+      flash[:danger] = "Failed to create team"
+      render :new
+    end
+  end
+
+  def edit
+    @team = Team.find(params[:id])
+  end
+
+  def update
+    @team = Team.find(params[:id])
+    if @team.update_attributes(team_params)
+      flash[:success] = "Updated team"
+      redirect_to edit_team_path(@team)
+    else
+      flash[:danger] = "Failed to update team"
+      render :edit
+    end
+  end
+
+  def destroy
+  end
+
+  def team_params
+    team_params = params.require(:team).permit(:name, :description, :leader, :friendly_id)
+  end
+end

--- a/WcaOnRails/app/controllers/teams_controller.rb
+++ b/WcaOnRails/app/controllers/teams_controller.rb
@@ -41,5 +41,9 @@ class TeamsController < ApplicationController
 
   def team_params
     team_params = params.require(:team).permit(:name, :description, :friendly_id, team_members_attributes: [:id, :team_id, :user_id, :start_date, :end_date, :team_leader, :_destroy])
+    team_params[:team_members_attributes].each do |member|
+      member.second.merge!(:current_user => current_user.id)
+    end
+    return team_params
   end
 end

--- a/WcaOnRails/app/controllers/teams_controller.rb
+++ b/WcaOnRails/app/controllers/teams_controller.rb
@@ -41,8 +41,10 @@ class TeamsController < ApplicationController
 
   def team_params
     team_params = params.require(:team).permit(:name, :description, :friendly_id, team_members_attributes: [:id, :team_id, :user_id, :start_date, :end_date, :team_leader, :_destroy])
-    team_params[:team_members_attributes].each do |member|
-      member.second.merge!(:current_user => current_user.id)
+    if team_params[:team_members_attributes]
+      team_params[:team_members_attributes].each do |member|
+        member.second.merge!(:current_user => current_user.id)
+      end
     end
     return team_params
   end

--- a/WcaOnRails/app/controllers/teams_controller.rb
+++ b/WcaOnRails/app/controllers/teams_controller.rb
@@ -36,9 +36,6 @@ class TeamsController < ApplicationController
     end
   end
 
-  def destroy
-  end
-
   def team_params
     team_params = params.require(:team).permit(:name, :description, :friendly_id, team_members_attributes: [:id, :team_id, :user_id, :start_date, :end_date, :team_leader, :_destroy])
     if team_params[:team_members_attributes]

--- a/WcaOnRails/app/controllers/teams_controller.rb
+++ b/WcaOnRails/app/controllers/teams_controller.rb
@@ -40,6 +40,6 @@ class TeamsController < ApplicationController
   end
 
   def team_params
-    team_params = params.require(:team).permit(:name, :description, :leader_id, :friendly_id, team_members_attributes: [:id, :team_id, :user_id, :start_date, :end_date, :_destroy])
+    team_params = params.require(:team).permit(:name, :description, :friendly_id, team_members_attributes: [:id, :team_id, :user_id, :start_date, :end_date, :team_leader, :_destroy])
   end
 end

--- a/WcaOnRails/app/controllers/teams_controller.rb
+++ b/WcaOnRails/app/controllers/teams_controller.rb
@@ -40,6 +40,6 @@ class TeamsController < ApplicationController
   end
 
   def team_params
-    team_params = params.require(:team).permit(:name, :description, :leader, :friendly_id)
+    team_params = params.require(:team).permit(:name, :description, :leader_id, :friendly_id, team_members_attributes: [:id, :team_id, :user_id, :start_date, :end_date, :_destroy])
   end
 end

--- a/WcaOnRails/app/controllers/teams_controller.rb
+++ b/WcaOnRails/app/controllers/teams_controller.rb
@@ -1,6 +1,6 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
-  before_action -> { redirect_unless_user(:can_edit_users?) }
+  before_action -> { redirect_unless_user(:can_edit_teams?) }
 
   def index
     @teams = Team.all

--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :authenticate_user!, except: [:search, :select_nearby_delegate]
 
   def self.WCA_TEAMS
-    [:software_team, :results_team, :wdc_team, :wrc_team]
+    ['software', 'results', 'wdc', 'wrc']
   end
 
   def index

--- a/WcaOnRails/app/helpers/static_pages_helper.rb
+++ b/WcaOnRails/app/helpers/static_pages_helper.rb
@@ -1,9 +1,8 @@
 module StaticPagesHelper
-  def format_team_members(team)
-    leader_team = :"#{team}_leader"
-    User.where(team => true).order(leader_team => :desc, name: :asc).map do |u|
-      s = u.name
-      if u.send(leader_team)
+  def format_team_members(team_friendly_id)
+    TeamMember.where(team_id: Team.find_by_friendly_id!(team_friendly_id).id).order(:team_leader => :desc).map do |u|
+      s = u.user.name
+      if u.team_leader
         s += " (leader)"
       end
       s

--- a/WcaOnRails/app/helpers/static_pages_helper.rb
+++ b/WcaOnRails/app/helpers/static_pages_helper.rb
@@ -1,6 +1,6 @@
 module StaticPagesHelper
   def format_team_members(team_friendly_id)
-    TeamMember.where(team_id: Team.find_by_friendly_id!(team_friendly_id).id).order(:team_leader => :desc).map do |u|
+    TeamMember.where(team_id: Team.find_by_friendly_id!(team_friendly_id).id).includes(:user).order(team_leader: :desc).order("users.name asc").map do |u|
       s = u.user.name
       if u.team_leader
         s += " (leader)"

--- a/WcaOnRails/app/inputs/user_ids_input.rb
+++ b/WcaOnRails/app/inputs/user_ids_input.rb
@@ -10,7 +10,7 @@ class UserIdsInput < SimpleForm::Inputs::Base
       persons = (@builder.object.send(attribute_name) || "").split(",").map { |wca_id| Person.find_by_id(wca_id) }
       merged_input_options[:data] = { data: persons.map(&:to_jsonable).to_json }
     else
-      users = (@builder.object.send(attribute_name) || "").split(",").map { |id| User.find_by_id(id) }
+      users = (@builder.object.send(attribute_name).to_s || "").split(",").map { |id| User.find_by_id(id) }
       merged_input_options[:data] = { data: users.map(&:to_jsonable).to_json }
     end
     if @options[:only_one]

--- a/WcaOnRails/app/models/team.rb
+++ b/WcaOnRails/app/models/team.rb
@@ -1,0 +1,3 @@
+class Team < ActiveRecord::Base
+  has_many :users, through: :team_member
+end

--- a/WcaOnRails/app/models/team.rb
+++ b/WcaOnRails/app/models/team.rb
@@ -1,3 +1,4 @@
 class Team < ActiveRecord::Base
   has_many :users, through: :team_member
+  belongs_to :leader, class_name: "User", foreign_key: "leader_id"
 end

--- a/WcaOnRails/app/models/team.rb
+++ b/WcaOnRails/app/models/team.rb
@@ -1,4 +1,6 @@
 class Team < ActiveRecord::Base
-  has_many :users, through: :team_member
+  has_many :team_members, dependent: :destroy
   belongs_to :leader, class_name: "User", foreign_key: "leader_id"
+
+  accepts_nested_attributes_for :team_members, reject_if: :all_blank, allow_destroy: true
 end

--- a/WcaOnRails/app/models/team.rb
+++ b/WcaOnRails/app/models/team.rb
@@ -1,6 +1,5 @@
 class Team < ActiveRecord::Base
   has_many :team_members, dependent: :destroy
-  belongs_to :leader, class_name: "User", foreign_key: "leader_id"
 
   accepts_nested_attributes_for :team_members, reject_if: :all_blank, allow_destroy: true
 end

--- a/WcaOnRails/app/models/team_member.rb
+++ b/WcaOnRails/app/models/team_member.rb
@@ -1,0 +1,4 @@
+class TeamMember < ActiveRecord::Base
+  belongs_to :team
+  belongs_to :user
+end

--- a/WcaOnRails/app/models/team_member.rb
+++ b/WcaOnRails/app/models/team_member.rb
@@ -8,6 +8,13 @@ class TeamMember < ActiveRecord::Base
     end_date == nil || end_date > Date.today
   end
 
+  validate :start_date_must_be_earlier_than_end_date
+  def start_date_must_be_earlier_than_end_date
+    if end_date != nil && start_date >= end_date
+      errors.add(:start_date, " must be earlier than end_date.")
+    end
+  end
+
   validate :cannot_demote_leader
   def cannot_demote_leader
     if !current_member? && team_leader

--- a/WcaOnRails/app/models/team_member.rb
+++ b/WcaOnRails/app/models/team_member.rb
@@ -4,16 +4,20 @@ class TeamMember < ActiveRecord::Base
 
   attr_accessor :current_user
 
+  def current_member?
+    end_date == nil || end_date > Date.today
+  end
+
   validate :cannot_demote_leader
   def cannot_demote_leader
-    if end_date != nil && end_date < Date.today && team_leader
+    if !current_member? && team_leader
       errors.add(:end_date, "A team leader must be a current member.")
     end
   end
 
   validate :cannot_demote_oneself
   def cannot_demote_oneself
-    if current_user == self.user_id && end_date != nil && end_date < Date.today
+    if current_user == self.user_id && !current_member?
       errors.add(:user_id, "You cannot demote yourself.")
     end
   end

--- a/WcaOnRails/app/models/team_member.rb
+++ b/WcaOnRails/app/models/team_member.rb
@@ -1,4 +1,20 @@
 class TeamMember < ActiveRecord::Base
   belongs_to :team
   belongs_to :user
+
+  attr_accessor :current_user
+
+  validate :cannot_demote_leader
+  def cannot_demote_leader
+    if end_date != nil && end_date < Date.today && team_leader
+      errors.add(:end_date, "A team leader must be a current member.")
+    end
+  end
+
+  validate :cannot_demote_oneself
+  def cannot_demote_oneself
+    if current_user == self.user_id && end_date != nil && end_date < Date.today
+      errors.add(:user_id, "You cannot demote yourself.")
+    end
+  end
 end

--- a/WcaOnRails/app/models/team_member.rb
+++ b/WcaOnRails/app/models/team_member.rb
@@ -11,21 +11,21 @@ class TeamMember < ActiveRecord::Base
   validate :start_date_must_be_earlier_than_end_date
   def start_date_must_be_earlier_than_end_date
     if end_date != nil && start_date >= end_date
-      errors.add(:start_date, " must be earlier than end_date.")
+      errors.add(:start_date, "must be earlier than end_date")
     end
   end
 
   validate :cannot_demote_leader
   def cannot_demote_leader
     if !current_member? && team_leader
-      errors.add(:end_date, "A team leader must be a current member.")
+      errors.add(:team_leader, "A team leader must be a current member")
     end
   end
 
   validate :cannot_demote_oneself
   def cannot_demote_oneself
     if current_user == self.user_id && !current_member?
-      errors.add(:user_id, "You cannot demote yourself.")
+      errors.add(:user_id, "You cannot demote yourself")
     end
   end
 end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -286,19 +286,19 @@ class User < ActiveRecord::Base
   end
 
   def software_team?
-    team_member?('software')
+    team_member?('software') != false
   end
 
   def results_team?
-    team_member?('results')
+    team_member?('results') != false
   end
 
   def wrc_team?
-    team_member?('wrc')
+    team_member?('wrc') != false
   end
 
   def wdc_team?
-    team_member?('wdc')
+    team_member?('wdc') != false
   end
 
   def team_member?(team)

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -312,7 +312,7 @@ class User < ActiveRecord::Base
 
   def was_team_member?(team)
     member = self.team_members.find_by_team_id( self.teams.find_by_friendly_id(team) )
-    if member && member.end_date < Date.today
+    if member && member.end_date != nil && member.end_date < Date.today
       return true
     else
       return false

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -303,22 +303,8 @@ class User < ActiveRecord::Base
     self.team_members.where(team_id: ( self.teams.find_by_friendly_id(team) ) ).any?(&:current_member?)
   end
 
-  def was_team_member?(team)
-    self.team_members.where(team_id: ( self.teams.find_by_friendly_id(team) ) ).each do |member|  
-      if !member.current_member?
-        return true
-      end
-    end
-    return false
-  end
-
   def team_leader?(team)
-    self.team_members.where(team_id: ( self.teams.find_by_friendly_id(team) ) ).each do |member|
-      if member.current_member? && member.team_leader
-        return true
-      end      
-    end
-    return false
+    self.team_members.where(team_id: self.teams.find_by_friendly_id(team).id, team_leader: true).any?(&:current_member?)
   end
 
   def admin?

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ActiveRecord::Base
   belongs_to :person, foreign_key: "wca_id"
   belongs_to :unconfirmed_person, foreign_key: "unconfirmed_wca_id", class_name: "Person"
   belongs_to :delegate_to_handle_wca_id_claim, -> { where.not(delegate_status: nil ) }, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User"
+  belongs_to :team
   has_many :users_claiming_wca_id, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User"
   has_many :oauth_applications, class_name: 'Doorkeeper::Application', as: :owner
 

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -300,7 +300,7 @@ class User < ActiveRecord::Base
   end
 
   def team_member?(team)
-    self.team_members.where(team_id: ( self.teams.find_by_friendly_id(team) ) ).any?(&:current_member?)
+    self.team_members.where(team_id: self.teams.find_by_friendly_id(team)).any?(&:current_member?)
   end
 
   def team_leader?(team)

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -233,19 +233,6 @@ class User < ActiveRecord::Base
     end
   end
 
-  validate :team_leaders_must_be_on_respective_teams
-  def team_leaders_must_be_on_respective_teams
-    UsersController.WCA_TEAMS.each do |team|
-  #    leader_team = :"#{team}_leader"
-  #    if send(leader_team) && !send(team)
-  #      errors.add(leader_team, "must be a #{team} to be a #{leader_team}")
-  #    end
-      if team_leader?(team) && !team_member?(team)
-        errors.add(leader_team, "must be a #{team} to be a #{team} leader")
-      end
-    end
-  end
-
   validate :senior_delegate_must_be_senior_delegate
   def senior_delegate_must_be_senior_delegate
     if senior_delegate && !senior_delegate.senior_delegate?
@@ -299,27 +286,27 @@ class User < ActiveRecord::Base
   end
 
   def software_team?
-    team_member?('software') || false
+    team_member?('software')
   end
 
   def results_team?
-    team_member?('results') || false
+    team_member?('results')
   end
 
   def wrc_team?
-    team_member?('wrc') || false
+    team_member?('wrc')
   end
 
   def wdc_team?
-    team_member?('wdc') || false
+    team_member?('wdc')
   end
 
   def team_member?(team)
-    self.teams.find_by_friendly_id(team) #end date?
+    self.teams.find_by_friendly_id(team) || false #end date?
   end
 
   def team_leader?(team)
-    self.team_members.find_by_team_id( Team.find_by_friendly_id(team) ) && self.team_members.find_by_team_id( Team.find_by_friendly_id(team) ).team_leader
+    team_member?(team) && team_member(team).team_leader
   end
 
   def admin?

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ActiveRecord::Base
   belongs_to :unconfirmed_person, foreign_key: "unconfirmed_wca_id", class_name: "Person"
   belongs_to :delegate_to_handle_wca_id_claim, -> { where.not(delegate_status: nil ) }, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User"
   has_one :team, foreign_key: "leader_id"
+  has_many :team_members, dependent: :destroy
   has_many :users_claiming_wca_id, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User"
   has_many :oauth_applications, class_name: 'Doorkeeper::Application', as: :owner
 

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ActiveRecord::Base
   belongs_to :person, foreign_key: "wca_id"
   belongs_to :unconfirmed_person, foreign_key: "unconfirmed_wca_id", class_name: "Person"
   belongs_to :delegate_to_handle_wca_id_claim, -> { where.not(delegate_status: nil ) }, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User"
-  belongs_to :team
+  has_one :team, foreign_key: "leader_id"
   has_many :users_claiming_wca_id, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User"
   has_many :oauth_applications, class_name: 'Doorkeeper::Application', as: :owner
 

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -337,6 +337,12 @@ class User < ActiveRecord::Base
     admin? || board_member? || results_team?
   end
 
+  # Team leaders should be able to edit their team.
+  # See https://github.com/cubing/worldcubeassociation.org/issues/427
+  def can_edit_teams?
+    admin? || board_member? || results_team?
+  end
+
   def can_create_competitions?
     can_admin_results? || any_kind_of_delegate?
   end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -260,11 +260,9 @@ class User < ActiveRecord::Base
 
   validate :not_illegally_demoting_oneself
   def not_illegally_demoting_oneself
-    about_to_lose_access = !software_team? && !board_member?
+    about_to_lose_access = !board_member?
     if current_user == self && about_to_lose_access
-      if self.was_team_member?('software')
-        errors.add(:admin, "You cannot resign from your role as a software team member! Find another person to fire you.")
-      elsif delegate_status_was == "board_member"
+      if delegate_status_was == "board_member"
         errors.add(:delegate_status, "You cannot resign from your role as a board member! Find another board member to fire you.")
       end
     end
@@ -302,12 +300,7 @@ class User < ActiveRecord::Base
   end
 
   def team_member?(team)
-    self.team_members.where(team_id: ( self.teams.find_by_friendly_id(team) ) ).each do |member|
-      if member.current_member?
-        return true
-      end
-    end
-    return false
+    self.team_members.where(team_id: ( self.teams.find_by_friendly_id(team) ) ).any?(&:current_member?)
   end
 
   def was_team_member?(team)
@@ -445,8 +438,6 @@ class User < ActiveRecord::Base
       fields << :email
     end
     if admin? || board_member?
-      #fields += UsersController.WCA_TEAMS
-      #fields += UsersController.WCA_TEAMS.map { |role| :"#{role}_leader" }
       fields << :delegate_status
       fields << :senior_delegate_id
       fields << :region

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -299,12 +299,12 @@ class User < ActiveRecord::Base
     team_member?('wdc')
   end
 
-  def team_member?(team)
-    self.team_members.where(team_id: self.teams.find_by_friendly_id(team)).any?(&:current_member?)
+  def team_member?(team_friendly_id)
+    self.team_members.where(team_id: Team.find_by_friendly_id!(team_friendly_id).id).any?(&:current_member?)
   end
 
-  def team_leader?(team)
-    self.team_members.where(team_id: self.teams.find_by_friendly_id(team).id, team_leader: true).any?(&:current_member?)
+  def team_leader?(team_friendly_id)
+    self.team_members.where(team_id: Team.find_by_friendly_id!(team_friendly_id).id, team_leader: true).any?(&:current_member?)
   end
 
   def admin?

--- a/WcaOnRails/app/views/admin/_nav.html.erb
+++ b/WcaOnRails/app/views/admin/_nav.html.erb
@@ -17,8 +17,9 @@
         { text: "Check rounds", path: "/results/admin/check_rounds.php", fa_icon: "check" },
         { text: "Check records", path: "/results/admin/check_regional_record_markers.php", fa_icon: "trophy" },
         { text: "Compute auxiliary data", path: "/results/admin/compute_auxiliary_data.php", fa_icon: "cogs" },
-        { text: "Update statistics", path: "/results/statistics.php?update8392=1", fa_icon: "group" },
+        { text: "Update statistics", path: "/results/statistics.php?update8392=1", fa_icon: "area-chart" },
         { text: "Export public", path: "/results/admin/export_public.php", fa_icon: "cloud-upload" },
+        { text: "Edit teams", path: teams_path, fa_icon: "users" },
       ].each do |nav_item| %>
         <%= link_to nav_item[:path], class: "list-group-item" + (current_page?(nav_item[:path]) ? ' active' : '') do %>
           <i class="fa fa-fw fa-<%= nav_item[:fa_icon] %>"></i> <%= nav_item[:text] %>

--- a/WcaOnRails/app/views/static_pages/about.html.erb
+++ b/WcaOnRails/app/views/static_pages/about.html.erb
@@ -29,13 +29,13 @@
 
   <p>The following committees are responsible for the operational activities of the WCA:</p>
   <ul>
-    <li><strong>WCA Disciplinary Committee (WDC)</strong>: <%= format_team_members(:wdc_team) %> <br />
+    <li><strong>WCA Disciplinary Committee (WDC)</strong>: <%= format_team_members('wdc') %> <br />
   This committee advises the WCA Board in special cases, like alleged violations of WCA Regulations, and may be contacted by WCA members in case of important personal matters regarding WCA competitions.</li>
-    <li><strong>WCA Regulations Committee (WRC)</strong>: <%= format_team_members(:wrc_team) %> <br />
+    <li><strong>WCA Regulations Committee (WRC)</strong>: <%= format_team_members('wrc') %> <br />
   This committee is responsible for managing the WCA Regulations.</li>
-    <li><strong>Results team</strong>: <%= format_team_members(:results_team) %> <br />
+    <li><strong>Results team</strong>: <%= format_team_members('results') %> <br />
   This team is responsible for managing all competition results.</li>
-    <li><strong>WCA Software team</strong>: <%= format_team_members(:software_team) %> <br />
+    <li><strong>WCA Software team</strong>: <%= format_team_members('software') %> <br />
     This team is responsible for managing the WCA's software (website, scramblers, workbooks, admin tools).</li>
   </ul>
 

--- a/WcaOnRails/app/views/static_pages/contact.html.erb
+++ b/WcaOnRails/app/views/static_pages/contact.html.erb
@@ -26,24 +26,24 @@
   <p>
     <strong>WCA Disciplinary Committee</strong> - <a href="mailto:wdc@worldcubeassociation.org">wdc@worldcubeassociation.org</a><br />
     (independent advice to WCA board, independent investigations, counselor for important personal matters)<br />
-    <%= format_team_members(:wdc_team) %>
+    <%= format_team_members('wdc') %>
   </p>
 
   <p>
     <strong>WCA Results Team</strong> - <a href="mailto:results@worldcubeassociation.org">results@worldcubeassociation.org</a><br />
     (competition results, result corrections)<br />
-    <%= format_team_members(:results_team) %>
+    <%= format_team_members('results') %>
   </p>
 
   <p>
     <strong>WCA Regulations Committee</strong> - <a href="mailto:wrc@worldcubeassociation.org">wrc@worldcubeassociation.org</a><br />
     (maintenance of the WCA Regulations)<br />
-    <%= format_team_members(:wrc_team) %>
+    <%= format_team_members('wrc') %>
   </p>
 
   <p>
     <strong>WCA Software Team</strong> - <a href="mailto:software@worldcubeassociation.org">software@worldcubeassociation.org</a><br />
     (maintenance of software of WCA)<br />
-    <%= format_team_members(:software_team) %>
+    <%= format_team_members('software') %>
   </p>
 </div>

--- a/WcaOnRails/app/views/teams/_team_member_fields.html.erb
+++ b/WcaOnRails/app/views/teams/_team_member_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="nested-fields">
+<div class="members">
   <%= f.input :user_id, required: true, as: :user_ids, only_one: true %>
   <%= f.input :start_date, as: :date_picker, required: true %>
   <%= f.input :end_date, as: :date_picker %>

--- a/WcaOnRails/app/views/teams/_team_member_fields.html.erb
+++ b/WcaOnRails/app/views/teams/_team_member_fields.html.erb
@@ -1,0 +1,6 @@
+<div class="nested-fields">
+  <%= f.text_field :user_id, label: "User", class: 'form-control', required: true %>
+  <%= f.text_field :start_date, label: "Start date", class: 'form-control', as: :date_picker %>
+  <%= f.text_field :end_date, label: "End date", class: 'form-control', as: :date_picker %>
+  <%= link_to_remove_association button_tag('x', type: "button", class: "btn btn-danger"), f %>
+</div>

--- a/WcaOnRails/app/views/teams/_team_member_fields.html.erb
+++ b/WcaOnRails/app/views/teams/_team_member_fields.html.erb
@@ -1,5 +1,5 @@
 <div class="nested-fields">
-  <%= f.input :user_id, required: true %>
+  <%= f.input :user_id, required: true, as: :user_ids, only_one: true %>
   <%= f.input :start_date, as: :date_picker, required: true %>
   <%= f.input :end_date, as: :date_picker %>
   <%= f.input :team_leader %>

--- a/WcaOnRails/app/views/teams/_team_member_fields.html.erb
+++ b/WcaOnRails/app/views/teams/_team_member_fields.html.erb
@@ -1,17 +1,6 @@
 <div class="nested-fields">
-  <%= f.label :user_id %>
-  <%= f.text_field :user_id, class: 'form-control', required: true %>
-
-  <div class="input-group date datetime">
-    <%= f.label :start_date %>
-    <%= f.text_field :start_date, class: 'form-control date_picker' %>
-  </div>
-
-  <div class="input-group date datetime">
-    <%= f.label :end_date %>
-    <%= f.text_field :end_date, class: 'form-control date_picker' %>
-  </div>
-
-  <%= f.label :team_leader %>
-  <%= f.check_box :team_leader, {class: 'form-control'}, "1", "0" %>
+  <%= f.input :user_id, required: true %>
+  <%= f.input :start_date, as: :date_picker, required: true %>
+  <%= f.input :end_date, as: :date_picker %>
+  <%= f.input :team_leader %>
 </div>

--- a/WcaOnRails/app/views/teams/_team_member_fields.html.erb
+++ b/WcaOnRails/app/views/teams/_team_member_fields.html.erb
@@ -1,6 +1,10 @@
 <div class="nested-fields">
-  <%= f.text_field :user_id, label: "User", class: 'form-control', required: true %>
-  <%= f.text_field :start_date, label: "Start date", class: 'form-control', as: :date_picker %>
-  <%= f.text_field :end_date, label: "End date", class: 'form-control', as: :date_picker %>
-  <%= link_to_remove_association button_tag('x', type: "button", class: "btn btn-danger"), f %>
+  <%= f.label :user_id %>
+  <%= f.text_field :user_id, class: 'form-control', required: true %>
+
+  <%= f.label :start_date %>
+  <%= f.text_field :start_date, class: 'form-control', as: :date_picker %>
+
+  <%= f.label :end_date %>
+  <%= f.text_field :end_date, class: 'form-control', as: :date_picker %>
 </div>

--- a/WcaOnRails/app/views/teams/_team_member_fields.html.erb
+++ b/WcaOnRails/app/views/teams/_team_member_fields.html.erb
@@ -2,9 +2,16 @@
   <%= f.label :user_id %>
   <%= f.text_field :user_id, class: 'form-control', required: true %>
 
-  <%= f.label :start_date %>
-  <%= f.text_field :start_date, class: 'form-control', as: :date_picker %>
+  <div class="input-group date datetime">
+    <%= f.label :start_date %>
+    <%= f.text_field :start_date, class: 'form-control date_picker' %>
+  </div>
 
-  <%= f.label :end_date %>
-  <%= f.text_field :end_date, class: 'form-control', as: :date_picker %>
+  <div class="input-group date datetime">
+    <%= f.label :end_date %>
+    <%= f.text_field :end_date, class: 'form-control date_picker' %>
+  </div>
+
+  <%= f.label :team_leader %>
+  <%= f.check_box :team_leader, {class: 'form-control'}, "1", "0" %>
 </div>

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -22,8 +22,16 @@
         Members
       </div>
       <div class="panel-body">
-        <%= f.fields_for :team_members do |members_form| %>
-          <%= render 'team_member_fields', f: members_form %>
+        <%#= f.fields_for :team_members do |members_form| %>
+        <%= f.simple_fields_for :team_members do |t| %>
+          <%#= render 'team_member_fields', f: members_form %>
+          <%= t.input :user_id, class: 'form-control', required: true %>
+
+          <%= t.input :start_date, class: 'form-control date_picker' %>
+
+          <%= t.input :end_date, class: 'form-control date_picker' %>
+
+          <%= t.input :team_leader, class: 'form-control' %>
         <% end %>
 
         <div class="links">

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -21,7 +21,7 @@
       <div class="panel-heading">
         Members
       </div>
-      <div class="panel-body">
+      <div class="panel-body form-inline">
         <%= f.simple_fields_for :team_members do |t| %>
           <div class="members">
             <%= t.input :user_id, required: true, as: :user_ids, only_one: true %>

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -16,7 +16,6 @@
     <%= f.input :friendly_id, label: "Friendly id" %>
     <%= f.input :name %>
     <%= f.input :description %>
-    <%= f.input :leader_id, collection: @team.team_members.map { |member| member.user }, selected: @team.leader_id %>
 
     <div class="panel panel-default">
       <div class="panel-heading">

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -23,8 +23,8 @@
       </div>
       <div class="panel-body">
         <%= f.simple_fields_for :team_members do |t| %>
-          <div class="duplicate">
-            <%= t.input :user_id, required: true %>
+          <div class="form-inline">
+            <%= t.input :user_id, required: true, as: :user_ids, only_one: true %>
             <%= t.input :start_date, as: :date_picker, required: true %>
             <%= t.input :end_date, as: :date_picker %>
             <%= t.input :team_leader %>
@@ -32,8 +32,7 @@
         <% end %>
 
         <div class="links">
-          <%= link_to_add_association button_tag('Add member', type: "button", class: "btn btn-primary"), f, :team_members %>
-          <%#= button_tag('Add member', type: "button", class: "btn btn-primary new_member") %>
+          <%= link_to_add_association button_tag('Add member', type: "button", class: "btn btn-primary add"), f, :team_members %>
         </div>
       </div>
     </div>
@@ -49,41 +48,14 @@
 </div>
 
 <script>
-// From http://davidlesches.com/blog/rails-nested-forms-using-jquery-and-simpleform
-$(function() {
-  if($(".duplicate").length) {
-    nestedForm = $(".duplicate").last().clone();
-  }
-});
+$(".add").click(function() {
+  // activate datepicker and autocomplete on the new member
+  // currently not working...
+  $('input.wca-autocomplete').wcaAutocomplete();
 
-$(".new_member").click(function() {
-  lastNestedForm = $('.duplicate').last();
-  newNestedForm = $(nestedForm).clone();
-  formsOnPage = $('.duplicate').length;
-
-  $(newNestedForm).find('select, input').each(function() {
-    oldName = $(this).attr('name');
-    newName = oldName.replace(new RegExp(/\[[0-9]+\]/), "["+formsOnPage+"]");
-    $(this).attr('name', newName);
-    $(this).val('');
+  $datetimepicker = $('.date_picker.form-control, .datetime_picker.form-control');
+  $datetimepicker.datetimepicker({
+    useStrict: true, keepInvalid: true, useCurrent: false
   });
-
-  $(newNestedForm).insertAfter(lastNestedForm);
-
-  console.log(formsOnPage);
-
-  $hidden = $("input[name$='][id]']").last().clone();
-  $newId = $hidden.clone();
-  oldHiddenName = $newId.attr('name');
-  newHiddenName = oldHiddenName.replace(new RegExp(/\[[0-9]+\]/), "["+formsOnPage+"]");
-  $newId.attr('name', newHiddenName);
-  $newId.val((parseInt(formsOnPage)+1));
-  oldId = $newId.attr('id');
-  newId = oldId.replace(new RegExp(/_[0-9]+_/), "_"+formsOnPage+"_");
-  $newId.attr('id', newId);
-
-  $newId.insertBefore(".links");
-  console.log($hidden);
-  console.log($newId);
 });
 </script>

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -23,7 +23,7 @@
       </div>
       <div class="panel-body form-inline">
         <%= f.simple_fields_for :team_members do |t| %>
-          <div class="members">
+          <div class="members <%= t.object.end_date != nil && t.object.end_date < Date.today ? 'past-member' : ''%>">
             <%= t.input :user_id, required: true, as: :user_ids, only_one: true %>
             <%= t.input :start_date, as: :date_picker, required: true %>
             <%= t.input :end_date, as: :date_picker %>

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -13,7 +13,7 @@
     }  do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
 
-    <%= f.input :friendly_id, label: "Friendly id" %>
+    <%= f.input :friendly_id, label: "Friendly ID" %>
     <%= f.input :name %>
     <%= f.input :description %>
 
@@ -23,14 +23,17 @@
       </div>
       <div class="panel-body">
         <%= f.simple_fields_for :team_members do |t| %>
-          <%= t.input :user_id, class: 'form-control', required: true %>
-          <%= t.input :start_date, class: 'form-control date_picker', as: :date_picker %>
-          <%= t.input :end_date, class: 'form-control date_picker', as: :date_picker %>
-          <%= t.input :team_leader, class: 'form-control' %>
+          <div class="duplicate">
+            <%= t.input :user_id, required: true %>
+            <%= t.input :start_date, as: :date_picker, required: true %>
+            <%= t.input :end_date, as: :date_picker %>
+            <%= t.input :team_leader %>
+          </div>
         <% end %>
 
         <div class="links">
           <%= link_to_add_association button_tag('Add member', type: "button", class: "btn btn-primary"), f, :team_members %>
+          <%#= button_tag('Add member', type: "button", class: "btn btn-primary new_member") %>
         </div>
       </div>
     </div>
@@ -41,6 +44,46 @@
       </div>
     </div>
   <% end %>
-  <%= link_to 'Back to Teams', teams_path, class: "polls-home" %>
+  <%= link_to 'Back to Teams', teams_path, class: "teams-home" %>
 
 </div>
+
+<script>
+// From http://davidlesches.com/blog/rails-nested-forms-using-jquery-and-simpleform
+$(function() {
+  if($(".duplicate").length) {
+    nestedForm = $(".duplicate").last().clone();
+  }
+});
+
+$(".new_member").click(function() {
+  lastNestedForm = $('.duplicate').last();
+  newNestedForm = $(nestedForm).clone();
+  formsOnPage = $('.duplicate').length;
+
+  $(newNestedForm).find('select, input').each(function() {
+    oldName = $(this).attr('name');
+    newName = oldName.replace(new RegExp(/\[[0-9]+\]/), "["+formsOnPage+"]");
+    $(this).attr('name', newName);
+    $(this).val('');
+  });
+
+  $(newNestedForm).insertAfter(lastNestedForm);
+
+  console.log(formsOnPage);
+
+  $hidden = $("input[name$='][id]']").last().clone();
+  $newId = $hidden.clone();
+  oldHiddenName = $newId.attr('name');
+  newHiddenName = oldHiddenName.replace(new RegExp(/\[[0-9]+\]/), "["+formsOnPage+"]");
+  $newId.attr('name', newHiddenName);
+  $newId.val((parseInt(formsOnPage)+1));
+  oldId = $newId.attr('id');
+  newId = oldId.replace(new RegExp(/_[0-9]+_/), "_"+formsOnPage+"_");
+  $newId.attr('id', newId);
+
+  $newId.insertBefore(".links");
+  console.log($hidden);
+  console.log($newId);
+});
+</script>

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -48,10 +48,7 @@
 </div>
 
 <script>
-//$(".add").click(function() {
 $(".panel-body").on('cocoon:after-insert', function() {
-  // activate datepicker and autocomplete on the new member
-  // currently not working...
   $('input.wca-autocomplete').wcaAutocomplete();
 
   $datetimepicker = $('.date_picker.form-control, .datetime_picker.form-control');

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -22,15 +22,10 @@
         Members
       </div>
       <div class="panel-body">
-        <%#= f.fields_for :team_members do |members_form| %>
         <%= f.simple_fields_for :team_members do |t| %>
-          <%#= render 'team_member_fields', f: members_form %>
           <%= t.input :user_id, class: 'form-control', required: true %>
-
-          <%= t.input :start_date, class: 'form-control date_picker' %>
-
-          <%= t.input :end_date, class: 'form-control date_picker' %>
-
+          <%= t.input :start_date, class: 'form-control date_picker', as: :date_picker %>
+          <%= t.input :end_date, class: 'form-control date_picker', as: :date_picker %>
           <%= t.input :team_leader, class: 'form-control' %>
         <% end %>
 

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -23,7 +23,7 @@
       </div>
       <div class="panel-body form-inline">
         <%= f.simple_fields_for :team_members do |t| %>
-          <div class="members <%= t.object.end_date != nil && t.object.end_date < Date.today ? 'past-member' : ''%>">
+          <div class="members <%= t.object.current_member? ? '' : 'past-member'%>">
             <%= t.input :user_id, required: true, as: :user_ids, only_one: true %>
             <%= t.input :start_date, as: :date_picker, required: true %>
             <%= t.input :end_date, as: :date_picker %>
@@ -51,9 +51,6 @@
 $(".panel-body").on('cocoon:after-insert', function() {
   $('input.wca-autocomplete').wcaAutocomplete();
 
-  $datetimepicker = $('.date_picker.form-control, .datetime_picker.form-control');
-  $datetimepicker.datetimepicker({
-    useStrict: true, keepInvalid: true, useCurrent: false
-  });
+  wca.datetimepicker();
 });
 </script>

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -16,7 +16,7 @@
     <%= f.input :friendly_id, label: "Friendly id" %>
     <%= f.input :name %>
     <%= f.input :description %>
-    <%= f.input :leader_id %>
+    <%= f.input :leader_id, collection: @team.team_members.map { |member| member.user }, selected: @team.leader_id %>
 
     <div class="panel panel-default">
       <div class="panel-heading">

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -23,7 +23,7 @@
       </div>
       <div class="panel-body">
         <%= f.simple_fields_for :team_members do |t| %>
-          <div class="form-inline">
+          <div class="members">
             <%= t.input :user_id, required: true, as: :user_ids, only_one: true %>
             <%= t.input :start_date, as: :date_picker, required: true %>
             <%= t.input :end_date, as: :date_picker %>
@@ -48,7 +48,8 @@
 </div>
 
 <script>
-$(".add").click(function() {
+//$(".add").click(function() {
+$(".panel-body").on('cocoon:after-insert', function() {
   // activate datepicker and autocomplete on the new member
   // currently not working...
   $('input.wca-autocomplete').wcaAutocomplete();

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -1,0 +1,29 @@
+<% provide(:title, "Editing team #{@team.friendly_id}") %>
+
+<div class="container">
+
+  <h3><%= yield(:title) %></h3>
+
+  <%= simple_form_for @team, html: { class: 'form-horizontal are-you-sure no-submit-on-enter' }, wrapper: :horizontal_form,
+    wrapper_mappings: {
+      check_boxes: :horizontal_radio_and_checkboxes,
+      radio_buttons: :horizontal_radio_and_checkboxes,
+      file: :horizontal_file_input,
+      boolean: :horizontal_boolean
+    }  do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+
+    <%= f.input :friendly_id, label: "Friendly id" %>
+    <%= f.input :name %>
+    <%= f.input :description %>
+    <%= f.input :leader %>
+    
+    <div class="form-group">
+      <div class="col-sm-offset-2 col-sm-10">
+        <%= f.button :submit, class: "btn-primary" %>
+      </div>
+    </div>
+  <% end %>
+  <%= link_to 'Back to Teams', teams_path, class: "polls-home" %>
+
+</div>

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -16,8 +16,23 @@
     <%= f.input :friendly_id, label: "Friendly id" %>
     <%= f.input :name %>
     <%= f.input :description %>
-    <%= f.input :leader %>
-    
+    <%= f.input :leader_id %>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        Members
+      </div>
+      <div class="panel-body">
+        <%= f.fields_for :team_members do |members_form| %>
+          <%= render 'team_member_fields', f: members_form %>
+        <% end %>
+
+        <div class="links">
+          <%= link_to_add_association button_tag('Add member', type: "button", class: "btn btn-primary"), f, :team_members %>
+        </div>
+      </div>
+    </div>
+
     <div class="form-group">
       <div class="col-sm-offset-2 col-sm-10">
         <%= f.button :submit, class: "btn-primary" %>

--- a/WcaOnRails/app/views/teams/index.html.erb
+++ b/WcaOnRails/app/views/teams/index.html.erb
@@ -11,13 +11,14 @@
   <% if @teams.empty? %>
     <div class="alert alert-warning">There are currently no teams.</div>
   <% else %>
-    <table class="table">
+    <!--table class="table"-->
+    <%= wca_table do %>
       <tr>
-        <th>Id</th>
+        <th>ID</th>
         <th>Name</th>
         <th>Description</th>
-        <th>Leader</th>
         <th>Members</th>
+        <th>Leader(s)</th>
         <th></th>
       </tr>
       <% @teams.each do |team| %>
@@ -25,11 +26,16 @@
           <td><%= team.friendly_id %></td>
           <td><%= team.name %></td>
           <td><%= team.description %></td>
-          <td><%= team.leader.name %></td>
-          <td><%= team.team_members.map{ |member| member.user.name }.to_sentence %></td>
+          <td><%= team.team_members.map { |member| member.user.name }.to_sentence %></td>
+          <td>
+            <% team.team_members.each do |member| %>
+              <%= member.team_leader ? member.user.name : "" %>
+            <% end %>
+          </td>
           <td><%= link_to "Manage team", edit_team_path(team) %></td>
         </tr>
       <% end %>
-    </table>
+    <% end %>
+    <!--/table-->
   <% end %>
 </div>

--- a/WcaOnRails/app/views/teams/index.html.erb
+++ b/WcaOnRails/app/views/teams/index.html.erb
@@ -1,0 +1,31 @@
+<% provide(:title, 'Teams') %>
+
+<div class="container">
+  <h1><%= yield(:title) %></h1>
+
+  <% can_edit = current_user.can_edit_users? %>
+  <% if can_edit %>
+    <%= link_to "New team", new_team_path %>
+  <% end %>
+
+  <% if @teams.empty? %>
+    <div class="alert alert-warning">There are currently no teams.</div>
+  <% else %>
+    <table class="table">
+      <tr>
+        <th>Id</th>
+        <th>Name</th>
+        <th>Description</th>
+        <th>Leader</th>
+      </tr>
+      <% @teams.each do |team| %>
+        <tr>
+          <td><%= team.friendly_id %></td>
+          <td><%= team.name %></td>
+          <td><%= team.description %></td>
+          <td><%= team.leader %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% end %>
+</div>

--- a/WcaOnRails/app/views/teams/index.html.erb
+++ b/WcaOnRails/app/views/teams/index.html.erb
@@ -26,11 +26,7 @@
           <td><%= team.name %></td>
           <td><%= team.description %></td>
           <td><%= team.leader.name %></td>
-          <td>
-            <% team.team_members.each do |member |%>
-              <%= member.user.name %>,
-            <% end %>
-          </td>
+          <td><%= team.team_members.map{ |member| member.user.name }.to_sentence %></td>
           <td><%= link_to "Manage team", edit_team_path(team) %></td>
         </tr>
       <% end %>

--- a/WcaOnRails/app/views/teams/index.html.erb
+++ b/WcaOnRails/app/views/teams/index.html.erb
@@ -27,9 +27,7 @@
           <td><%= team.description %></td>
           <td><%= team.team_members.map { |member| member.user.name }.to_sentence %></td>
           <td>
-            <% team.team_members.each do |member| %>
-              <%= member.team_leader ? member.user.name : "" %>
-            <% end %>
+            <%= team.team_members.where(team_leader: true).map { |leader| leader.user.name }.sort.to_sentence %>
           </td>
           <td><%= link_to "Manage team", edit_team_path(team) %></td>
         </tr>

--- a/WcaOnRails/app/views/teams/index.html.erb
+++ b/WcaOnRails/app/views/teams/index.html.erb
@@ -11,8 +11,7 @@
   <% if @teams.empty? %>
     <div class="alert alert-warning">There are currently no teams.</div>
   <% else %>
-    <!--table class="table"-->
-    <%= wca_table do %>
+    <table class="table">
       <tr>
         <th>ID</th>
         <th>Name</th>
@@ -35,7 +34,6 @@
           <td><%= link_to "Manage team", edit_team_path(team) %></td>
         </tr>
       <% end %>
-    <% end %>
-    <!--/table-->
+    </table>
   <% end %>
 </div>

--- a/WcaOnRails/app/views/teams/index.html.erb
+++ b/WcaOnRails/app/views/teams/index.html.erb
@@ -23,7 +23,7 @@
           <td><%= team.friendly_id %></td>
           <td><%= team.name %></td>
           <td><%= team.description %></td>
-          <td><%= team.leader %></td>
+          <td><%= team.leader.name %></td>
         </tr>
       <% end %>
     </table>

--- a/WcaOnRails/app/views/teams/index.html.erb
+++ b/WcaOnRails/app/views/teams/index.html.erb
@@ -17,6 +17,8 @@
         <th>Name</th>
         <th>Description</th>
         <th>Leader</th>
+        <th>Members</th>
+        <th></th>
       </tr>
       <% @teams.each do |team| %>
         <tr>
@@ -24,6 +26,12 @@
           <td><%= team.name %></td>
           <td><%= team.description %></td>
           <td><%= team.leader.name %></td>
+          <td>
+            <% team.team_members.each do |member |%>
+              <%= member.user.name %>,
+            <% end %>
+          </td>
+          <td><%= link_to "Manage team", edit_team_path(team) %></td>
         </tr>
       <% end %>
     </table>

--- a/WcaOnRails/app/views/teams/new.html.erb
+++ b/WcaOnRails/app/views/teams/new.html.erb
@@ -1,0 +1,11 @@
+<% provide(:title, 'Create team') %>
+
+<div class="container">
+  <h1><%= yield(:title) %></h1>
+
+  <%= simple_form_for @team, html: { class: 'form-horizontal are-you-sure no-submit-on-enter' }, wrapper: :horizontal_form do |f| %>
+    <%= f.input :name, required: true %>
+
+    <button type="submit" class="btn btn-success">Create team</button>
+  <% end %>
+</div>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -146,11 +146,11 @@
         </div>
       </div>
 
-      <% UsersController.WCA_TEAMS.each do |role| %>
-        <%= f.input role, disabled: !editable_fields.include?(role) %>
-        <% leader_role = :"#{role}_leader" %>
-        <%= f.input leader_role, disabled: !editable_fields.include?(leader_role) %>
-      <% end %>
+      <%# UsersController.WCA_TEAMS.each do |role| %>
+        <%#= f.input role, disabled: !editable_fields.include?(role) %>
+        <%# leader_role = :"#{role}_leader" %>
+        <%#= f.input leader_role, disabled: !editable_fields.include?(leader_role) %>
+      <%# end %>
       <%= f.input :delegate_status, collection: User.delegate_statuses.keys, label_method: lambda { |k| k.titleize }, disabled: !editable_fields.include?(:senior_delegate_id) %>
       <%= f.association :senior_delegate, disabled: !editable_fields.include?(:senior_delegate_id) %>
       <%= f.input :region, disabled: !editable_fields.include?(:region) %>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -146,11 +146,6 @@
         </div>
       </div>
 
-      <%# UsersController.WCA_TEAMS.each do |role| %>
-        <%#= f.input role, disabled: !editable_fields.include?(role) %>
-        <%# leader_role = :"#{role}_leader" %>
-        <%#= f.input leader_role, disabled: !editable_fields.include?(leader_role) %>
-      <%# end %>
       <%= f.input :delegate_status, collection: User.delegate_statuses.keys, label_method: lambda { |k| k.titleize }, disabled: !editable_fields.include?(:senior_delegate_id) %>
       <%= f.association :senior_delegate, disabled: !editable_fields.include?(:senior_delegate_id) %>
       <%= f.input :region, disabled: !editable_fields.include?(:region) %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -59,7 +59,7 @@ en:
       mark: '*'
       # You can uncomment the line below if you need to overwrite the whole required html.
       # When using html, text and mark won't be used.
-      # html: '<abbr title="required">*</abbr>'
+      html: ''
     error_notification:
       default_message: "Please review the problems below:"
     labels:

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -45,6 +45,8 @@ Rails.application.routes.draw do
   get 'polls/:id/vote' => 'votes#vote', as: 'polls_vote'
   get 'polls/:id/results' => 'polls#results', as: 'polls_results'
 
+  resources :teams, only: [:index, :new, :create, :update, :edit, :destroy]
+
   resources :votes, only: [:create, :update]
 
   # TODO - these are vulnerable to CSRF. We should be able to change these to

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
   get 'polls/:id/vote' => 'votes#vote', as: 'polls_vote'
   get 'polls/:id/results' => 'polls#results', as: 'polls_results'
 
-  resources :teams, only: [:index, :new, :create, :update, :edit, :destroy]
+  resources :teams, only: [:index, :new, :create, :update, :edit]
 
   resources :votes, only: [:create, :update]
 

--- a/WcaOnRails/db/migrate/20160218135313_create_teams.rb
+++ b/WcaOnRails/db/migrate/20160218135313_create_teams.rb
@@ -4,7 +4,7 @@ class CreateTeams < ActiveRecord::Migration
       t.string :friendly_id
       t.string :name
       t.text :description
-      t.integer :leader, :user_id
+      t.integer :leader_id
 
       t.timestamps null: false
     end

--- a/WcaOnRails/db/migrate/20160218135313_create_teams.rb
+++ b/WcaOnRails/db/migrate/20160218135313_create_teams.rb
@@ -4,7 +4,6 @@ class CreateTeams < ActiveRecord::Migration
       t.string :friendly_id
       t.string :name, null: false
       t.text :description
-      t.integer :leader_id
 
       t.timestamps null: false
     end

--- a/WcaOnRails/db/migrate/20160218135313_create_teams.rb
+++ b/WcaOnRails/db/migrate/20160218135313_create_teams.rb
@@ -1,0 +1,12 @@
+class CreateTeams < ActiveRecord::Migration
+  def change
+    create_table :teams do |t|
+      t.string :friendly_id
+      t.string :name
+      t.text :description
+      t.integer :leader, :user_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/WcaOnRails/db/migrate/20160218135313_create_teams.rb
+++ b/WcaOnRails/db/migrate/20160218135313_create_teams.rb
@@ -2,7 +2,7 @@ class CreateTeams < ActiveRecord::Migration
   def change
     create_table :teams do |t|
       t.string :friendly_id
-      t.string :name
+      t.string :name, null: false
       t.text :description
       t.integer :leader_id
 

--- a/WcaOnRails/db/migrate/20160218234447_create_team_members.rb
+++ b/WcaOnRails/db/migrate/20160218234447_create_team_members.rb
@@ -5,6 +5,7 @@ class CreateTeamMembers < ActiveRecord::Migration
       t.integer :user_id, null: false
       t.date :start_date, null: false
       t.date :end_date, default: nil
+      t.boolean :team_leader, default: false, null: false
 
       t.timestamps null: false
     end

--- a/WcaOnRails/db/migrate/20160218234447_create_team_members.rb
+++ b/WcaOnRails/db/migrate/20160218234447_create_team_members.rb
@@ -1,0 +1,12 @@
+class CreateTeamMembers < ActiveRecord::Migration
+  def change
+    create_table :team_members do |t|
+      t.integer :team_id, null: false
+      t.integer :user_id, null: false
+      t.date :start_date, null: false
+      t.date :end_date, default: nil
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/WcaOnRails/db/migrate/20160303144700_fill_teams_tables.rb
+++ b/WcaOnRails/db/migrate/20160303144700_fill_teams_tables.rb
@@ -1,0 +1,39 @@
+class FillTeamsTables < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+      INSERT INTO teams (friendly_id, name, description) values ('results','Results Team','This team is responsible for managing all competition results.')
+    SQL
+
+    execute <<-SQL
+      INSERT INTO teams (friendly_id, name, description) values ('software','Software Team','This team is responsible for managing the WCA\'s software (website, scramblers, workbooks, admin tools).')
+    SQL
+
+    execute <<-SQL
+      INSERT INTO teams (friendly_id, name, description) values ('wdc','Disciplinary Committee','This committee advises the WCA Board in special cases, like alleged violations of WCA Regulations, and may be contacted by WCA members in case of important personal matters regarding WCA competitions.')
+    SQL
+
+    execute <<-SQL
+      INSERT INTO teams (friendly_id, name, description) values ('wrc','Regulations Committee','This committee is responsible for managing the WCA Regulations.')
+    SQL
+
+    execute <<-SQL
+      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, Date.today FROM teams,users WHERE teams.friendly_id = 'results' and users.results_team = '1'
+    SQL
+
+    execute <<-SQL
+      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, Date.today FROM teams,users WHERE teams.friendly_id = 'software' and users.software_team = '1'
+    SQL
+
+    execute <<-SQL
+      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, Date.today FROM teams,users WHERE teams.friendly_id = 'wdc' and users.wdc_team = '1'
+    SQL
+
+    execute <<-SQL
+      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, Date.today FROM teams,users WHERE teams.friendly_id = 'wrc' and users.wrc_team = '1'
+    SQL
+
+    execute <<-SQL
+      UPDATE team_members SET team_leader = '1' where user_id in (SELECT id from users where (wrc_team_leader = 1 OR wdc_team_leader = 1 OR results_team_leader = 1 or software_team_leader = '1'))
+    SQL
+  end
+end

--- a/WcaOnRails/db/migrate/20160303144700_fill_teams_tables.rb
+++ b/WcaOnRails/db/migrate/20160303144700_fill_teams_tables.rb
@@ -1,37 +1,39 @@
 class FillTeamsTables < ActiveRecord::Migration
   def change
     execute <<-SQL
-      INSERT INTO teams (friendly_id, name, description) values ('results','Results Team','This team is responsible for managing all competition results.')
+      INSERT INTO teams (friendly_id, name, description, created_at, updated_at) values ('results','Results Team','This team is responsible for managing all competition results.', NOW(), NOW())
     SQL
 
     execute <<-SQL
-      INSERT INTO teams (friendly_id, name, description) values ('software','Software Team','This team is responsible for managing the WCA\'s software (website, scramblers, workbooks, admin tools).')
+      INSERT INTO teams (friendly_id, name, description, created_at, updated_at) values ('software','Software Team','This team is responsible for managing the WCA\\'s software (website, scramblers, workbooks, admin tools).', NOW(), NOW())
     SQL
 
     execute <<-SQL
-      INSERT INTO teams (friendly_id, name, description) values ('wdc','Disciplinary Committee','This committee advises the WCA Board in special cases, like alleged violations of WCA Regulations, and may be contacted by WCA members in case of important personal matters regarding WCA competitions.')
+      INSERT INTO teams (friendly_id, name, description, created_at, updated_at) values ('wdc','Disciplinary Committee','This committee advises the WCA Board in special cases, like alleged violations of WCA Regulations, and may be contacted by WCA members in case of important personal matters regarding WCA competitions.', NOW(), NOW())
     SQL
 
     execute <<-SQL
-      INSERT INTO teams (friendly_id, name, description) values ('wrc','Regulations Committee','This committee is responsible for managing the WCA Regulations.')
+      INSERT INTO teams (friendly_id, name, description, created_at, updated_at) values ('wrc','Regulations Committee','This committee is responsible for managing the WCA Regulations.', NOW(), NOW())
     SQL
 
     execute <<-SQL
-      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, NOW() FROM teams,users WHERE teams.friendly_id = 'results' and users.results_team = 1
+      INSERT INTO team_members (team_id, user_id, start_date, created_at, updated_at) SELECT teams.id, users.id, NOW(), NOW(), NOW() FROM teams,users WHERE teams.friendly_id = 'results' and users.results_team = 1
     SQL
 
     execute <<-SQL
-      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, NOW() FROM teams,users WHERE teams.friendly_id = 'software' and users.software_team = 1
+      INSERT INTO team_members (team_id, user_id, start_date, created_at, updated_at) SELECT teams.id, users.id, NOW(), NOW(), NOW() FROM teams,users WHERE teams.friendly_id = 'software' and users.software_team = 1
     SQL
 
     execute <<-SQL
-      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, NOW() FROM teams,users WHERE teams.friendly_id = 'wdc' and users.wdc_team = 1
+      INSERT INTO team_members (team_id, user_id, start_date, created_at, updated_at) SELECT teams.id, users.id, NOW(), NOW(), NOW() FROM teams,users WHERE teams.friendly_id = 'wdc' and users.wdc_team = 1
     SQL
 
     execute <<-SQL
-      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, NOW() FROM teams,users WHERE teams.friendly_id = 'wrc' and users.wrc_team = 1
+      INSERT INTO team_members (team_id, user_id, start_date, created_at, updated_at) SELECT teams.id, users.id, NOW(), NOW(), NOW() FROM teams,users WHERE teams.friendly_id = 'wrc' and users.wrc_team = 1
     SQL
 
+    # This will work because each team leader is a member of just one team.
+    # We would have to split this query otherwise.
     execute <<-SQL
       UPDATE team_members SET team_leader = 1 where user_id in (SELECT id from users where (wrc_team_leader = 1 OR wdc_team_leader = 1 OR results_team_leader = 1 or software_team_leader = 1))
     SQL

--- a/WcaOnRails/db/migrate/20160303144700_fill_teams_tables.rb
+++ b/WcaOnRails/db/migrate/20160303144700_fill_teams_tables.rb
@@ -17,23 +17,23 @@ class FillTeamsTables < ActiveRecord::Migration
     SQL
 
     execute <<-SQL
-      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, Date.today FROM teams,users WHERE teams.friendly_id = 'results' and users.results_team = '1'
+      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, NOW() FROM teams,users WHERE teams.friendly_id = 'results' and users.results_team = 1
     SQL
 
     execute <<-SQL
-      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, Date.today FROM teams,users WHERE teams.friendly_id = 'software' and users.software_team = '1'
+      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, NOW() FROM teams,users WHERE teams.friendly_id = 'software' and users.software_team = 1
     SQL
 
     execute <<-SQL
-      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, Date.today FROM teams,users WHERE teams.friendly_id = 'wdc' and users.wdc_team = '1'
+      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, NOW() FROM teams,users WHERE teams.friendly_id = 'wdc' and users.wdc_team = 1
     SQL
 
     execute <<-SQL
-      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, Date.today FROM teams,users WHERE teams.friendly_id = 'wrc' and users.wrc_team = '1'
+      INSERT INTO team_members (team_id, user_id, start_date) SELECT teams.id, users.id, NOW() FROM teams,users WHERE teams.friendly_id = 'wrc' and users.wrc_team = 1
     SQL
 
     execute <<-SQL
-      UPDATE team_members SET team_leader = '1' where user_id in (SELECT id from users where (wrc_team_leader = 1 OR wdc_team_leader = 1 OR results_team_leader = 1 or software_team_leader = '1'))
+      UPDATE team_members SET team_leader = 1 where user_id in (SELECT id from users where (wrc_team_leader = 1 OR wdc_team_leader = 1 OR results_team_leader = 1 or software_team_leader = 1))
     SQL
   end
 end

--- a/WcaOnRails/db/migrate/20160305170821_remove_teams_columns.rb
+++ b/WcaOnRails/db/migrate/20160305170821_remove_teams_columns.rb
@@ -1,0 +1,12 @@
+class RemoveTeamsColumns < ActiveRecord::Migration
+  def change
+    remove_column :users, :wrc_team
+    remove_column :users, :wrc_team_leader
+    remove_column :users, :wdc_team
+    remove_column :users, :wdc_team_leader
+    remove_column :users, :results_team
+    remove_column :users, :results_team_leader
+    remove_column :users, :software_team
+    remove_column :users, :software_team_leader
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -674,7 +674,6 @@ CREATE TABLE `users` (
   `unconfirmed_email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `results_team` tinyint(1) DEFAULT NULL,
   `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `delegate_status` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `senior_delegate_id` int(11) DEFAULT NULL,
@@ -690,13 +689,6 @@ CREATE TABLE `users` (
   `saved_pending_avatar_crop_y` int(11) DEFAULT NULL,
   `saved_pending_avatar_crop_w` int(11) DEFAULT NULL,
   `saved_pending_avatar_crop_h` int(11) DEFAULT NULL,
-  `wdc_team` tinyint(1) DEFAULT NULL,
-  `wdc_team_leader` tinyint(1) DEFAULT NULL,
-  `wrc_team` tinyint(1) DEFAULT NULL,
-  `wrc_team_leader` tinyint(1) DEFAULT NULL,
-  `results_team_leader` tinyint(1) DEFAULT NULL,
-  `software_team` tinyint(1) DEFAULT NULL,
-  `software_team_leader` tinyint(1) DEFAULT NULL,
   `unconfirmed_wca_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `delegate_id_to_handle_wca_id_claim` int(11) DEFAULT NULL,
   `dob` date DEFAULT NULL,
@@ -859,3 +851,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160223204831');
 INSERT INTO schema_migrations (version) VALUES ('20160224013453');
 
 INSERT INTO schema_migrations (version) VALUES ('20160303144700');
+
+INSERT INTO schema_migrations (version) VALUES ('20160305170821');
+

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.16  Distrib 10.1.10-MariaDB, for Linux (x86_64)
+-- MySQL dump 10.13  Distrib 5.5.46, for debian-linux-gnu (x86_64)
 --
 -- Host: 127.0.0.1    Database: wca_development
 -- ------------------------------------------------------
--- Server version	10.1.10-MariaDB-log
+-- Server version	5.5.46-0ubuntu0.14.04.2
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -291,7 +291,7 @@ CREATE TABLE `Preregs` (
   `guests` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_Preregs_on_competitionId_and_user_id` (`competitionId`,`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=80551 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=80556 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -312,7 +312,7 @@ CREATE TABLE `RanksAverage` (
   PRIMARY KEY (`id`),
   KEY `fk_persons` (`personId`),
   KEY `fk_events` (`eventId`)
-) ENGINE=InnoDB AUTO_INCREMENT=94 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=99 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -333,7 +333,7 @@ CREATE TABLE `RanksSingle` (
   PRIMARY KEY (`id`),
   KEY `fk_persons` (`personId`),
   KEY `fk_events` (`eventId`)
-) ENGINE=InnoDB AUTO_INCREMENT=94 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=99 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -372,7 +372,7 @@ CREATE TABLE `Results` (
   KEY `Results_regionalAverageRecordCheckSpeedup` (`eventId`,`competitionId`,`roundId`,`countryId`,`average`),
   KEY `Results_regionalSingleRecordCheckSpeedup` (`eventId`,`competitionId`,`roundId`,`countryId`,`best`),
   KEY `Results_fk_competitor` (`personId`)
-) ENGINE=InnoDB AUTO_INCREMENT=855477 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=1;
+) ENGINE=InnoDB AUTO_INCREMENT=857977 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -443,7 +443,7 @@ CREATE TABLE `competition_delegates` (
   UNIQUE KEY `index_competition_delegates_on_competition_id_and_delegate_id` (`competition_id`,`delegate_id`),
   KEY `index_competition_delegates_on_competition_id` (`competition_id`),
   KEY `index_competition_delegates_on_delegate_id` (`delegate_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4249 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5251 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -464,7 +464,7 @@ CREATE TABLE `competition_organizers` (
   UNIQUE KEY `idx_competition_organizers_on_competition_id_and_organizer_id` (`competition_id`,`organizer_id`),
   KEY `index_competition_organizers_on_competition_id` (`competition_id`),
   KEY `index_competition_organizers_on_organizer_id` (`organizer_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=280 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2282 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -534,7 +534,7 @@ CREATE TABLE `oauth_applications` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_applications_on_uid` (`uid`),
   KEY `index_oauth_applications_on_owner_id_and_owner_type` (`owner_id`,`owner_type`)
-) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -571,7 +571,7 @@ CREATE TABLE `polls` (
   `updated_at` datetime NOT NULL,
   `comment` text COLLATE utf8_unicode_ci,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -595,7 +595,7 @@ CREATE TABLE `posts` (
   UNIQUE KEY `index_posts_on_slug` (`slug`),
   KEY `index_posts_on_world_readable_and_sticky_and_created_at` (`world_readable`,`sticky`,`created_at`),
   KEY `index_posts_on_world_readable_and_created_at` (`world_readable`,`created_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=4986 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5006 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -609,6 +609,25 @@ CREATE TABLE `schema_migrations` (
   `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   UNIQUE KEY `unique_schema_migrations` (`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `teams`
+--
+
+DROP TABLE IF EXISTS `teams`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `teams` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `friendly_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `description` text COLLATE utf8_unicode_ci,
+  `leader` int(11) DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -670,7 +689,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_wca_id` (`wca_id`),
   KEY `index_users_on_senior_delegate_id` (`senior_delegate_id`),
   KEY `index_users_on_delegate_id_to_handle_wca_id_claim` (`delegate_id_to_handle_wca_id_claim`)
-) ENGINE=InnoDB AUTO_INCREMENT=6040 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6091 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -715,7 +734,7 @@ CREATE TABLE `votes` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-01-27 18:41:22
+-- Dump completed on 2016-02-18 16:43:31
 INSERT INTO schema_migrations (version) VALUES ('20150501004846');
 
 INSERT INTO schema_migrations (version) VALUES ('20150504022234');
@@ -812,6 +831,9 @@ INSERT INTO schema_migrations (version) VALUES ('20160120071503');
 
 INSERT INTO schema_migrations (version) VALUES ('20160128023834');
 
+INSERT INTO schema_migrations (version) VALUES ('20160218135313');
+
 INSERT INTO schema_migrations (version) VALUES ('20160223204831');
 
 INSERT INTO schema_migrations (version) VALUES ('20160224013453');
+

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -858,3 +858,4 @@ INSERT INTO schema_migrations (version) VALUES ('20160223204831');
 
 INSERT INTO schema_migrations (version) VALUES ('20160224013453');
 
+INSERT INTO schema_migrations (version) VALUES ('20160303144700');

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -291,7 +291,7 @@ CREATE TABLE `Preregs` (
   `guests` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_Preregs_on_competitionId_and_user_id` (`competitionId`,`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=80556 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=80561 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -312,7 +312,7 @@ CREATE TABLE `RanksAverage` (
   PRIMARY KEY (`id`),
   KEY `fk_persons` (`personId`),
   KEY `fk_events` (`eventId`)
-) ENGINE=InnoDB AUTO_INCREMENT=99 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=104 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -333,7 +333,7 @@ CREATE TABLE `RanksSingle` (
   PRIMARY KEY (`id`),
   KEY `fk_persons` (`personId`),
   KEY `fk_events` (`eventId`)
-) ENGINE=InnoDB AUTO_INCREMENT=99 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=104 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -372,7 +372,7 @@ CREATE TABLE `Results` (
   KEY `Results_regionalAverageRecordCheckSpeedup` (`eventId`,`competitionId`,`roundId`,`countryId`,`average`),
   KEY `Results_regionalSingleRecordCheckSpeedup` (`eventId`,`competitionId`,`roundId`,`countryId`,`best`),
   KEY `Results_fk_competitor` (`personId`)
-) ENGINE=InnoDB AUTO_INCREMENT=857977 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=1;
+) ENGINE=InnoDB AUTO_INCREMENT=857992 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -443,7 +443,7 @@ CREATE TABLE `competition_delegates` (
   UNIQUE KEY `index_competition_delegates_on_competition_id_and_delegate_id` (`competition_id`,`delegate_id`),
   KEY `index_competition_delegates_on_competition_id` (`competition_id`),
   KEY `index_competition_delegates_on_delegate_id` (`delegate_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=5251 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5255 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -464,7 +464,7 @@ CREATE TABLE `competition_organizers` (
   UNIQUE KEY `idx_competition_organizers_on_competition_id_and_organizer_id` (`competition_id`,`organizer_id`),
   KEY `index_competition_organizers_on_competition_id` (`competition_id`),
   KEY `index_competition_organizers_on_organizer_id` (`organizer_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2282 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2290 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -534,7 +534,7 @@ CREATE TABLE `oauth_applications` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_applications_on_uid` (`uid`),
   KEY `index_oauth_applications_on_owner_id_and_owner_type` (`owner_id`,`owner_type`)
-) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=12 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -571,7 +571,7 @@ CREATE TABLE `polls` (
   `updated_at` datetime NOT NULL,
   `comment` text COLLATE utf8_unicode_ci,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -595,7 +595,7 @@ CREATE TABLE `posts` (
   UNIQUE KEY `index_posts_on_slug` (`slug`),
   KEY `index_posts_on_world_readable_and_sticky_and_created_at` (`world_readable`,`sticky`,`created_at`),
   KEY `index_posts_on_world_readable_and_created_at` (`world_readable`,`created_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=5006 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5026 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -608,6 +608,25 @@ DROP TABLE IF EXISTS `schema_migrations`;
 CREATE TABLE `schema_migrations` (
   `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   UNIQUE KEY `unique_schema_migrations` (`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `team_members`
+--
+
+DROP TABLE IF EXISTS `team_members`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `team_members` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `team_id` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL,
+  `start_date` date NOT NULL,
+  `end_date` date DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -627,7 +646,7 @@ CREATE TABLE `teams` (
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -689,7 +708,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_wca_id` (`wca_id`),
   KEY `index_users_on_senior_delegate_id` (`senior_delegate_id`),
   KEY `index_users_on_delegate_id_to_handle_wca_id_claim` (`delegate_id_to_handle_wca_id_claim`)
-) ENGINE=InnoDB AUTO_INCREMENT=6091 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6144 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -734,7 +753,7 @@ CREATE TABLE `votes` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-02-18 16:43:31
+-- Dump completed on 2016-02-19  9:22:26
 INSERT INTO schema_migrations (version) VALUES ('20150501004846');
 
 INSERT INTO schema_migrations (version) VALUES ('20150504022234');
@@ -832,6 +851,8 @@ INSERT INTO schema_migrations (version) VALUES ('20160120071503');
 INSERT INTO schema_migrations (version) VALUES ('20160128023834');
 
 INSERT INTO schema_migrations (version) VALUES ('20160218135313');
+
+INSERT INTO schema_migrations (version) VALUES ('20160218234447');
 
 INSERT INTO schema_migrations (version) VALUES ('20160223204831');
 

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -624,6 +624,7 @@ CREATE TABLE `team_members` (
   `user_id` int(11) NOT NULL,
   `start_date` date NOT NULL,
   `end_date` date DEFAULT NULL,
+  `team_leader` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`)
@@ -640,13 +641,12 @@ DROP TABLE IF EXISTS `teams`;
 CREATE TABLE `teams` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `friendly_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `description` text COLLATE utf8_unicode_ci,
-  `leader` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/WcaOnRails/spec/controllers/teams_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/teams_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe TeamsController do
+
+  describe "GET #index" do
+    context "when not signed in" do
+      sign_out
+
+      it 'redirects to the sign in page' do
+        get :index
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context "when signed in as admin" do
+      sign_in { FactoryGirl.create :admin }
+
+      it 'shows the teams index page' do
+        get :index
+        expect(response).to render_template :index
+      end
+    end
+
+    context 'when signed in as a regular user' do
+      sign_in { FactoryGirl.create :user }
+
+      it 'does not allow access' do
+        get :index
+        expect(response).to redirect_to root_url
+      end
+    end
+  end
+
+  describe "GET #new" do
+    context "when not signed in" do
+      sign_out
+
+      it 'redirects to the sign in page' do
+        get :new
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context "when signed in as admin" do
+      sign_in { FactoryGirl.create :admin }
+
+      it 'shows the teams index page' do
+        get :new
+        expect(response).to render_template :new
+      end
+    end
+
+    context 'when signed in as a regular user' do
+      sign_in { FactoryGirl.create :user }
+
+      it 'does not allow access' do
+        get :new
+        expect(response).to redirect_to root_url
+      end
+    end
+  end
+
+end

--- a/WcaOnRails/spec/controllers/teams_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/teams_controller_spec.rb
@@ -142,6 +142,13 @@ describe TeamsController do
         admin_team.reload
         expect(admin_team.team_members.first.end_date).to eq nil
       end
+
+      it 'cannot set start_date < end_date' do
+        member = FactoryGirl.create :user
+        patch :update, id: team, team: { team_members_attributes: {"0" => { user_id: member.id, start_date: Date.today, end_date: Date.today-1, team_leader: false } } }
+        invalid_team = assigns(:team)
+        expect(invalid_team).to be_invalid
+      end
     end
   end
 end

--- a/WcaOnRails/spec/controllers/teams_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/teams_controller_spec.rb
@@ -82,8 +82,8 @@ describe TeamsController do
 
       it 'creates a new team' do
         post :create, team: { name: "Team2016" }
-        new_team = assigns(:team)
-        expect(response).to redirect_to edit_team_path(new_team)        
+        new_team = Team.find_by_name("Team2016")
+        expect(response).to redirect_to edit_team_path(new_team)
         expect(new_team.name).to eq "Team2016"
       end
     end
@@ -99,41 +99,41 @@ describe TeamsController do
       it 'can change name' do
         patch :update, id: team, team: { name: "Hello" }
         expect(response).to redirect_to edit_team_path(team)
-        new_team = assigns(:team)
-        expect(new_team.name).to eq "Hello"
+        team.reload
+        expect(team.name).to eq "Hello"
       end
 
       it 'can change description' do
         patch :update, id: team, team: { description: "This team is the best!" }
         expect(response).to redirect_to edit_team_path(team)
-        new_team = assigns(:team)
-        expect(new_team.description).to eq "This team is the best!"
+        team.reload
+        expect(team.description).to eq "This team is the best!"
       end
 
       it 'can change friendly ID' do
         patch :update, id: team, team: { friendly_id: "bestteam" }
         expect(response).to redirect_to edit_team_path(team)
-        new_team = assigns(:team)
-        expect(new_team.friendly_id).to eq "bestteam"
+        team.reload
+        expect(team.friendly_id).to eq "bestteam"
       end
 
       it 'can add a member' do
         member = FactoryGirl.create :user
         patch :update, id: team, team: { team_members_attributes: {"0" => { user_id: member.id, start_date: Date.today, team_leader: false } } }
         expect(response).to redirect_to edit_team_path(team)
-        new_team = assigns(:team)
-        expect(new_team.team_members.first.user.id).to eq member.id
+        team.reload
+        expect(team.team_members.first.user.id).to eq member.id
       end
 
       it 'can deactivate a member' do
         other_member = FactoryGirl.create :user
         patch :update, id: team, team: { team_members_attributes: {"0" => { user_id: other_member.id, start_date: Date.today-2, team_leader: false} } }
         expect(response).to redirect_to edit_team_path(team)
-        new_team = assigns(:team)
-        new_member = new_team.team_members.first
+        team.reload
+        new_member = team.team_members.first
         patch :update, id: team, team: { team_members_attributes: {"0" => { id: new_member.id, user_id: other_member.id, start_date: new_member.start_date, end_date: Date.today-1, team_leader: false } } }
-        other_team = assigns(:team)
-        expect(other_team.team_members.first.user.was_team_member?(team.friendly_id)).to be true
+        team.reload
+        expect(team.team_members.first.user.was_team_member?(team.friendly_id)).to be true
       end
 
       it 'cannot demote oneself' do

--- a/WcaOnRails/spec/controllers/teams_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/teams_controller_spec.rb
@@ -133,7 +133,7 @@ describe TeamsController do
         new_member = team.team_members.first
         patch :update, id: team, team: { team_members_attributes: {"0" => { id: new_member.id, user_id: other_member.id, start_date: new_member.start_date, end_date: Date.today-1, team_leader: false } } }
         team.reload
-        expect(team.team_members.first.user.was_team_member?(team.friendly_id)).to be true
+        expect(team.team_members.first.current_member?).to be false
       end
 
       it 'cannot demote oneself' do

--- a/WcaOnRails/spec/controllers/teams_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/teams_controller_spec.rb
@@ -91,7 +91,10 @@ describe TeamsController do
 
   describe 'POST #update' do
     context 'when signed in as an admin' do
-      sign_in { FactoryGirl.create :admin }
+      let(:admin) { FactoryGirl.create :admin }
+      before :each do
+        sign_in admin 
+      end
 
       it 'can change name' do
         patch :update, id: team, team: { name: "Hello" }
@@ -131,6 +134,13 @@ describe TeamsController do
         patch :update, id: team, team: { team_members_attributes: {"0" => { id: new_member.id, user_id: other_member.id, start_date: new_member.start_date, end_date: Date.today-1, team_leader: false } } }
         other_team = assigns(:team)
         expect(other_team.team_members.first.user.was_team_member?(team.friendly_id)).to be true
+      end
+
+      it 'cannot demote oneself' do
+        admin_team = admin.teams.first
+        patch :update, id: admin_team.id, team: { team_members_attributes: {"0" => { user_id: admin.id, start_date: admin.team_members.first.start_date, end_date: Date.today-1 } } }
+        admin_team.reload
+        expect(admin_team.team_members.first.end_date).to eq nil
       end
     end
   end

--- a/WcaOnRails/spec/controllers/users_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/users_controller_spec.rb
@@ -108,7 +108,7 @@ describe UsersController do
   describe "editing user data" do
     let(:user) { FactoryGirl.create(:user) }
     let(:delegate) { FactoryGirl.create(:delegate) }
-    
+
     it "user can change email" do
       sign_in user
       expect(user.confirmation_sent_at).to eq nil

--- a/WcaOnRails/spec/factories/team_members.rb
+++ b/WcaOnRails/spec/factories/team_members.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :team_member do
+    team_id 1
+    user_id 1
+    start_date "2016-02-18"
+    end_date nil
+  end
+
+end

--- a/WcaOnRails/spec/factories/teams.rb
+++ b/WcaOnRails/spec/factories/teams.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :team do
+    friendly_id 'foo'
+    name 'Foo Team'
+    description "Just a fake team."
+  end
+
+end

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -16,15 +16,24 @@ FactoryGirl.define do
     factory :admin do
       name "Mr. Admin"
       email "admin@worldcubeassociation.org"
-      software_team true
+      after(:create) do |user|
+        software_team = FactoryGirl.create(:team, friendly_id: 'software', name: 'Software Team', description: 'Does software')
+        FactoryGirl.create(:team_member, team_id: software_team.id, user_id: user.id, team_leader: true)
+      end
     end
 
     factory :results_team do
-      results_team true
+      after(:create) do |user|
+        results_team = FactoryGirl.create(:team, friendly_id: 'results', name: 'Results Team', description: 'Posts results')
+        FactoryGirl.create(:team_member, team_id: results_team.id, user_id: user.id)
+      end
     end
 
     factory :wrc_team do
-      wrc_team true
+      after(:create) do |user|
+        wrc_team = FactoryGirl.create(:team, friendly_id: 'wrc', name: 'WRC Team', description: 'Regulations')
+        FactoryGirl.create(:team_member, team_id: wrc_team.id, user_id: user.id)
+      end
     end
 
     trait :wca_id do

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -17,21 +17,21 @@ FactoryGirl.define do
       name "Mr. Admin"
       email "admin@worldcubeassociation.org"
       after(:create) do |user|
-        software_team = FactoryGirl.create(:team, friendly_id: 'software', name: 'Software Team', description: 'Does software')
+        software_team = Team.find_by_friendly_id('software') || FactoryGirl.create(:team, friendly_id: 'software', name: 'Software Team', description: 'Does software')
         FactoryGirl.create(:team_member, team_id: software_team.id, user_id: user.id, team_leader: true)
       end
     end
 
     factory :results_team do
       after(:create) do |user|
-        results_team = FactoryGirl.create(:team, friendly_id: 'results', name: 'Results Team', description: 'Posts results')
+        results_team = Team.find_by_friendly_id('results') || FactoryGirl.create(:team, friendly_id: 'results', name: 'Results Team', description: 'Posts results')
         FactoryGirl.create(:team_member, team_id: results_team.id, user_id: user.id)
       end
     end
 
     factory :wrc_team do
       after(:create) do |user|
-        wrc_team = FactoryGirl.create(:team, friendly_id: 'wrc', name: 'WRC Team', description: 'Regulations')
+        wrc_team = Team.find_by_friendly_id('wrc') || FactoryGirl.create(:team, friendly_id: 'wrc', name: 'WRC Team', description: 'Regulations')
         FactoryGirl.create(:team_member, team_id: wrc_team.id, user_id: user.id)
       end
     end

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -17,21 +17,21 @@ FactoryGirl.define do
       name "Mr. Admin"
       email "admin@worldcubeassociation.org"
       after(:create) do |user|
-        software_team = Team.find_by_friendly_id('software') || FactoryGirl.create(:team, friendly_id: 'software', name: 'Software Team', description: 'Does software')
+        software_team = Team.find_by_friendly_id('software')
         FactoryGirl.create(:team_member, team_id: software_team.id, user_id: user.id, team_leader: true)
       end
     end
 
     factory :results_team do
       after(:create) do |user|
-        results_team = Team.find_by_friendly_id('results') || FactoryGirl.create(:team, friendly_id: 'results', name: 'Results Team', description: 'Posts results')
+        results_team = Team.find_by_friendly_id('results')
         FactoryGirl.create(:team_member, team_id: results_team.id, user_id: user.id)
       end
     end
 
     factory :wrc_team do
       after(:create) do |user|
-        wrc_team = Team.find_by_friendly_id('wrc') || FactoryGirl.create(:team, friendly_id: 'wrc', name: 'WRC Team', description: 'Regulations')
+        wrc_team = Team.find_by_friendly_id('wrc')
         FactoryGirl.create(:team_member, team_id: wrc_team.id, user_id: user.id)
       end
     end

--- a/WcaOnRails/spec/helpers/static_pages_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/static_pages_helper_spec.rb
@@ -6,10 +6,12 @@ describe StaticPagesHelper do
       team = FactoryGirl.create(:team)
       member = FactoryGirl.create(:user, name: "Jeremy")
       other_member = FactoryGirl.create(:user, name: "Pedro")
+      another_member = FactoryGirl.create(:user, name: "Aaron")
       team_member = FactoryGirl.create(:team_member, team_id: team.id, user_id: member.id, start_date: Date.today-1, team_leader: true)
       other_team_member = FactoryGirl.create(:team_member, team_id: team.id, user_id: other_member.id, start_date: Date.today-1)
+      another_team_member = FactoryGirl.create(:team_member, team_id: team.id, user_id: another_member.id, start_date: Date.today-1)
       string = helper.format_team_members(team.friendly_id)
-      expect(string).to eq "Jeremy (leader), Pedro"
+      expect(string).to eq "Jeremy (leader), Aaron, Pedro"
     end
   end
 end

--- a/WcaOnRails/spec/helpers/static_pages_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/static_pages_helper_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe StaticPagesHelper do
+  describe "#format_team_members" do
+    it "returns the team structure" do
+      team = FactoryGirl.create(:team)
+      member = FactoryGirl.create(:user, name: "Jeremy")
+      other_member = FactoryGirl.create(:user, name: "Pedro")
+      team_member = FactoryGirl.create(:team_member, team_id: team.id, user_id: member.id, start_date: Date.today-1, team_leader: true)
+      other_team_member = FactoryGirl.create(:team_member, team_id: team.id, user_id: other_member.id, start_date: Date.today-1)
+      string = helper.format_team_members(team.friendly_id)
+      expect(string).to eq "Jeremy (leader), Pedro"
+    end
+  end
+end

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -62,25 +62,6 @@ RSpec.describe User, type: :model do
     expect(User.find(delegate.id)).to eq delegate
   end
 
-  describe "team leaders" do
-    it "results team" do
-      user = FactoryGirl.build :user, results_team: false, results_team_leader: true
-      expect(user).not_to be_valid
-    end
-    it "wdc team" do
-      user = FactoryGirl.build :user, wdc_team: false, wdc_team_leader: true
-      expect(user).not_to be_valid
-    end
-    it "wrc team" do
-      user = FactoryGirl.build :user, wrc_team: false, wrc_team_leader: true
-      expect(user).not_to be_valid
-    end
-    it "software admin team" do
-      user = FactoryGirl.build :user, software_team: false, software_team_leader: true
-      expect(user).not_to be_valid
-    end
-  end
-
   it "does not give delegates results admin privileges" do
     delegate = FactoryGirl.create :delegate
     expect(delegate.can_admin_results?).to be false

--- a/WcaOnRails/spec/support/database_cleaner.rb
+++ b/WcaOnRails/spec/support/database_cleaner.rb
@@ -13,6 +13,10 @@ RSpec.configure do |config|
 
   config.before(:each) do
     DatabaseCleaner.start
+    FactoryGirl.create(:team, friendly_id: 'software', name: 'Software Team', description: 'Does software')
+    FactoryGirl.create(:team, friendly_id: 'results', name: 'Results Team', description: 'Posts results')
+    FactoryGirl.create(:team, friendly_id: 'wrc', name: 'WRC Team', description: 'Regulations')
+    FactoryGirl.create(:team, friendly_id: 'wdc', name: 'WDC Team', description: 'Disciplinary Committee')
   end
 
   config.after(:each) do


### PR DESCRIPTION
Fixes #185 

This is not done yet. Please alert me if I'm going into some wrong direction.

We have to consider also moving delegates to a "team" table. This could be tricky, because we have 4 types of them...

Things to do:
- [x] have the members be selected similar to how you select delegate(s) for a competition
- [x] better styling on the member form (inline?)
- [x] activate the datepicker and autocomplete when adding a new member
- [x] migration to remove the old fields
- [x] fix all the some_team? and can_something?

For the first one, I tried using as: :user_ids, only_one: true but it is trying to split the numeric id...