### PR TITLE
Change searching for selected events to be strict.

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -67,15 +67,7 @@ class CompetitionsController < ApplicationController
     end
 
     unless params[:event_ids].empty?
-      @competitions = @competitions.map do |competition|
-        [competition, competition.matching_event_ids_count(params[:event_ids])]
-      end.select do |competition_and_matching_event_count|
-        competition_and_matching_event_count[1] > 0
-      end.sort_by! do |competition_and_matching_event_count|
-        -competition_and_matching_event_count[1]
-      end.map! do |competition_and_matching_event_count|
-        competition_and_matching_event_count[0]
-      end
+      @competitions = @competitions.select { |competition| competition.has_events_with_ids?(params[:event_ids]) }
     end
 
     @past_competitions, @not_past_competitions = @competitions.partition(&:is_over?)

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -305,10 +305,10 @@ class Competition < ActiveRecord::Base
     eventSpecs.split.map { |e| Event.find_by_id(e.split("=")[0]) }.sort_by &:rank
   end
 
-  def matching_event_ids_count(event_ids)
+  def has_events_with_ids?(event_ids)
     # See https://github.com/cubing/worldcubeassociation.org/issues/95 for
     # what these equal signs are about.
-    (eventSpecs.split.map { |e| e.split("=")[0] } & event_ids).count
+    (event_ids - eventSpecs.split.map { |e| e.split("=")[0] }).empty?
   end
 
   def has_event?(event)

--- a/WcaOnRails/app/views/competitions/index.html.erb
+++ b/WcaOnRails/app/views/competitions/index.html.erb
@@ -24,8 +24,14 @@
     <%= render 'index_form' %>
   <% end %>
 
-  <% if @competitions.length == 0 %>
-    <div class="alert alert-warning">No competitions found.</div>
+  <% if @competitions.empty? %>
+    <div class="alert alert-warning">
+      <%= unless params[:event_ids].empty?
+        "We didn't find any competitions with those #{ pluralize(params[:event_ids].count, "event" )}! Try searching for fewer events."
+      else
+        "No competitions found."
+      end %>
+    </div>
   <% else %>
     <% if params[:display] == "List" %>
       <div class="row competition-list">

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -6,7 +6,7 @@ describe CompetitionsController do
   describe 'GET #index' do
     let!(:competition1) { FactoryGirl.create(:competition, starts: 1.week.from_now, eventSpecs: "222 333 444 555 666") }
     let!(:competition2) { FactoryGirl.create(:competition, starts: 2.week.from_now, eventSpecs: "333 444 555 pyram clock") }
-    let!(:competition3) { FactoryGirl.create(:competition, starts: 3.week.from_now, eventSpecs: "222 skewb 666 pyram sq1") }
+    let!(:competition3) { FactoryGirl.create(:competition, starts: 3.week.from_now, eventSpecs: "222 333 skewb 666 pyram sq1") }
     let!(:competition4) { FactoryGirl.create(:competition, starts: 4.week.from_now, eventSpecs: "333 pyram 666 777 clock") }
 
     describe "selecting events" do
@@ -18,25 +18,20 @@ describe CompetitionsController do
       end
 
       context "when events are selected" do
-        it "competitions are sorted by the count of matched events" do
-          get :index, event_ids: ["333", "444", "555", "666"]
-          expect(assigns(:competitions)).to eq [competition1, competition2, competition4, competition3]
-        end
-
-        it "competitions with the same count of matched events are still sorted by start date" do
+        it "only competitions matching all of the selected events are shown" do
           get :index, event_ids: ["333", "pyram", "clock"]
-          expect(assigns(:competitions)).to eq [competition4, competition2, competition3, competition1]
+          expect(assigns(:competitions)).to eq [competition4, competition2]
         end
 
-        it "competitions which doesn't have at least one of the selected events are filtered out" do
-          get :index, event_ids: ["777", "333fm", "333oh"]
-          expect(assigns(:competitions)).to eq [competition4]
+        it "competitions are still sorted by start date" do
+          get :index, event_ids: ["333"]
+          expect(assigns(:competitions)).to eq [competition4, competition3, competition2, competition1]
         end
 
         # See: https://github.com/cubing/worldcubeassociation.org/issues/472
         it "works when event_ids are passed as a hash instead of an array (facebook redirection)" do
           get :index, event_ids: { "0" => "333", "1" => "pyram", "2" => "clock" }
-          expect(assigns(:competitions)).to eq [competition4, competition2, competition3, competition1]
+          expect(assigns(:competitions)).to eq [competition4, competition2]
         end
       end
     end


### PR DESCRIPTION
Discussed in #471. We decided to abandon the idea with labels because it wasn't very clean.
Something like this:
![image](https://cloud.githubusercontent.com/assets/17034772/14358805/f09d48e2-fcee-11e5-82d9-33c0a1e5b995.png)


Now the searching is strict, so all the selected events must be matched be a competition.
Note: if user select a lot of events and there's no competition matching them, he can easily decide himself which of the events he doesn't need and uncheck it. Now we show a kind message suggesting that.
![image](https://cloud.githubusercontent.com/assets/17034772/14358832/1a0eaa36-fcef-11e5-8391-e50d130d688d.png)
