### PR TITLE
Optimize account creation flow

### DIFF
--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -55,8 +55,25 @@ $(function() {
   // "change his mind" and select a different date without
   // having to click outside and clicking on the input again.
   $datetimepicker = $('.date_picker.form-control, .datetime_picker.form-control');
-  $datetimepicker.datetimepicker({
-    useStrict: true, keepInvalid: true, useCurrent: false, keepOpen: true
+  $datetimepicker.each(function() {
+    var $this = $(this);
+    var datetimepickerOptions = {
+      useStrict: true,
+      keepInvalid: true,
+      useCurrent: false,
+      keepOpen: true,
+      sideBySide: true,
+    };
+    if($this.attr("name") === "user[dob]") {
+      // Don't allow people to choose a birthdate in the future.
+      datetimepickerOptions.maxDate = new Date();
+    } else {
+      // Only show the today button if we're not using dealing with a birthdate,
+      // where the today button can't possibly work because today is after the maxDate
+      // for the datetimepicker.
+      datetimepickerOptions.showTodayButton = true;
+    }
+    $this.datetimepicker(datetimepickerOptions);
   });
 
   // Using 'blur' here, because 'change' or 'dp.change' is not fired every time

--- a/WcaOnRails/app/assets/stylesheets/footer.scss
+++ b/WcaOnRails/app/assets/stylesheets/footer.scss
@@ -3,7 +3,7 @@ This doesn't act like a truly sticky footer (it's not always onscreen),
 but when there is space for it, it is guaranteed to appear on the bottom
 of the window, rather than immediately after our content.
 -------------------------------------------------- */
-$footer-height-em: 2em;
+$footer-height-px: 30px;
 
 html {
   position: relative;
@@ -11,15 +11,15 @@ html {
 }
 body {
   /* Margin bottom by footer height */
-  margin-bottom: $footer-height-em;
+  margin-bottom: $footer-height-px;
 }
 .footer {
   position: absolute;
   bottom: 0;
   width: 100%;
 
-  height: $footer-height-em;
-  background-color: #f5f5f5;
+  height: $footer-height-px;
+  background-color: $navbar-default-bg;
   .container .text-muted {
     margin: 5px;
     text-align: center;

--- a/WcaOnRails/app/assets/stylesheets/footer.scss
+++ b/WcaOnRails/app/assets/stylesheets/footer.scss
@@ -15,11 +15,16 @@ body {
 }
 .footer {
   position: absolute;
-  bottom: 0;
+  bottom: 1px;
   width: 100%;
 
   height: $footer-height-px;
   background-color: $navbar-default-bg;
+
+  border-top-width: 1px;
+  border-top-style: solid;
+  border-color: $navbar-default-border;
+
   .container .text-muted {
     margin: 5px;
     text-align: center;

--- a/WcaOnRails/app/assets/stylesheets/footer.scss
+++ b/WcaOnRails/app/assets/stylesheets/footer.scss
@@ -4,14 +4,16 @@ but when there is space for it, it is guaranteed to appear on the bottom
 of the window, rather than immediately after our content.
 -------------------------------------------------- */
 $footer-height-px: 30px;
+$footer-body-spacing: 10px;
 
 html {
   position: relative;
   min-height: 100%;
 }
 body {
-  /* Margin bottom by footer height */
-  margin-bottom: $footer-height-px;
+  // Add some extra space so the body content does not
+  // jut right up against the footer.
+  margin-bottom: $footer-height-px + $footer-body-spacing;
 }
 .footer {
   position: absolute;

--- a/WcaOnRails/app/assets/stylesheets/registrations.scss
+++ b/WcaOnRails/app/assets/stylesheets/registrations.scss
@@ -23,5 +23,5 @@ table.registrations-table {
 #registrations-actions {
   position: fixed;
   z-index: 1000; /* show over sticky table headers */
-  bottom: calc(5px + #{$footer-height-em});
+  bottom: calc(5px + #{$footer-height-px});
 }

--- a/WcaOnRails/app/assets/stylesheets/wca.scss
+++ b/WcaOnRails/app/assets/stylesheets/wca.scss
@@ -184,3 +184,16 @@ table.wca-results {
     }
   }
 }
+
+// Add a border to .tab-pane to line up nicely with corresponding .nav-tabs.
+// Note, we only want to do this on screensizes where the nav buttons have not
+// yet collapsed.
+.tab-pane {
+  margin-bottom: 10px;
+
+  @media (min-width: $screen-sm) {
+    border: 1px solid #{$nav-tabs-border-color};
+    border-top: 0;
+    padding: 10px;
+  }
+}

--- a/WcaOnRails/app/controllers/application_controller.rb
+++ b/WcaOnRails/app/controllers/application_controller.rb
@@ -18,7 +18,15 @@ class ApplicationController < ActionController::Base
 
   before_action :configure_permitted_parameters, if: :devise_controller?
   protected def configure_permitted_parameters
-    devise_parameter_sanitizer.for(:sign_up) << :name << :email << :dob << :gender << :country_iso2
+    devise_parameter_sanitizer.for(:sign_up) <<
+      :name <<
+      :email <<
+      :dob <<
+      :gender <<
+      :country_iso2
+    User::CLAIM_WCA_ID_PARAMS.each do |p|
+      devise_parameter_sanitizer.for(:sign_up) << p
+    end
     devise_parameter_sanitizer.for(:sign_in) << :login
     devise_parameter_sanitizer.for(:account_update) << :name << :email
   end

--- a/WcaOnRails/app/controllers/application_controller.rb
+++ b/WcaOnRails/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
 
   before_action :configure_permitted_parameters, if: :devise_controller?
   protected def configure_permitted_parameters
-    devise_parameter_sanitizer.for(:sign_up) << :name << :email
+    devise_parameter_sanitizer.for(:sign_up) << :name << :email << :dob << :gender << :country_iso2
     devise_parameter_sanitizer.for(:sign_in) << :login
     devise_parameter_sanitizer.for(:account_update) << :name << :email
   end

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -269,7 +269,13 @@ module ApplicationHelper
       end
     end
 
-    user.users_claiming_wca_id.each do |user_claiming_wca_id|
+    # Show all the users who are waiting to have their WCA ID claims approved.
+    # Note that it is possible for users who have not yet confirmed their accounts
+    # to have claimed a WCA ID, as we support claiming a WCA ID as part of signing up
+    # for an account. We don't want to bother delegates with these claims until
+    # the user has confirmed their account, though, so filter out users with
+    # confirmed_at=NULL.
+    user.users_claiming_wca_id.where.not(confirmed_at: nil).each do |user_claiming_wca_id|
       notifications << {
         text: "#{user_claiming_wca_id.email} has claimed WCA ID #{user_claiming_wca_id.unconfirmed_wca_id}",
         url: edit_user_path(user_claiming_wca_id.id, anchor: "wca_id"),

--- a/WcaOnRails/app/inputs/date_picker_input.rb
+++ b/WcaOnRails/app/inputs/date_picker_input.rb
@@ -35,7 +35,7 @@ class DatePickerInput < SimpleForm::Inputs::StringInput
 
   def set_value_html_option
     return unless value.present?
-    input_html_options[:value] ||= I18n.localize(value, format: display_pattern)
+    input_html_options[:value] ||= value.is_a?(String) ? value : I18n.localize(value, format: display_pattern)
   end
 
   def value

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -404,7 +404,6 @@ class User < ActiveRecord::Base
       fields << :current_password
       fields << :password << :password_confirmation
       fields << :email
-      fields += CLAIM_WCA_ID_PARAMS
     end
     if admin? || board_member?
       fields += UsersController.WCA_TEAMS
@@ -425,6 +424,7 @@ class User < ActiveRecord::Base
         fields << :gender
         fields << :country_iso2
       end
+      fields += CLAIM_WCA_ID_PARAMS
       fields << :pending_avatar << :pending_avatar_cache << :remove_pending_avatar
       fields << :avatar_crop_x << :avatar_crop_y << :avatar_crop_w << :avatar_crop_h
       fields << :pending_avatar_crop_x << :pending_avatar_crop_y << :pending_avatar_crop_w << :pending_avatar_crop_h

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -21,7 +21,6 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable,
          :confirmable
-  validates :email, presence: true
   validates :name, presence: true
   WCA_ID_RE = /\A(|\d{4}[A-Z]{4}\d{2})\z/
   validates :wca_id, format: { with: WCA_ID_RE }, allow_nil: true

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -21,6 +21,7 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable,
          :confirmable
+  validates :email, presence: true
   validates :name, presence: true
   WCA_ID_RE = /\A(|\d{4}[A-Z]{4}\d{2})\z/
   validates :wca_id, format: { with: WCA_ID_RE }, allow_nil: true

--- a/WcaOnRails/app/views/competitions/edit.html.erb
+++ b/WcaOnRails/app/views/competitions/edit.html.erb
@@ -256,8 +256,7 @@
     <%= f.input :use_wca_registration %>
 
     <div class="wca-registration-options">
-      <%# This is pretty annoying, see https://groups.google.com/d/msg/plataformatec-simpleform/aHAtI3pONJo/B_YDb9u1AgAJ %>
-      <%= f.input :guests_enabled, as: :radio_buttons, collection: [ [t('simple_form.options.competition.guests_enabled.true'), true], [t('simple_form.options.competition.guests_enabled.false'), false]] %>
+      <%= f.input :guests_enabled, as: :radio_buttons, collection: [ :true, :false ] %>
 
       <% if @competition.can_receive_registration_emails?(current_user.id) %>
         <%# Quick hack to fill receive_registration_emails with the correct

--- a/WcaOnRails/app/views/devise/registrations/new.html.erb
+++ b/WcaOnRails/app/views/devise/registrations/new.html.erb
@@ -8,8 +8,8 @@
       <%= simple_form_for(resource, as: resource_name, url: user_registration_path, html: { role: "form" }) do |f| %>
         <%= f.input :email %>
         <%= f.input :name %>
-        <%= f.input :password %>
-        <%= f.input :password_confirmation %>
+        <%= f.input :password, required: true %>
+        <%= f.input :password_confirmation, required: true %>
 
         <%= f.submit t('.sign_up', :default => "Sign up"), class: "btn btn-primary" %>
       <% end %>

--- a/WcaOnRails/app/views/devise/registrations/new.html.erb
+++ b/WcaOnRails/app/views/devise/registrations/new.html.erb
@@ -5,9 +5,17 @@
       <h4><%= t('.sign_up', :default => "Sign up") %></h4>
     </div>
     <div class="panel-body">
-      <%= simple_form_for(resource, as: resource_name, url: user_registration_path, html: { role: "form" }) do |f| %>
-        <%= f.input :email %>
+      <%= simple_form_for(resource, as: resource_name, url: user_registration_path, html: { class: 'are-you-sure no-submit-on-enter' }) do |f| %>
+        <%= f.input :email, required: true %>
+
+        <%# Copied from app/views/users/edit.html.erb %>
         <%= f.input :name %>
+        <%= f.input :dob, as: :date_picker %>
+        <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: "Male", f: "Female", o: "Other" }[g] } %>
+        <%= f.input :country_iso2, collection: Country.all.map(&:iso2), label_method: lambda { |iso2| Country.find_by_iso2(iso2).name } %>
+
+        <hr>
+
         <%= f.input :password, required: true %>
         <%= f.input :password_confirmation, required: true %>
 

--- a/WcaOnRails/app/views/devise/registrations/new.html.erb
+++ b/WcaOnRails/app/views/devise/registrations/new.html.erb
@@ -5,23 +5,12 @@
       <h4><%= t('.sign_up', :default => "Sign up") %></h4>
     </div>
     <div class="panel-body">
-      <%= form_for(resource, :as => resource_name, :url => user_registration_path, html: { role: "form" }) do |f| %>
-        <div class="form-group">
-          <%= f.label :email %>
-          <%= f.email_field :email, autofocus: true, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= f.label :name %>
-          <%= f.text_field :name, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= f.label :password %><br />
-          <%= f.password_field :password, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= f.label :password_confirmation %>
-          <%= f.password_field :password_confirmation, class: "form-control" %>
-        </div>
+      <%= simple_form_for(resource, as: resource_name, url: user_registration_path, html: { role: "form" }) do |f| %>
+        <%= f.input :email %>
+        <%= f.input :name %>
+        <%= f.input :password %>
+        <%= f.input :password_confirmation %>
+
         <%= f.submit t('.sign_up', :default => "Sign up"), class: "btn btn-primary" %>
       <% end %>
     </div>

--- a/WcaOnRails/app/views/devise/registrations/new.html.erb
+++ b/WcaOnRails/app/views/devise/registrations/new.html.erb
@@ -7,6 +7,7 @@
     <div class="panel-body">
       <%= simple_form_for(resource, as: resource_name, url: user_registration_path, html: { class: 'are-you-sure no-submit-on-enter' }) do |f| %>
         <%= f.input :email, required: true %>
+        <%= resource.password %>
         <%= f.input :password, required: true %>
         <%= f.input :password_confirmation, required: true %>
 

--- a/WcaOnRails/app/views/devise/registrations/new.html.erb
+++ b/WcaOnRails/app/views/devise/registrations/new.html.erb
@@ -7,20 +7,84 @@
     <div class="panel-body">
       <%= simple_form_for(resource, as: resource_name, url: user_registration_path, html: { class: 'are-you-sure no-submit-on-enter' }) do |f| %>
         <%= f.input :email, required: true %>
-
-        <%# Copied from app/views/users/edit.html.erb %>
-        <%= f.input :name %>
-        <%= f.input :dob, as: :date_picker %>
-        <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: "Male", f: "Female", o: "Other" }[g] } %>
-        <%= f.input :country_iso2, collection: Country.all.map(&:iso2), label_method: lambda { |iso2| Country.find_by_iso2(iso2).name } %>
-
-        <hr>
-
         <%= f.input :password, required: true %>
         <%= f.input :password_confirmation, required: true %>
 
-        <%= f.submit t('.sign_up', :default => "Sign up"), class: "btn btn-primary" %>
+
+        <ul class="nav nav-tabs nav-justified" id="have-you-competed-nav" role="tablist">
+          <li role="presentation">
+            <a href="#have-competed" aria-controls="have-competed" role="tab" data-toggle="tab">
+              I have competed in a WCA competition.
+            </a>
+          </li>
+          <li role="presentation">
+            <a href="#never-competed" aria-controls="never-competed" role="tab" data-toggle="tab">
+              I have never competed in a WCA competition.
+            </a>
+          </li>
+        </ul>
+
+        <div class="tab-content">
+          <div role="tabpanel" class="tab-pane active" id="unknown-competed">
+            Please let us know if you have competed in a WCA competition before.
+          </div>
+
+          <div role="tabpanel" class="tab-pane" id="have-competed">
+            <p>
+              Welcome back! To create your WCA website account, we need to know the
+              WCA ID under which you competed.
+            </p>
+
+            <%= render "users/claim_wca_id_selector", f: f %>
+          </div>
+
+          <div role="tabpanel" class="tab-pane" id="never-competed">
+            <p>
+              Welcome! Before you can compete in your first WCA competition, we need some
+              additional information for records keeping purposes. Please note that
+              your birthdate will never be released without your permission.
+            </p>
+
+            <%# Copied from app/views/users/edit.html.erb %>
+            <%= f.input :name %>
+            <%= f.input :dob, as: :date_picker %>
+            <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: "Male", f: "Female", o: "Other" }[g] } %>
+            <%= f.input :country_iso2, collection: Country.all.map(&:iso2), label_method: lambda { |iso2| Country.find_by_iso2(iso2).name } %>
+
+          </div>
+        </div>
+
+        <%= f.hidden_field :claiming_wca_id %>
+
+        <%= f.submit t('.sign_up', :default => "Sign up"), class: "btn btn-primary", disabled: true %>
       <% end %>
     </div>
   </div>
 </div>
+
+<script>
+  $(function() {
+    var $claiming_wca_id = $('#user_claiming_wca_id');
+    $('#have-you-competed-nav a').on('shown.bs.tab', function() {
+      // Leave the "Sign up" button disabled until the user tells us if they
+      // have competed before.
+      $('input[type="submit"]').attr('disabled', false);
+    });
+
+    var $haveCompetedLink = $('#have-you-competed-nav a[href="#have-competed"]');
+    if($claiming_wca_id.val() === "true") {
+      $haveCompetedLink.tab('show');
+    }
+    $haveCompetedLink.on('shown.bs.tab', function() {
+      $claiming_wca_id.val('true');
+    });
+
+    var $neverCompetedLink = $('#have-you-competed-nav a[href="#never-competed"]');
+    if($claiming_wca_id.val() === "false") {
+      $neverCompetedLink.tab('show');
+    }
+    $neverCompetedLink.on('shown.bs.tab', function() {
+      $claiming_wca_id.val('false');
+    });
+  });
+</script>

--- a/WcaOnRails/app/views/shared/_wca_id.html.erb
+++ b/WcaOnRails/app/views/shared/_wca_id.html.erb
@@ -1,4 +1,6 @@
 <%= content_tag :span, class: "wca-id" do -%>
 <%# We use a full url because this can be rendered inside of emails -%>
-<%= link_to wca_id, "#{root_url}results/p.php?i=#{wca_id}" -%>
+<% options = {} %>
+<% options[:target] = target if defined?(target) %>
+<%= link_to wca_id, "#{root_url}results/p.php?i=#{wca_id}", options -%>
 <% end %>

--- a/WcaOnRails/app/views/users/_claim_wca_id_selector.html.erb
+++ b/WcaOnRails/app/views/users/_claim_wca_id_selector.html.erb
@@ -1,0 +1,56 @@
+<%= f.input :unconfirmed_wca_id, label: "WCA ID", as: :user_ids, persons_table: true, only_one: true %>
+<div id="select-nearby-delegate-area"></div>
+
+<%= f.input :dob_verification, label: "Birthdate", as: :date_picker %>
+
+<script>
+  $(function() {
+    var $dobArea = $("div.user_dob_verification");
+    var $unconfirmed_wca_id = $("#user_unconfirmed_wca_id");
+    var $submitButton = $("#claim-wca-id-button");
+    $unconfirmed_wca_id.wcaAutocomplete();
+    var unconfirmed_wca_id_selectize = $unconfirmed_wca_id[0].selectize;
+
+    function clearExtraInfo() {
+      $submitButton.prop("disabled", true);
+      $dobArea.toggle(false);
+    }
+    clearExtraInfo();
+    var onUnconfirmedWcaId = function(unconfirmed_wca_id) {
+      clearExtraInfo();
+
+      wca.cancelPendingAjaxAndAjax('render_select_nearby_delegate', {
+        url: '<%= profile_claim_wca_id_select_nearby_delegate_path %>',
+        data: {
+          'user[unconfirmed_wca_id]': unconfirmed_wca_id,
+        },
+        success: function(data) {
+          $('#select-nearby-delegate-area').html(data);
+
+          var $delegateSearch = $('#nearby-delegate-search');
+          if($delegateSearch.length > 0) {
+            $delegateSearch.wcaAutocomplete();
+            var selectize = $delegateSearch[0].selectize;
+            var $radioInput = $delegateSearch.siblings('input');
+            selectize.on("focus", function(e) {
+              $radioInput.prop('checked', true);
+            });
+            selectize.on("change", function(value) {
+              $radioInput.val(value);
+              $submitButton.prop("disabled", false);
+            });
+          }
+        }
+      });
+    };
+    unconfirmed_wca_id_selectize.on("change", onUnconfirmedWcaId);
+    if(unconfirmed_wca_id_selectize.items.length > 0) {
+      onUnconfirmedWcaId(unconfirmed_wca_id_selectize.items[0]);
+    }
+
+    $("form.edit_user").on("change", 'input[type="radio"]', function(e) {
+      var selectedDelgateId = e.currentTarget.value;
+      $submitButton.prop("disabled", !selectedDelgateId);
+    });
+  });
+</script>

--- a/WcaOnRails/app/views/users/_claim_wca_id_selector.html.erb
+++ b/WcaOnRails/app/views/users/_claim_wca_id_selector.html.erb
@@ -1,5 +1,7 @@
 <%= f.input :unconfirmed_wca_id, label: "WCA ID", as: :user_ids, persons_table: true, only_one: true %>
-<div id="select-nearby-delegate-area"></div>
+<div id="select-nearby-delegate-area">
+  <%= render "users/select_nearby_delegate" %>
+</div>
 
 <%= f.input :dob_verification, label: "Birthdate", as: :date_picker %>
 
@@ -44,8 +46,12 @@
       });
     };
     unconfirmed_wca_id_selectize.on("change", onUnconfirmedWcaId);
+    if($('[name="user[delegate_id_to_handle_wca_id_claim]"]:checked').val()) {
+      $dobArea.toggle(true);
+      $submitButton.prop("disabled", false);
+    }
     if(unconfirmed_wca_id_selectize.items.length > 0) {
-      onUnconfirmedWcaId(unconfirmed_wca_id_selectize.items[0]);
+      var $selected_delegate_id = $('[name="user[delegate_id_to_handle_wca_id_claim]"]:checked');
     }
 
     $("form.edit_user").on("change", 'input[type="radio"]', function(e) {

--- a/WcaOnRails/app/views/users/_select_nearby_delegate.html.erb
+++ b/WcaOnRails/app/views/users/_select_nearby_delegate.html.erb
@@ -1,15 +1,15 @@
 <% if !@user.unconfirmed_person %>
   <p>
-    WCA ID <%= render "shared/wca_id", wca_id: @user.unconfirmed_wca_id %> does not exist.
+    WCA ID <%= render "shared/wca_id", wca_id: @user.unconfirmed_wca_id, target: "_blank" %> does not exist.
   </p>
 <% elsif @user.unconfirmed_person.user && !@user.unconfirmed_person.user.dummy_account? %>
   <p>
-    WCA ID <%= render "shared/wca_id", wca_id: @user.unconfirmed_wca_id %> is already assigned to a different account.
+    WCA ID <%= render "shared/wca_id", wca_id: @user.unconfirmed_wca_id, target: "_blank" %> is already assigned to a different account.
     If you believe this was done in error, contact your local <%= link_to "delegate", delegates_path %>.
   </p>
 <% elsif !@user.unconfirmed_person.dob %>
   <p>
-    WCA ID <%= render "shared/wca_id", wca_id: @user.unconfirmed_wca_id %> does
+    WCA ID <%= render "shared/wca_id", wca_id: @user.unconfirmed_wca_id, target: "_blank" %> does
     not have a birthdate assigned. Please contact the
     <%= mail_to "results@worldcubeassociation.org", "Results team", target: "_blank" %> to fix this.
   </p>

--- a/WcaOnRails/app/views/users/_select_nearby_delegate.html.erb
+++ b/WcaOnRails/app/views/users/_select_nearby_delegate.html.erb
@@ -15,15 +15,21 @@
   </p>
 <% else %>
   <p>
-    In order to assign you your WCA ID, we need to confirm your identify. Please
-    select the delegate you think knows you best and enter your birthdate.
+    In order to assign you your WCA ID, we need a delegate to confirm your
+    identify. Please select the delegate you think knows you best and enter
+    your birthdate.
   </p>
 
   <div class="form-group radio_buttons optional">
+    <% found_delegate = false %>
     <% @user.unconfirmed_person.likely_delegates.each do |delegate| %>
       <span class="radio">
         <label>
-          <%= radio_button_tag "user[delegate_id_to_handle_wca_id_claim]", delegate.id, false, class: "radio_buttons center-vertically" %>
+          <% is_selected_delegate = @user.delegate_id_to_handle_wca_id_claim == delegate.id %>
+          <% if is_selected_delegate %>
+            <% found_delegate = true %>
+          <% end %>
+          <%= radio_button_tag "user[delegate_id_to_handle_wca_id_claim]", delegate.id, is_selected_delegate, class: "radio_buttons center-vertically", checked: is_selected_delegate %>
           <%= render "shared/user", user: delegate %>
         </label>
       </span>
@@ -34,8 +40,24 @@
            make sure it doesn't focus anything by setting the wrapping label to
            focus nothing -->
       <label class="full-width" for="nonexistant-id">
-        <input class="radio_buttons optional center-vertically" type="radio" value="" name="user[delegate_id_to_handle_wca_id_claim]" />
-        <input id="nearby-delegate-search" class="optional form-control wca-autocomplete wca-autocomplete-users_search wca-autocomplete-only_delegates wca-autocomplete-only_one" />
+        <% chose_extra_delegate = !found_delegate && @user.delegate_to_handle_wca_id_claim %>
+        <input class="radio_buttons optional center-vertically"
+               type="radio"
+               value="<%= chose_extra_delegate ? @user.delegate_to_handle_wca_id_claim.id : '' %>"
+               name="user[delegate_id_to_handle_wca_id_claim]" <%= chose_extra_delegate ? 'checked' : '' %> />
+
+        <% input_data = {} %>
+        <% value = "" %>
+        <% if chose_extra_delegate %>
+          <% delegate = @user.delegate_to_handle_wca_id_claim %>
+          <% input_data[:data] = [delegate.to_jsonable].to_json %>
+          <% value = @user.delegate_to_handle_wca_id_claim.id %>
+        <% end %>
+        <%= text_field_tag "", value,
+                           id: "nearby-delegate-search",
+                           class: "optional form-control wca-autocomplete wca-autocomplete-users_search wca-autocomplete-only_delegates wca-autocomplete-only_one",
+                           data: input_data %>
+
       </label>
     </span>
   </div>

--- a/WcaOnRails/app/views/users/_select_nearby_delegate.html.erb
+++ b/WcaOnRails/app/views/users/_select_nearby_delegate.html.erb
@@ -1,6 +1,8 @@
 <% if !@user.unconfirmed_person %>
   <p>
-    WCA ID <%= render "shared/wca_id", wca_id: @user.unconfirmed_wca_id, target: "_blank" %> does not exist.
+    <% if @user.unconfirmed_wca_id.present? %>
+      WCA ID <%= render "shared/wca_id", wca_id: @user.unconfirmed_wca_id, target: "_blank" %> does not exist.
+    <% end %>
   </p>
 <% elsif @user.unconfirmed_person.user && !@user.unconfirmed_person.user.dummy_account? %>
   <p>

--- a/WcaOnRails/app/views/users/claim_wca_id.html.erb
+++ b/WcaOnRails/app/views/users/claim_wca_id.html.erb
@@ -4,11 +4,12 @@
   <h1 class="text-center"><%= yield(:title) %></h1>
 
   <%= render 'shared/error_messages', object: @user %>
-  <% if @user.person %>
-    You already have WCA ID <%= render "shared/wca_id", wca_id: @user.wca_id -%>.
-  <% elsif @user.unconfirmed_person && @user.delegate_to_handle_wca_id_claim %>
-    You've claimed WCA ID <%= render "shared/wca_id", wca_id: @user.unconfirmed_wca_id -%>.
-    Contact <%= mail_to @user.delegate_to_handle_wca_id_claim.email, @user.delegate_to_handle_wca_id_claim.name, target: "_blank" %> if you have any questions.
+  <% real_user = User.find(@user.id) %>
+  <% if real_user.person %>
+    You already have WCA ID <%= render "shared/wca_id", wca_id: real_user.wca_id -%>.
+  <% elsif real_user.unconfirmed_person && real_user.delegate_to_handle_wca_id_claim %>
+    You've claimed WCA ID <%= render "shared/wca_id", wca_id: real_user.unconfirmed_wca_id -%>.
+    Contact <%= mail_to real_user.delegate_to_handle_wca_id_claim.email, real_user.delegate_to_handle_wca_id_claim.name, target: "_blank" %> if you have any questions.
   <% else %>
     <p>
       If you've competed before, you can request to have your WCA ID connected

--- a/WcaOnRails/app/views/users/claim_wca_id.html.erb
+++ b/WcaOnRails/app/views/users/claim_wca_id.html.erb
@@ -20,65 +20,13 @@
       competition are uploaded.
     </p>
 
-    <%= simple_form_for @user, url: profile_claim_wca_id_path, html: { multipart: true } do |f| %>
-      <%= f.input :unconfirmed_wca_id, label: "WCA ID", as: :user_ids, persons_table: true, only_one: true %>
-      <div id="select-nearby-delegate-area"></div>
+    <%= simple_form_for @user do |f| %>
+      <% @user.claiming_wca_id = true %>
+      <%= f.hidden_field :claiming_wca_id %>
 
-      <%= f.input :dob_verification, label: "Birthdate", as: :date_picker %>
-
+      <%= render "claim_wca_id_selector", f: f %>
       <%= f.button :submit, 'Claim WCA ID', id: "claim-wca-id-button", class: "btn-primary" %>
+
     <% end %>
-
-    <script>
-      $(function() {
-        var $dobArea = $("div.user_dob_verification");
-        var $unconfirmed_wca_id = $("#user_unconfirmed_wca_id");
-        var $submitButton = $("#claim-wca-id-button");
-        $unconfirmed_wca_id.wcaAutocomplete();
-        var unconfirmed_wca_id_selectize = $unconfirmed_wca_id[0].selectize;
-
-        function clearExtraInfo() {
-          $submitButton.prop("disabled", true);
-          $dobArea.toggle(false);
-        }
-        clearExtraInfo();
-        var onUnconfirmedWcaId = function(unconfirmed_wca_id) {
-          clearExtraInfo();
-
-          wca.cancelPendingAjaxAndAjax('render_select_nearby_delegate', {
-            url: '<%= profile_claim_wca_id_select_nearby_delegate_path %>',
-            data: {
-              'user[unconfirmed_wca_id]': unconfirmed_wca_id,
-            },
-            success: function(data) {
-              $('#select-nearby-delegate-area').html(data);
-
-              var $delegateSearch = $('#nearby-delegate-search');
-              if($delegateSearch.length > 0) {
-                $delegateSearch.wcaAutocomplete();
-                var selectize = $delegateSearch[0].selectize;
-                var $radioInput = $delegateSearch.siblings('input');
-                selectize.on("focus", function(e) {
-                  $radioInput.prop('checked', true);
-                });
-                selectize.on("change", function(value) {
-                  $radioInput.val(value);
-                  $submitButton.prop("disabled", false);
-                });
-              }
-            }
-          });
-        };
-        unconfirmed_wca_id_selectize.on("change", onUnconfirmedWcaId);
-        if(unconfirmed_wca_id_selectize.items.length > 0) {
-          onUnconfirmedWcaId(unconfirmed_wca_id_selectize.items[0]);
-        }
-
-        $("form.edit_user").on("change", 'input[type="radio"]', function(e) {
-          var selectedDelgateId = e.currentTarget.value;
-          $submitButton.prop("disabled", !selectedDelgateId);
-        });
-      });
-    </script>
   <% end %>
 </div>

--- a/WcaOnRails/app/views/users/confirm_password.html.erb
+++ b/WcaOnRails/app/views/users/confirm_password.html.erb
@@ -9,7 +9,9 @@
       <%= simple_form_for @user do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
         <% current_user.editable_fields_of_user(@user).each do |field| %>
-          <%= f.hidden_field field %>
+          <% if params["user"].include?(field.to_s) %>
+            <%= f.hidden_field field %>
+          <% end %>
         <% end %>
         <%= f.input :current_password, autofocus: true %>
 

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -69,7 +69,7 @@ en:
         id: "ID"
     hints:
       defaults:
-        dob: "Enter your date of birth in the format YYYY-MM-DD"
+        dob: "Enter your date of birth in the format YYYY-MM-DD."
       user:
         name_html: "Enter your full name correctly, for example <strong>Stefan Pochmann</strong>. Not sloppily like <strong>s pochman</strong>."
       competition:

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -70,6 +70,8 @@ en:
     hints:
       defaults:
         dob: "Enter your date of birth in the format YYYY-MM-DD"
+      user:
+        name_html: "Enter your full name correctly, for example <strong>Stefan Pochmann</strong>. Not sloppily like <strong>s pochman</strong>."
       competition:
         competition_id_to_clone: "Optional. Can save you some typing if you're running a similar competition to a past competition."
         name: "The full name of the competition including the year at the end (e.g., European Rubik's Cube Championship 2006). Be sure to capitalize."

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -31,7 +31,7 @@ en:
         wca_id: "WCA ID"
         unconfirmed_wca_id: "Unconfirmed WCA ID"
         login: "Email or WCA ID"
-        country_iso2: "Country"
+        country_iso2: "Citizenship"
         dob: "Birthdate"
       competition:
         isConfirmed: "Do not let organizers edit this competition"

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -20,7 +20,6 @@ Rails.application.routes.draw do
   get 'profile/edit' => 'users#edit'
 
   get 'profile/claim_wca_id' => 'users#claim_wca_id'
-  patch 'profile/claim_wca_id' => 'users#do_claim_wca_id'
   get 'profile/claim_wca_id/select_nearby_delegate' => 'users#select_nearby_delegate'
 
   get 'users/:id/edit/avatar_thumbnail' => 'users#edit_avatar_thumbnail', as: :users_avatar_thumbnail_edit

--- a/WcaOnRails/spec/controllers/notifications_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/notifications_controller_spec.rb
@@ -45,10 +45,13 @@ RSpec.describe NotificationsController, type: :controller do
         ]
       end
 
-      it "shows WCA ID claims" do
+      it "shows WCA ID claims for confirmed accounts, but not for unconfirmed accounts" do
         person = FactoryGirl.create :person
         user = FactoryGirl.create :user
         user.update_attributes!(unconfirmed_wca_id: person.id, delegate_to_handle_wca_id_claim: delegate)
+
+        unconfirmed_user = FactoryGirl.create :user, :unconfirmed
+        unconfirmed_user.update_attributes!(unconfirmed_wca_id: person.id, delegate_to_handle_wca_id_claim: delegate)
 
         get :index
         notifications = assigns(:notifications)

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -7,7 +7,11 @@ FactoryGirl.define do
     dob Date.new(1980, 1, 1)
     password "wca"
     password_confirmation { "wca" }
+
     before(:create) { |user| user.skip_confirmation! }
+    trait :unconfirmed do
+      before(:create) { |user| user.confirmed_at = nil }
+    end
 
     factory :admin do
       name "Mr. Admin"

--- a/WcaOnRails/spec/features/claim_wca_id_spec.rb
+++ b/WcaOnRails/spec/features/claim_wca_id_spec.rb
@@ -34,8 +34,16 @@ RSpec.feature "Claim WCA ID" do
       delegate = person.competitions.first.delegates.first
       choose("user_delegate_id_to_handle_wca_id_claim_#{delegate.id}")
 
-      fill_in "Birthdate", with: "1988-02-03"
+      # First, intentionally fill in the incorrect birthdate,
+      # to test out our validations.
+      fill_in "Birthdate", with: "1900-01-01"
+      click_button "Claim WCA ID"
 
+      # Make sure we inform the user of the incorrect birthdate they just
+      # entered.
+      expect(page.find(".alert.alert-danger")).to have_content("Dob verification incorrect")
+      # Now enter the correct birthdate and submit the form!
+      fill_in "Birthdate", with: "1988-02-03"
       click_button "Claim WCA ID"
 
       user.reload

--- a/WcaOnRails/spec/features/log_user_id_spec.rb
+++ b/WcaOnRails/spec/features/log_user_id_spec.rb
@@ -1,38 +1,22 @@
 require "rails_helper"
 
-RSpec.feature "log user id" do
-  before :each do
-    allow(Rails.logger).to receive(:info).and_call_original
-  end
-
-  context "not logged in" do
-    before :each do
-      expect_logger_to_log("[User Id] Request was made by user id: <not logged in>")
-    end
-
-    it "logs the not logged in user" do
-      visit root_path
-    end
-  end
-
-  context "logged in" do
-    let(:admin) { FactoryGirl.create :admin }
+RSpec.feature "edit user" do
+  context "editing own profile" do
+    let(:admin) { FactoryGirl.create :admin, :wca_id }
 
     before :each do
       sign_in admin
-
-      expect_logger_to_log("[User Id] Request was made by user id: #{admin.id}")
     end
 
-    it "logs the current user" do
-      visit root_path
-    end
-  end
+    it "can clear wca id" do
+      visit profile_edit_path
+      fill_in "WCA ID", with: ""
+      click_button "Save"
 
-  def expect_logger_to_log(message)
-    expect(Rails.logger).to receive(:info).
-                            at_least(:once).
-                            with(message).
-                            and_call_original
+      fill_in "Current password", with: "wca"
+      click_button "Confirm"
+      expect(page.status_code).to eq 200
+      expect(admin.reload.wca_id).to eq nil
+    end
   end
 end

--- a/WcaOnRails/spec/features/sign_up_spec.rb
+++ b/WcaOnRails/spec/features/sign_up_spec.rb
@@ -44,8 +44,19 @@ RSpec.feature "Sign up" do
       delegate = person.competitions.first.delegates.first
       choose("user_delegate_id_to_handle_wca_id_claim_#{delegate.id}")
 
-      fill_in "Birthdate", with: "1988-02-03"
+      # First, intentionally fill in the incorrect birthdate,
+      # to test out our validations.
+      fill_in "Birthdate", with: "1900-01-01"
+      click_button "Sign up"
 
+      # Make sure we inform the user of the incorrect birthdate they just
+      # entered.
+      expect(page.find(".alert.alert-danger")).to have_content("Dob verification incorrect")
+      # Now enter the correct birthdate and submit the form!
+      fill_in "Birthdate", with: "1988-02-03"
+      # We also have to re-fill in the password and password confirmation
+      fill_in "user[password]", with: "wca"
+      fill_in "user[password_confirmation]", with: "wca"
       click_button "Sign up"
 
       u = User.find_by_email!("jack@example.com")

--- a/WcaOnRails/spec/features/sign_up_spec.rb
+++ b/WcaOnRails/spec/features/sign_up_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+RSpec.feature "Sign up" do
+  let!(:person) { FactoryGirl.create(:person_who_has_competed_once, year: 1988, month: 02, day: 03) }
+  let!(:person_without_dob) { FactoryGirl.create :person, year: 0, month: 0, day: 0 }
+
+  context 'when signing up as a returning competitor', js: true do
+    it 'disables sign up button until the user selects "have competed"' do
+      visit "/users/sign_up"
+
+      expect(page).to have_selector('#unknown-competed', visible: true)
+      expect(page).to have_button("Sign up", disabled: true)
+      click_on "I have competed in a WCA competition."
+      expect(page).to have_selector('#unknown-competed', visible: false)
+      expect(page).to have_button("Sign up")
+    end
+
+    it 'finds people by name' do
+      visit "/users/sign_up"
+
+      fill_in "Email", with: "jack@example.com"
+      fill_in "user[password]", with: "wca"
+      fill_in "user[password_confirmation]", with: "wca"
+      click_on "I have competed in a WCA competition."
+
+      # They have not selected a valid WCA ID yet, so don't show the birthdate verification
+      # field.
+      expect(page.find("div.user_dob_verification", visible: false).visible?).to eq false
+
+      selectize_input = page.find("div.user_unconfirmed_wca_id .selectize-control input")
+      selectize_input.native.send_key(person.wca_id)
+      # Wait for selectize popup to appear.
+      expect(page).to have_selector("div.selectize-dropdown", visible: true)
+      # Select item with selectize.
+      page.find("div.user_unconfirmed_wca_id input").native.send_key(:return)
+
+      # Wait for select delegate area to load via ajax.
+      expect(page.find("#select-nearby-delegate-area")).to have_content "In order to assign you your WCA ID"
+
+      # Now that they've selected a valid WCA ID, make sure the birthdate
+      # verification field is visible.
+      expect(page.find("div.user_dob_verification", visible: true).visible?).to eq true
+
+      delegate = person.competitions.first.delegates.first
+      choose("user_delegate_id_to_handle_wca_id_claim_#{delegate.id}")
+
+      fill_in "Birthdate", with: "1988-02-03"
+
+      click_button "Sign up"
+
+      u = User.find_by_email!("jack@example.com")
+      expect(u.name).to eq person.name
+      expect(u.gender).to eq person.gender
+      expect(u.country_iso2).to eq person.country_iso2
+
+      expect(u.unconfirmed_wca_id).to eq person.wca_id
+      expect(u.delegate_id_to_handle_wca_id_claim).to eq delegate.id
+
+      expect(WcaIdClaimMailer).to receive(:notify_delegate_of_wca_id_claim).with(u).and_call_original
+      expect do
+        visit "/users/confirmation?confirmation_token=#{u.confirmation_token}"
+      end.to change { ActionMailer::Base.deliveries.length }.by(1)
+    end
+
+    it "remembers that they have competed before on validation error" do
+      visit "/users/sign_up"
+      click_on "I have competed in a WCA competition."
+      click_button "Sign up"
+
+      expect(page).to have_selector('#have-competed', visible: true)
+    end
+  end
+
+  context 'when signing up as a first time competitor', js: true do
+    it 'can sign up' do
+      visit "/users/sign_up"
+
+      fill_in "Email", with: "jack@example.com"
+      fill_in "user[password]", with: "wca"
+      fill_in "user[password_confirmation]", with: "wca"
+
+      # Check that we disable the sign up button until the user selects
+      # "never competed".
+      expect(page).to have_selector('#unknown-competed', visible: true)
+      expect(page).to have_button("Sign up", disabled: true)
+      click_on "I have never competed in a WCA competition."
+      expect(page).to have_selector('#unknown-competed', visible: false)
+      expect(page).to have_button("Sign up")
+
+      fill_in "Full name", with: "Jack Johnson"
+      fill_in "Birthdate", with: "1975-05-18"
+      select "Male", from: "Gender"
+      select "USA", from: "Citizenship"
+
+      click_button "Sign up"
+
+      u = User.find_by_email!("jack@example.com")
+      expect(u.gender).to eq "m"
+    end
+
+    it "remembers that they have not competed before on validation error" do
+      visit "/users/sign_up"
+      click_on "I have never competed in a WCA competition."
+      click_button "Sign up"
+
+      expect(page).to have_selector('#never-competed', visible: true)
+    end
+  end
+end


### PR DESCRIPTION
(this fixes #389)

Optimize account creation, especially for people who have actually competed before.

On account sign up, we now ask if you've competed before:

![2016-03-04_23 48 19_1253x1033_kaladin](https://cloud.githubusercontent.com/assets/277474/13546465/b8b0ae2e-e263-11e5-881d-cc2e2b5d2c6e.png)

If you say you have competed before, we only
ask for your WCA ID, since we can figure out the rest of your
information from that. Note that this doesn't actually give you that WCA
ID, instead it sets up a WCA ID claim (but we don't bother notifying or
emailing your delegate until you've confirmed your email address).

![2016-03-05_18 41 01_1147x992_kaladin](https://cloud.githubusercontent.com/assets/277474/13551979/dce6091c-e301-11e5-9424-92f37907570f.png)

At this point, things proceed much the same as our claiming a WCA ID page (https://github.com/cubing/worldcubeassociation.org/pull/267). First, you must enter a valid WCA ID, and then select a delegate to verify your identity. You also must enter the correct birthdate in order to claim a WCA ID:

![2016-03-05_18 41 54_1143x1138_kaladin](https://cloud.githubusercontent.com/assets/277474/13551982/f5cb6d78-e301-11e5-9471-aa30ace1cf53.png)

After you pick a WCA ID and a delegate to approve your claim, then you can click "Sign up" to actually create your new account. Remember that at this point, your account is still not yet activated, so I decided it does not yet make sense to email their delegate or give their delegate a notifcation on our website.


Because you just created an account, you'll receive an email asking you to confirm your account:

![2016-03-05_18 43 05_1164x258_kaladin](https://cloud.githubusercontent.com/assets/277474/13551986/2576a678-e302-11e5-88c8-d7dbc4f7670e.png)

![2016-03-05_18 43 42_561x400_kaladin](https://cloud.githubusercontent.com/assets/277474/13551987/32dc9ea8-e302-11e5-8c62-74772d66e21a.png)


After you confirm your account, your delegate will be emailed with the details of the WCA ID you requested:

![2016-03-05_18 44 04_1166x507_kaladin](https://cloud.githubusercontent.com/assets/277474/13551989/414d46fe-e302-11e5-9238-a4251dae012c.png)

![2016-03-05_18 44 28_1144x311_kaladin](https://cloud.githubusercontent.com/assets/277474/13551994/4e04d59c-e302-11e5-8a20-8fe6093efd58.png)


If you have not competed before, there isn't much we can do... we just
ask you for your dob, gender, and citizenship:

![2016-03-04_23 48 41_922x1034_kaladin](https://cloud.githubusercontent.com/assets/277474/13546473/def644c2-e263-11e5-847a-d5182a28db63.png)