### PR TITLE
Using cellName for the competitions index.

### DIFF
--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -21,7 +21,7 @@
           <% unless competition.country.name.match(/Multiple Countries/) %>
             <i class="flag f16 <%= competition.country.iso2.downcase %>"></i>
           <% end %>
-          <%= link_to competition.name, competition_path(competition) %>
+          <%= link_to competition.cellName, competition_path(competition) %>
         </p>
         <p class="location"><strong><%= competition.country.name %></strong>, <%= competition.cityName %></p>
         <div class="venue-link">


### PR DESCRIPTION
I just realised I made a mistake. We should use cellName (competition nickname) at the index. See https://github.com/cubing/worldcubeassociation.org/blob/master/webroot/results/competitions.php#L70