### PR TITLE
Add handy helper for pages specific JavaScript

### DIFF
--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -284,3 +284,24 @@ $(function() {
     $('[data-toggle="tooltip"]').tooltip();
   });
 });
+
+// Helpers
+
+// Executes the given function on the specified page/pages.
+// The given string should have a format: '<controller>#<action>'.
+// The action name preceded by '#' is optional.
+// Could be followed by comma and another pair.
+// Example: 'users#show, users#edit, users#update, competitions'.
+function onPage(controllersWithActions, fun) {
+  controllersWithActions = controllersWithActions.replace(/\s/g, '');
+  controllersWithActions = controllersWithActions.split(',');
+  controllersWithActions = controllersWithActions.map(function(controllerWithAction) { return controllerWithAction.split('#'); });
+  $(function() {
+    if (controllersWithActions.some(function(controllerWithAction) {
+      return controllerWithAction[0] === document.body.dataset.railsControllerName &&
+            (controllerWithAction[1] ? document.body.dataset.railsControllerActionName === controllerWithAction[1] : true);
+    })) {
+      fun();
+    }
+  });
+}

--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -1,8 +1,4 @@
-$(function() {
-  if(document.body.dataset.railsControllerName !== "competitions") {
-    return;
-  }
-
+onPage('competitions', function() {
   var $competitionSelect = $('#competition_competition_id_to_clone');
   if($competitionSelect.length > 0) {
     var selectize = $competitionSelect[0].selectize;

--- a/WcaOnRails/app/assets/javascripts/registrations.js
+++ b/WcaOnRails/app/assets/javascripts/registrations.js
@@ -1,8 +1,4 @@
-$(function() {
-  if(document.body.dataset.railsControllerName !== "registrations") {
-    return;
-  }
-
+onPage('registrations', function() {
   var $registrationsTable = $('table.registrations-table:not(.floatThead-table)');
   if($registrationsTable.length > 0) {
     var showHideActions = function(e) {

--- a/WcaOnRails/app/assets/javascripts/users.js
+++ b/WcaOnRails/app/assets/javascripts/users.js
@@ -1,8 +1,4 @@
-$(function() {
-  if(document.body.dataset.railsControllerName !== "users") {
-    return;
-  }
-
+onPage('users', function() {
   // Hide/show senior delegate select based on what the user's role is.
   $('select[name="user[delegate_status]"]').on("change", function(e) {
     var delegateStatus = this.value;


### PR DESCRIPTION
Now adding JavaScript to a subset of pages is cleaner and more concise.
Examples:
- Actions
```javascript
onPage('users#index', function() {
  // Code for the index view action in users controller.
});
````
- Controllers
```javascript
onPage('competitions', function() {
  // Code for all views in competitions controller.
});
````
- Chaining
```javascript
onPage('competitions#index, users', function() {
  // Code for the index action view in competitions controller and all views in users controller.
});
````