### PR TITLE
Bump TNoodle official version

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -22,12 +22,12 @@ class Api::V0::ApiController < ApplicationController
   def scramble_program
     render json: {
       "current" => {
-        "name" => "TNoodle-WCA-0.10.0",
+        "name" => "TNoodle-WCA-0.11.1",
         "information" => "#{root_url}regulations/scrambles/",
-        "download" => "#{root_url}regulations/scrambles/tnoodle/TNoodle-WCA-0.10.0.jar"
+        "download" => "#{root_url}regulations/scrambles/tnoodle/TNoodle-WCA-0.11.1.jar"
       },
       "allowed" => [
-        "TNoodle-WCA-0.10.0"
+        "TNoodle-WCA-0.11.1"
       ],
       "history" => [
         "TNoodle-0.7.4",       # 2013-01-01
@@ -39,7 +39,8 @@ class Api::V0::ApiController < ApplicationController
         "TNoodle-WCA-0.8.2",   # 2014-01-28
         "TNoodle-WCA-0.8.4",   # 2014-02-10
         "TNoodle-WCA-0.9.0",   # 2015-03-30
-        "TNoodle-WCA-0.10.0"   # 2015-06-30
+        "TNoodle-WCA-0.10.0",  # 2015-06-30
+        "TNoodle-WCA-0.11.1"   # 2016-04-04
       ]
     }
   end

--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -186,7 +186,7 @@ describe Api::V0::ApiController do
       get :scramble_program
       expect(response.status).to eq 200
       json = JSON.parse(response.body)
-      expect(json["current"]["name"]).to eq "TNoodle-WCA-0.10.0"
+      expect(json["current"]["name"]).to eq "TNoodle-WCA-0.11.1"
     end
   end
 

--- a/regulations/pages/scrambles.md
+++ b/regulations/pages/scrambles.md
@@ -1,12 +1,12 @@
 # WCA Scrambles
 
-The current official scramble program is *TNoodle-WCA-0.10.0*. It generates high-quality scramble sequences for all the events of a competition at once.
+The current official scramble program is *TNoodle-WCA-0.11.1*. It generates high-quality scramble sequences for all the events of a competition at once.
   
 <br>
 <center><span style="font-size: 200%; line-height: 150%; padding: 0.5em;">
-Download the official scramble program:<br><a href="tnoodle/TNoodle-WCA-0.10.0.jar" style="font-weight: bold;">TNoodle-WCA-0.10.0.jar</a><br></span>
+Download the official scramble program:<br><a href="tnoodle/TNoodle-WCA-0.11.1.jar" style="font-weight: bold;">TNoodle-WCA-0.11.1.jar</a><br></span>
 <br>
-Last official change: June 30, 2015
+Last official change: April 4, 2016
 </center>
 
 ## Important Notes for Delegates
@@ -19,7 +19,7 @@ Last official change: June 30, 2015
 
 TNoodle requires <a href="https://www.java.com/en/">Java</a> to be installed on your computer.
 
-1. Run the `TNoodle-WCA-0.10.0.jar` file on your computer.  
+1. Run the `TNoodle-WCA-0.11.1.jar` file on your computer.  
   It will open the page <http://localhost:2014/scramble> in your browser.
 2. Enter the details for your competition (competition name, number of rounds for each event, details for each round).  
   If you would like to password protect the file, enter a password.
@@ -51,4 +51,5 @@ Old versions must not be used without permission from the WCA Board. These are p
 - [TNoodle-WCA-0.8.2](tnoodle/old/TNoodle-WCA-0.8.2.jar) (2014-01-28)
 - [TNoodle-WCA-0.8.4](tnoodle/old/TNoodle-WCA-0.8.4.jar) (2014-02-10)
 - [TNoodle-WCA-0.9.0](tnoodle/old/TNoodle-WCA-0.9.0.jar) (2015-03-30)
-- [TNoodle-WCA-0.10.0](tnoodle/TNoodle-WCA-0.10.0.jar) (2015-06-30)
+- [TNoodle-WCA-0.10.0](tnoodle/old/TNoodle-WCA-0.10.0.jar) (2015-06-30)
+- [TNoodle-WCA-0.11.1](tnoodle/TNoodle-WCA-0.11.1.jar) (2016-04-04)


### PR DESCRIPTION
Next TNoodle official version is 0.11.1.

I checked what needed to be done [here](https://github.com/cubing/worldcubeassociation.org/blob/master/regulations/doc/scramble-program-release.md), I didn't do the "announcement" part. I think @Laura-O can do this directly from the website, right ?

Edit: oh and I assumed the jar file would be there in the production environment, please tell me if something else is needed about that.