### PR TITLE
Registration table changes

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -49,7 +49,6 @@ gem 'lodash-rails'
 gem 'cocoon'
 gem 'momentjs-rails', '~> 2.9',  :github => 'derekprior/momentjs-rails'
 gem 'datetimepicker-rails', github: 'zpaulovics/datetimepicker-rails', branch: 'master', submodules: true
-gem 'table-for'
 gem 'blocks'
 gem 'rack-cors', require: 'rack/cors'
 

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -345,9 +345,6 @@ GEM
       activemodel (>= 3.0, < 5.0)
     system (0.1.3)
       version (~> 1.0.0)
-    table-for (3.4.0)
-      rails (>= 3.0.0)
-      with_template (~> 0.1.0)
     test_after_commit (0.4.1)
       activerecord (>= 3.2)
     therubyracer (0.12.2)
@@ -387,9 +384,6 @@ GEM
       coffee-rails
       kaminari (>= 0.13.0)
     will_paginate (3.0.7)
-    with_template (0.1.0)
-      blocks (~> 2.7.0)
-      rails (>= 3.0.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -451,7 +445,6 @@ DEPENDENCIES
   spring-commands-rspec
   strip_attributes
   system
-  table-for
   test_after_commit
   therubyracer
   time_will_tell

--- a/WcaOnRails/app/assets/javascripts/registrations.js
+++ b/WcaOnRails/app/assets/javascripts/registrations.js
@@ -3,7 +3,7 @@ $(function() {
     return;
   }
 
-  var $registrationsTable = $('table.registrations-table');
+  var $registrationsTable = $('table.registrations-table:not(.floatThead-table)');
   if($registrationsTable.length > 0) {
     var showHideActions = function(e) {
       var $selectedRows = $registrationsTable.find("tr.selected-row");

--- a/WcaOnRails/app/assets/javascripts/selectable-rows.js
+++ b/WcaOnRails/app/assets/javascripts/selectable-rows.js
@@ -1,7 +1,10 @@
 $(function() {
-  $("table.selectable-rows").each(function() {
+  $("table.selectable-rows:not(.floatThead-table)").each(function() {
     var $table = $(this);
-    var $th = $table.find("thead th:first-child");
+    $table.floatThead();
+
+    var $rowGroups = $table.floatThead("getRowGroups");
+    var $th = $rowGroups.find("th:first-child");
 
     var $checkboxes = $table.find(".select-row-checkbox");
     var $trs = $checkboxes.closest("tr");
@@ -20,7 +23,7 @@ $(function() {
       }
     }
     updateHeaderIcon();
-    $(this).on("change", "input.select-row-checkbox", function() {
+    $table.on("change", "input.select-row-checkbox", function() {
       var $tr = $(this).closest("tr");
       if(this.checked) {
         selectedCount++;

--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -10,56 +10,112 @@
         <h2>Approved registrations</h2>
       <% end %>
       <% registrations = @competition.registrations.send(status).order(created_at: :asc, id: :asc) %>
-      <%= wca_selectable_table_for registrations, extra_table_class: "registrations-table" do |table| %>
-        <% table.column :data => "Edit", link_url: lambda { |registration| edit_registration_path(registration) } %>
-
-        <% table.column :wca_id %>
-        <% table.column :name %>
-        <% table.column :countryId %>
-        <% table.column :birthday %>
-        <% @competition.events.each do |event| %>
-          <% table.column event.id.to_s %>
-        <% end %>
-
-        <% table.column :guests do |registration| %>
-          <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.guests %> <%= registration.guests_old %>">
-            <%= registration.guests %>
-            <% #https://github.com/cubing/worldcubeassociation.org/issues/403 %>
-            <%= registration.guests_old %>
-          </span>
-        <% end %>
-        <% table.column :comments do |registration| %>
-          <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.comments %>">
-            <%= registration.comments %>
-          </span>
-        <% end %>
-        <% table.column :data => "" do |registration| %>
-          <%= mail_to registration.email, target: "_blank", class: "hide-new-window-icon" do %>
-            <span class="glyphicon glyphicon-envelope"></span>
-          <% end %>
-        <% end %>
-
-        <% table.define :footer do %>
-          <tfoot>
-            <tr>
-              <td colspan="4">
-                <%= render "registration_info_people", registrations: registrations %>
-              </td>
-              <% country_count = registrations.map(&:countryId).uniq.length %>
-              <td><%= country_count %> <%= "country".pluralize(country_count) %></td>
-              <td></td>
-              <% @competition.events.each do |event| %>
-                <td><%= registrations.select { |r| r.events.include?(event) }.length %></td>
-              <% end %>
+      <%= wca_table table_class: "registrations-table selectable-rows" do %>
+        <thead>
+          <tr>
+            <th><span></span></th>
+            <th></th>
+            <th class="wca-id">WCA ID</th>
+            <th class="name">Name</th>
+            <th class="countryId">Citizen of</th>
+            <th class="birthday">Birthday</th>
+            <% @competition.events.each do |event| %>
               <td>
-                <% if @competition.guests_enabled? %>
-                  <%= registrations.map(&:guests).reduce { |sum, guests| sum + guests } %>
+                <span title="<%= event.name %>"
+                      class="cubing-icon icon-<%= event.id %>"
+                      data-toggle="tooltip"
+                      data-placement="bottom"
+                      data-container="body">
+                </span>
+              </td>
+            <% end %>
+
+            <th class="guests">Guests</th>
+            <th class="comments">Comments</th>
+            <th></th>
+
+            <!-- Extra column for .table-greedy-last-column -->
+            <th></th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <% registrations.each do |registration| %>
+            <tr class="<%= registration.pending? ? "registration-pending" : "" %> <%= registration.accepted? ? "registration-accepted" : "" %>">
+              <td>
+                <span>
+                  <input type="checkbox" name="registration-<%= registration.id %>" value="1" class="select-row-checkbox" />
+                </span>
+              </td>
+
+              <td>
+                <%= link_to "Edit", edit_registration_path(registration) %>
+              </td>
+
+              <td class="wca-id">
+                <% if registration.wca_id %>
+                  <%= render "shared/wca_id", wca_id: registration.wca_id %>
                 <% end %>
               </td>
-              <td colspan="3"></td>
+
+              <td class="name"><%= registration.name %></td>
+              <td class="countryId"><%= registration.countryId %></td>
+              <td class="birthday"><%= registration.birthday %></td>
+              <% @competition.events.each do |event| %>
+                <td>
+                  <% if registration.events.include?(event) %>
+                    <span title="<%= event.name %>"
+                          class="cubing-icon icon-<%= event.id %>"
+                          data-toggle="tooltip"
+                          data-placement="bottom"
+                          data-container="body">
+                    </span>
+                  <% end %>
+                </td>
+              <% end %>
+              <td class="guests">
+                <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.guests %> <%= registration.guests_old %>">
+                  <%= registration.guests %>
+                  <% #https://github.com/cubing/worldcubeassociation.org/issues/403 %>
+                  <%= registration.guests_old %>
+                </span>
+              </td>
+              <td class="comments">
+                <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.comments %>">
+                  <%= registration.comments %>
+                </span>
+              </td>
+              <td>
+                <%= mail_to registration.email, target: "_blank", class: "hide-new-window-icon" do %>
+                  <span class="glyphicon glyphicon-envelope"></span>
+                <% end %>
+              </td>
+
+              <!-- Extra column for .table-greedy-last-column -->
+              <td></td>
             </tr>
-          </tfoot>
-        <% end %>
+          <% end %>
+        </tbody>
+
+        <tfoot>
+          <tr>
+            <td colspan="4">
+              <%= render "registration_info_people", registrations: registrations %>
+            </td>
+            <% country_count = registrations.map(&:countryId).uniq.length %>
+            <td><%= country_count %> <%= "country".pluralize(country_count) %></td>
+            <td></td>
+            <% @competition.events.each do |event| %>
+              <td><%= registrations.select { |r| r.events.include?(event) }.length %></td>
+            <% end %>
+            <td>
+              <% if @competition.guests_enabled? %>
+                <%= registrations.map(&:guests).reduce { |sum, guests| sum + guests } %>
+              <% end %>
+            </td>
+            <td colspan="3"></td>
+          </tr>
+        </tfoot>
       <% end %>
     <% end %>
 


### PR DESCRIPTION
Fix for both #423 and $331. Moving away from table-for has a noticeable affect on performance.

Before:

```
~ @kaladin> time curl 'https://www.worldcubeassociation.org/competitions/Euro2016/edit/registrations' ...
...
</body>
</html>

real	0m6.940s
user	0m0.017s
sys	0m0.013s
```