### PR TITLE
Competitions index improvements

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -27,6 +27,7 @@ gem 'wice_grid'
 gem 'strip_attributes'
 gem 'time_will_tell'
 gem 'redcarpet', '~> 3.3'
+gem 'world-flags', git: 'git://github.com/world-flags/world-flags.git'
 
 # Pointing to jfly/carrierwave-crop which has a workaround for
 #  https://github.com/brianreavis/selectize.js/issues/953

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -21,6 +21,15 @@ GIT
     selectize-rails (0.12.1)
 
 GIT
+  remote: git://github.com/world-flags/world-flags.git
+  revision: b6ea11dbec91d1ec07cc6808215a05d182e67d65
+  specs:
+    world-flags (1.0.0)
+      hashie (>= 1.2)
+      i18n (>= 0.6)
+      sass-rails (>= 3.1.0)
+
+GIT
   remote: git://github.com/zpaulovics/datetimepicker-rails.git
   revision: 36d21cec5da7f5b214925804f60e63c61c747023
   branch: master
@@ -454,6 +463,7 @@ DEPENDENCIES
   web-console
   wice_grid
   will_paginate
+  world-flags!
 
 BUNDLED WITH
    1.11.2

--- a/WcaOnRails/app/assets/stylesheets/application.css.scss
+++ b/WcaOnRails/app/assets/stylesheets/application.css.scss
@@ -26,7 +26,8 @@
 @import "jquery.jcrop";
 @import "font-awesome-sprockets";
 @import "font-awesome";
-
+@import "flags/basic";
+@import "flags/flags16";
 
 @import "wca";
 @import "navbar-static-top";

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -195,6 +195,10 @@ $venue-map-wrapper-height: 400px;
   .date {
     float: right;
     font-weight: bold;
+    i {
+      float: left;
+      margin-right: 10px;
+    }
   }
 
   @media (min-width: $screen-sm) {

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -185,11 +185,11 @@ $venue-map-wrapper-height: 400px;
   li {
     padding: 5px 10px;
     font-size: 13px;
-  }
 
-  li.break {
-    text-align: center;
-    font-weight: bold;
+    &.break {
+      text-align: center;
+      font-weight: bold;
+    }
   }
 
   .date {

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -187,6 +187,11 @@ $venue-map-wrapper-height: 400px;
     font-size: 13px;
   }
 
+  li.break {
+    text-align: center;
+    font-weight: bold;
+  }
+
   .date {
     float: right;
     font-weight: bold;

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -201,6 +201,12 @@ $venue-map-wrapper-height: 400px;
     }
   }
 
+  .flag {
+    position: relative;
+    top: 3px;
+    margin-right: 5px;
+  }
+
   @media (min-width: $screen-sm) {
     .competition-link {
       display: inline-block;

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -49,8 +49,12 @@ class CompetitionsController < ApplicationController
     if params[:years] == "current"
       @competitions = @competitions.where("CAST(CONCAT(year,'-',month,'-',day) as Datetime) > ? AND year = ?",
                                           (Date.today - PAST_COMPETITIONS_DAYS), Date.today.year)
-    elsif params[:years] != "all"
+      @past_comps_title = "Competitions from the last #{CompetitionsController::PAST_COMPETITIONS_DAYS} days "
+    elsif params[:years] == "all"
+      @past_comps_title = "All past competitions"
+    else
       @competitions = @competitions.select { |competition| competition.year.to_s == params[:years] }
+      @past_comps_title = "Competitions from #{params[:years]}"
     end
 
     if params[:event] && params[:event] != "all"

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -47,7 +47,8 @@ class CompetitionsController < ApplicationController
     end
 
     if params[:years] == "current"
-      @competitions = @competitions.where("CAST(CONCAT(year,'-',month,'-',day) as Datetime) > ?", (Date.today - PAST_COMPETITIONS_DAYS))
+      @competitions = @competitions.where("CAST(CONCAT(year,'-',month,'-',day) as Datetime) > ? AND year = ?",
+                                          (Date.today - PAST_COMPETITIONS_DAYS), Date.today.year)
     elsif params[:years] != "all"
       @competitions = @competitions.select { |competition| competition.year.to_s == params[:years] }
     end

--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -5,7 +5,16 @@
       <li class="list-group-item break"><%= competition.year %></li>
     <% end %>
     <li class="list-group-item <%= competition.is_over? ? "past" : "not-past" %>">
-      <span class="date"><%= date_range(competition.start_date, competition.end_date, separator: '-', show_year: false) %>, <%= competition.year %></span>
+      <span class="date">
+        <% if competition.is_over? %>
+          <%= icon('hourglass-end') %>
+        <% elsif competition.in_progress? %>
+          <%= icon('hourglass-half') %>
+        <% else %>
+          <%= icon('hourglass-start') %>
+        <% end %>
+        <%= date_range(competition.start_date, competition.end_date, separator: '-', show_year: false) %>, <%= competition.year %>
+      </span>
       <span class="competition-info">
         <p class="competition-link"><%= link_to competition.name, competition_path(competition) %></p>
         <p class="location"><strong><%= competition.country.name %></strong>, <%= competition.cityName %></p>

--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -1,6 +1,9 @@
 <ul class="list-group">
   <li class="list-group-item"><strong><%= title %></strong></li>
   <% competitions.each_with_index do |competition, index| %>
+    <% if index > 0 && competition.year != competitions[index - 1].year %>
+      <li class="list-group-item break"><%= competition.year %></li>
+    <% end %>
     <li class="list-group-item <%= competition.is_over? ? "past" : "not-past" %>">
       <span class="date"><%= date_range(competition.start_date, competition.end_date, separator: '-', show_year: false) %>, <%= competition.year %></span>
       <span class="competition-info">

--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -16,7 +16,13 @@
         <%= date_range(competition.start_date, competition.end_date, separator: '-', show_year: false) %>, <%= competition.year %>
       </span>
       <span class="competition-info">
-        <p class="competition-link"><%= link_to competition.name, competition_path(competition) %></p>
+        <p class="competition-link">
+          <!-- The 'unless' is necessary to remove a default flag. Can be removed after resolving https://github.com/cubing/worldcubeassociation.org/issues/447 -->
+          <% unless competition.country.name.match(/Multiple Countries/) %>
+            <i class="flag f16 <%= competition.country.iso2.downcase %>"></i>
+          <% end %>
+          <%= link_to competition.name, competition_path(competition) %>
+        </p>
         <p class="location"><strong><%= competition.country.name %></strong>, <%= competition.cityName %></p>
         <div class="venue-link">
           <%=md(processLinks_to_markdown(competition.venue), target_blank: true) %>

--- a/WcaOnRails/app/views/competitions/index.html.erb
+++ b/WcaOnRails/app/views/competitions/index.html.erb
@@ -43,7 +43,7 @@
 
         <% if @past_competitions.length > 0 %>
           <div class="col-md-12" id="past">
-            <%= render 'index_table', competitions: @past_competitions, title: "Past competitions (last #{CompetitionsController::PAST_COMPETITIONS_DAYS} days)" %>
+            <%= render 'index_table', competitions: @past_competitions, title: @past_comps_title %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
This applies some changes to competitions index.
Changes marked in #438 and done:
- Little national flags before the competition name/link
- Have  blank line separating the years on the list
![image](https://cloud.githubusercontent.com/assets/17034772/14115247/822d5da4-f5da-11e5-9c68-4b7347860f3a.png)

- Change the captions for the past competitions table.

Other changes:
- Add hour-glass icon before competition's date, with different state for: passed, upcoming and in progress
![image](https://cloud.githubusercontent.com/assets/17034772/14115373/fe98e0fc-f5da-11e5-92d5-c2cb14a2d050.png)




- Fix displaying competitions in future years when current year is selected.