### PR TITLE
Api to query for competitions

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -17,8 +17,7 @@ gem 'mail_form'
 gem 'simple_form'
 gem 'valid_email'
 gem 'recaptcha', :require => 'recaptcha/rails'
-gem 'will_paginate'
-gem 'bootstrap-will_paginate'
+gem 'kaminari'
 gem 'local_time'
 gem 'devise'
 gem 'devise-bootstrap-views'
@@ -52,6 +51,7 @@ gem 'momentjs-rails', '~> 2.9',  :github => 'derekprior/momentjs-rails'
 gem 'datetimepicker-rails', github: 'zpaulovics/datetimepicker-rails', branch: 'master', submodules: true
 gem 'blocks'
 gem 'rack-cors', require: 'rack/cors'
+gem 'api-pagination'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-autosize'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.8)
     ansi (1.5.0)
+    api-pagination (4.3.0)
     arel (6.0.0)
     ast (2.1.0)
     autoprefixer-rails (5.2.1)
@@ -99,8 +100,6 @@ GEM
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
     bootstrap-table-rails (1.10.1)
-    bootstrap-will_paginate (0.0.10)
-      will_paginate
     builder (3.2.2)
     byebug (4.0.5)
       columnize (= 0.9.0)
@@ -201,6 +200,9 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    kaminari (0.16.3)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     kgio (2.9.3)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -389,7 +391,6 @@ GEM
     websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    will_paginate (3.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -397,12 +398,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  api-pagination
   better_errors
   binding_of_caller
   blocks
   bootstrap-sass
   bootstrap-table-rails
-  bootstrap-will_paginate
   byebug
   capybara
   capybara-screenshot
@@ -423,6 +424,7 @@ DEPENDENCIES
   high_voltage
   jbuilder
   jquery-rails
+  kaminari
   launchy
   local_time
   lodash-rails
@@ -460,7 +462,6 @@ DEPENDENCIES
   unicorn
   valid_email
   web-console
-  will_paginate
   world-flags!
 
 BUNDLED WITH

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -204,7 +204,7 @@ $venue-map-wrapper-height: 400px;
     }
   }
 
-  .flag {
+  .f16.flag {
     position: relative;
     top: -1px;
     margin-right: 5px;

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -206,7 +206,7 @@ $venue-map-wrapper-height: 400px;
 
   .flag {
     position: relative;
-    top: 3px;
+    top: -1px;
     margin-right: 5px;
   }
 

--- a/WcaOnRails/app/assets/stylesheets/wca.scss
+++ b/WcaOnRails/app/assets/stylesheets/wca.scss
@@ -224,8 +224,10 @@ table.wca-results {
 }
 
 
-// Set flag imitations for competitions taking place in multiple countries.
 .f16.flag {
+  vertical-align: middle;
+
+  // Set flag imitations for competitions taking place in multiple countries.
   &.xe,
   &.xa,
   &.xs {

--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -1,5 +1,9 @@
 class Api::V0::ApiController < ApplicationController
   before_filter :doorkeeper_authorize!, only: [:me]
+  rescue_from WcaExceptions::BadApiParameter, with: :bad_api_parameter
+  def bad_api_parameter(e)
+    render status: :unprocessable_entity, json: { errors: [ e.to_s ] }
+  end
 
   DEFAULT_API_RESULT_LIMIT = 20
 

--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -94,4 +94,10 @@ class Api::V0::ApiController < ApplicationController
     user = User.find_by_wca_id(params[:wca_id])
     show_user(user)
   end
+
+  def competitions
+    competitions = Competition.where(showAtAll: true).order(year: :desc, month: :desc, day: :desc)
+
+    paginate json: competitions
+  end
 end

--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -97,7 +97,8 @@ class Api::V0::ApiController < ApplicationController
   end
 
   def competitions
-    competitions = Competition.where(showAtAll: true).order(year: :desc, month: :desc, day: :desc)
+    params[:sort] ||= "-start_date"
+    competitions = Competition.search(params[:q], params: params)
     competitions = competitions.includes(:delegates).includes(:organizers)
 
     paginate json: competitions

--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -5,7 +5,8 @@ class Api::V0::ApiController < ApplicationController
 
   def me
     current_resource_owner = User.find(doorkeeper_token.resource_owner_id)
-    render json: { me: current_resource_owner.to_jsonable(doorkeeper_token: doorkeeper_token) }
+    current_resource_owner.doorkeeper_token = doorkeeper_token
+    render json: { me: current_resource_owner }
   end
 
   def auth_results
@@ -55,7 +56,7 @@ class Api::V0::ApiController < ApplicationController
       return
     end
     result = models.map { |model| model.search(query, params: params).limit(DEFAULT_API_RESULT_LIMIT) }.flatten(1)
-    render json: { status: "ok", result: result.map(&:to_jsonable) }
+    render status: :ok, json: { result: result }
   end
 
   def posts_search
@@ -79,9 +80,9 @@ class Api::V0::ApiController < ApplicationController
 
   def show_user(user)
     if user
-      render status: :ok, json: { status: "ok", user: user.to_jsonable }
+      render status: :ok, json: { user: user }
     else
-      render status: :not_found, json: { status: "ok", user: nil }
+      render status: :not_found, json: { user: nil }
     end
   end
 
@@ -97,6 +98,7 @@ class Api::V0::ApiController < ApplicationController
 
   def competitions
     competitions = Competition.where(showAtAll: true).order(year: :desc, month: :desc, day: :desc)
+    competitions = competitions.includes(:delegates).includes(:organizers)
 
     paginate json: competitions
   end

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -5,12 +5,6 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
       render json: { error: "Competition with id #{params[:id]} not found" }, status: 404
       return
     end
-    render json: {
-      status: "ok",
-      id: competition.id,
-      website: competition.website,
-      start_date: competition.start_date,
-      end_date: competition.end_date,
-    }
+    render json: competition
   end
 end

--- a/WcaOnRails/app/controllers/posts_controller.rb
+++ b/WcaOnRails/app/controllers/posts_controller.rb
@@ -3,11 +3,11 @@ class PostsController < ApplicationController
   before_action -> { redirect_unless_user(:can_create_posts?) }, except: [:index, :rss, :show]
 
   def index
-    @posts = Post.where(world_readable: true).order(sticky: :desc, created_at: :desc).includes(:author).paginate(page: params[:page])
+    @posts = Post.where(world_readable: true).order(sticky: :desc, created_at: :desc).includes(:author).page(params[:page])
   end
 
   def rss
-    @posts = Post.where(world_readable: true).order(created_at: :desc).includes(:author).paginate(page: params[:page])
+    @posts = Post.where(world_readable: true).order(created_at: :desc).includes(:author).page(params[:page])
 
     # Force responding with xml, regardless of the given HTTP_ACCEPT headers.
     request.format = :xml

--- a/WcaOnRails/app/controllers/search_results_controller.rb
+++ b/WcaOnRails/app/controllers/search_results_controller.rb
@@ -4,9 +4,9 @@ class SearchResultsController < ApplicationController
   def index
     @omni_query = params[:q]
     if @omni_query.present?
-      @competitions = Competition.search(@omni_query).paginate(page: params[:competitions_page], per_page: SEARCH_RESULT_LIMIT)
-      @persons = User.search(@omni_query, params: { persons_table: true }).paginate(page: params[:people_page], per_page: SEARCH_RESULT_LIMIT)
-      @posts = Post.search(@omni_query).paginate(page: params[:posts_page], per_page: SEARCH_RESULT_LIMIT)
+      @competitions = Competition.search(@omni_query).page(params[:competitions_page]).per(SEARCH_RESULT_LIMIT)
+      @persons = User.search(@omni_query, params: { persons_table: true }).page(params[:people_page]).per(SEARCH_RESULT_LIMIT)
+      @posts = Post.search(@omni_query).page(params[:posts_page]).per(SEARCH_RESULT_LIMIT)
     end
   end
 end

--- a/WcaOnRails/app/inputs/competition_id_input.rb
+++ b/WcaOnRails/app/inputs/competition_id_input.rb
@@ -6,7 +6,7 @@ class CompetitionIdInput < SimpleForm::Inputs::Base
       merged_input_options[:class] << "wca-autocomplete-only_one"
     end
     competitions = (@builder.object.send(attribute_name) || "").split(",").map { |id| Competition.find_by_id(id) }
-    merged_input_options[:data] = { data: competitions.map(&:to_jsonable).to_json }
+    merged_input_options[:data] = { data: competitions.to_json }
     @builder.text_field(attribute_name, merged_input_options)
   end
 end

--- a/WcaOnRails/app/inputs/user_ids_input.rb
+++ b/WcaOnRails/app/inputs/user_ids_input.rb
@@ -8,10 +8,10 @@ class UserIdsInput < SimpleForm::Inputs::Base
     if @options[:persons_table]
       merged_input_options[:class] << "wca-autocomplete-persons_table"
       persons = (@builder.object.send(attribute_name) || "").split(",").map { |wca_id| Person.find_by_id(wca_id) }
-      merged_input_options[:data] = { data: persons.map(&:to_jsonable).to_json }
+      merged_input_options[:data] = { data: persons.to_json }
     else
       users = (@builder.object.send(attribute_name).to_s || "").split(",").map { |id| User.find_by_id(id) }
-      merged_input_options[:data] = { data: users.map(&:to_jsonable).to_json }
+      merged_input_options[:data] = { data: users.to_json }
     end
     if @options[:only_one]
       merged_input_options[:class] << "wca-autocomplete-only_one"

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -470,18 +470,21 @@ class Competition < ActiveRecord::Base
     Competition.where("id LIKE :sql_query OR name LIKE :sql_query OR cellName LIKE :sql_query OR cityName LIKE :sql_query OR countryId LIKE :sql_query", sql_query: sql_query).order(year: :desc, month: :desc, day: :desc)
   end
 
-  def to_jsonable
+  def serializable_hash(options = nil)
     json = {
       class: self.class.to_s.downcase,
       url: "/results/c.php?i=#{id}",
 
       id: id,
       name: name,
+      website: website,
       cellName: cellName,
       cityName: cityName,
       countryId: countryId,
-      delegates: delegates.map(&:to_jsonable),
-      organizers: organizers.map(&:to_jsonable),
+      delegates: delegates,
+      organizers: organizers,
+      start_date: start_date,
+      end_date: end_date,
     }
     json
   end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -470,15 +470,26 @@ class Competition < ActiveRecord::Base
 
     if params[:country_iso2].present?
       country = Country.find_by_iso2(params[:country_iso2])
+      if !country
+        raise WcaExceptions::BadApiParameter, "Invalid country_iso2: #{params[:country_iso2]}"
+      end
       competitions = competitions.where(countryId: country.id)
     end
 
     if params[:start].present?
-      competitions = competitions.where("CAST(CONCAT(year,'-',month,'-',day) as Datetime) >= ?", params[:start])
+      start_date = Date.safe_parse(params[:start])
+      if !start_date
+        raise WcaExceptions::BadApiParameter, "Invalid start: #{params[:start]}"
+      end
+      competitions = competitions.where("CAST(CONCAT(year,'-',month,'-',day) as Datetime) >= ?", start_date)
     end
 
     if params[:end].present?
-      competitions = competitions.where("CAST(CONCAT(year,'-',endMonth,'-',endDay) as Datetime) <= ?", params[:end])
+      end_date = Date.safe_parse(params[:end])
+      if !end_date
+        raise WcaExceptions::BadApiParameter, "Invalid end: #{params[:end]}"
+      end
+      competitions = competitions.where("CAST(CONCAT(year,'-',endMonth,'-',endDay) as Datetime) <= ?", end_date)
     end
 
     if query.present?

--- a/WcaOnRails/app/models/person.rb
+++ b/WcaOnRails/app/models/person.rb
@@ -56,7 +56,7 @@ class Person < ActiveRecord::Base
     SolveTime.new(event.id, type, rank ? rank.best : 0)
   end
 
-  def to_jsonable(include_private_info: false)
+  def serializable_hash(options = nil)
     json = {
       class: self.class.to_s.downcase,
       url: "/results/p.php?i=#{self.wca_id}",
@@ -69,13 +69,9 @@ class Person < ActiveRecord::Base
       country_iso2: self.country_iso2,
     }
 
-    if include_private_info
-      json[:dob] = person.dob
-    end
-
     # If there's a user for this Person, merge in all their data,
     # the Person's data takes priority, though.
-    json = (user || User.new).to_jsonable.merge(json)
+    json = (user || User.new).serializable_hash.merge(json)
 
     json
   end

--- a/WcaOnRails/app/models/person.rb
+++ b/WcaOnRails/app/models/person.rb
@@ -71,8 +71,6 @@ class Person < ActiveRecord::Base
 
     # If there's a user for this Person, merge in all their data,
     # the Person's data takes priority, though.
-    json = (user || User.new).serializable_hash.merge(json)
-
-    json
+    (user || User.new).serializable_hash.merge(json)
   end
 end

--- a/WcaOnRails/app/models/post.rb
+++ b/WcaOnRails/app/models/post.rb
@@ -43,7 +43,7 @@ class Post < ActiveRecord::Base
     Post.where("world_readable = 1 AND (title LIKE :sql_query OR body LIKE :sql_query)", sql_query: sql_query).order(created_at: :desc)
   end
 
-  def to_jsonable
+  def serializable_hash(options = nil)
     json = {
       class: self.class.to_s.downcase,
 
@@ -51,7 +51,7 @@ class Post < ActiveRecord::Base
       title: title,
       body: body,
       slug: slug,
-      author: author ? author.to_jsonable : nil,
+      author: author,
     }
 
     json

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -504,7 +504,8 @@ class User < ActiveRecord::Base
     users
   end
 
-  def to_jsonable(doorkeeper_token: nil)
+  attr_accessor :doorkeeper_token
+  def serializable_hash(options = nil)
     json = {
       class: self.class.to_s.downcase,
       url: "/results/p.php?i=#{self.wca_id}",

--- a/WcaOnRails/app/views/kaminari/_first_page.html.erb
+++ b/WcaOnRails/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote %>
+</li>

--- a/WcaOnRails/app/views/kaminari/_gap.html.erb
+++ b/WcaOnRails/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='disabled'>
+  <%= content_tag :a, raw(t 'views.pagination.truncate') %>
+</li>

--- a/WcaOnRails/app/views/kaminari/_last_page.html.erb
+++ b/WcaOnRails/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote} %>
+</li>

--- a/WcaOnRails/app/views/kaminari/_next_page.html.erb
+++ b/WcaOnRails/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote %>
+</li>

--- a/WcaOnRails/app/views/kaminari/_page.html.erb
+++ b/WcaOnRails/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class='active'>
+    <%= content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)) %>
+  </li>
+<% else %>
+  <li>
+    <%= link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)) %>
+  </li>
+<% end %>

--- a/WcaOnRails/app/views/kaminari/_paginator.html.erb
+++ b/WcaOnRails/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do -%>
+  <div class="pagination">
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| -%>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end -%>
+      <% end -%>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </div>
+<% end -%>

--- a/WcaOnRails/app/views/kaminari/_prev_page.html.erb
+++ b/WcaOnRails/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote %>
+</li>

--- a/WcaOnRails/app/views/posts/index.html.erb
+++ b/WcaOnRails/app/views/posts/index.html.erb
@@ -1,4 +1,4 @@
 <div class="container">
   <%= render @posts, render_permalink: true %>
-  <%= will_paginate @posts %>
+  <%= paginate @posts %>
 </div>

--- a/WcaOnRails/app/views/search_results/index.html.erb
+++ b/WcaOnRails/app/views/search_results/index.html.erb
@@ -28,7 +28,7 @@
           <% end %>
         </tbody>
       </table>
-      <%= will_paginate @competitions, param_name: 'competitions_page', params: { anchor: "competitions" } %>
+      <%= paginate @competitions, param_name: :competitions_page, params: { anchor: "competitions" } %>
     <% end %>
 
     <% if !@persons.empty? %>
@@ -55,7 +55,7 @@
           <% end %>
         </tbody>
       </table>
-      <%= will_paginate @persons, param_name: 'people_page', params: { anchor: "people" } %>
+      <%= paginate @persons, param_name: :people_page, params: { anchor: "people" } %>
     <% end %>
 
     <% if !@posts.empty? %>
@@ -70,7 +70,7 @@
           </blockquote>
         </div>
       <% end %>
-      <%= will_paginate @posts, param_name: 'posts_page', params: { anchor: "posts" } %>
+      <%= paginate @posts, param_name: :posts_page, params: { anchor: "posts" } %>
     <% end %>
 
     <% if @competitions.empty? %>

--- a/WcaOnRails/app/views/users/_select_nearby_delegate.html.erb
+++ b/WcaOnRails/app/views/users/_select_nearby_delegate.html.erb
@@ -52,7 +52,7 @@
         <% value = "" %>
         <% if chose_extra_delegate %>
           <% delegate = @user.delegate_to_handle_wca_id_claim %>
-          <% input_data[:data] = [delegate.to_jsonable].to_json %>
+          <% input_data[:data] = [delegate].to_json %>
           <% value = @user.delegate_to_handle_wca_id_claim.id %>
         <% end %>
         <%= text_field_tag "", value,

--- a/WcaOnRails/config/application.rb
+++ b/WcaOnRails/config/application.rb
@@ -50,6 +50,7 @@ module WcaOnRails
         resource '/api/*',
           headers: ['Origin', 'X-Requested-With', 'Content-Type', 'Accept', 'Authorization'],
           methods: [:get, :post, :delete, :put, :patch, :options, :head],
+          expose: ['Total', 'Per-Page', 'Link'],
           max_age: 0,
           credentials: false
       end

--- a/WcaOnRails/config/application.rb
+++ b/WcaOnRails/config/application.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 require_relative '../lib/middlewares/fix_accept_header'
 require_relative '../lib/middlewares/warden_user_logger'
+require_relative '../lib/wca_exceptions'
 
 require 'rails/all'
 

--- a/WcaOnRails/config/application.rb
+++ b/WcaOnRails/config/application.rb
@@ -4,6 +4,8 @@ require_relative '../lib/middlewares/warden_user_logger'
 
 require 'rails/all'
 
+require_relative '../lib/monkeypatch_json_renderer_to_pretty_print'
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/WcaOnRails/config/initializers/kaminari_config.rb
+++ b/WcaOnRails/config/initializers/kaminari_config.rb
@@ -1,0 +1,10 @@
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  config.left = 8
+  config.right = 3
+  # config.page_method_name = :page
+  # config.param_name = :page
+end

--- a/WcaOnRails/config/initializers/monkey_patches.rb
+++ b/WcaOnRails/config/initializers/monkey_patches.rb
@@ -5,7 +5,7 @@ Rails.configuration.to_prepare do
   # http://stackoverflow.com/a/21034652/1739415
   Date.class_eval do
     def self.safe_parse(value, default = nil)
-      Date.parse(value.to_s)
+      Date.strptime(value.to_s, '%Y-%m-%d')
     rescue ArgumentError
       default
     end

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -102,6 +102,7 @@ Rails.application.routes.draw do
       get '/search/users' => 'api#users_search'
       get '/users/:id' => 'api#show_user_by_id', constraints: { id: /\d+/ }
       get '/users/:wca_id' => 'api#show_user_by_wca_id'
+      get '/competitions' => 'api#competitions'
       resources :competitions, only: [:show]
     end
   end

--- a/WcaOnRails/db/seeds/development/posts.seeds.rb
+++ b/WcaOnRails/db/seeds/development/posts.seeds.rb
@@ -1,6 +1,6 @@
 after "development:users" do
   results_team_users = Team.find_by_friendly_id('software').team_members.map(&:user)
-  20.times do
+  100.times do
     sticky = (rand(25) == 0)
     title = Faker::Hacker.say_something_smart
     post = Post.create!(

--- a/WcaOnRails/lib/monkeypatch_json_renderer_to_pretty_print.rb
+++ b/WcaOnRails/lib/monkeypatch_json_renderer_to_pretty_print.rb
@@ -1,0 +1,8 @@
+# Monkeypatch ActiveSupport's JSON encoder to prettyprint JSON.
+module ActiveSupport::JSON::Encoding
+  class JSONGemEncoder
+    def stringify(jsonified)
+      JSON.pretty_generate(jsonified)
+    end
+  end
+end

--- a/WcaOnRails/lib/wca_exceptions.rb
+++ b/WcaOnRails/lib/wca_exceptions.rb
@@ -1,0 +1,3 @@
+module WcaExceptions
+  class BadApiParameter < StandardError; end
+end

--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -247,21 +247,28 @@ describe Api::V0::ApiController do
       get :competitions, start: "2015"
       expect(response.status).to eq 422
       json = JSON.parse(response.body)
-      expect(json["errors"]).to eq ["Invalid start: 2015"]
+      expect(json["errors"]).to eq ["Invalid start: '2015'"]
     end
 
     it 'validates end' do
       get :competitions, end: "2014"
       expect(response.status).to eq 422
       json = JSON.parse(response.body)
-      expect(json["errors"]).to eq ["Invalid end: 2014"]
+      expect(json["errors"]).to eq ["Invalid end: '2014'"]
     end
 
     it 'validates country_iso2' do
       get :competitions, country_iso2: "this is not a country"
       expect(response.status).to eq 422
       json = JSON.parse(response.body)
-      expect(json["errors"]).to eq ["Invalid country_iso2: this is not a country"]
+      expect(json["errors"]).to eq ["Invalid country_iso2: 'this is not a country'"]
+    end
+
+    it 'validates sort' do
+      get :competitions, sort: "foo"
+      expect(response.status).to eq 422
+      json = JSON.parse(response.body)
+      expect(json["errors"]).to eq ["Unrecognized sort field: 'foo'"]
     end
 
     it 'can query by date' do

--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -243,6 +243,27 @@ describe Api::V0::ApiController do
       expect(json[0]["id"]).to eq terrible_comp.id
     end
 
+    it 'validates start' do
+      get :competitions, start: "2015"
+      expect(response.status).to eq 422
+      json = JSON.parse(response.body)
+      expect(json["errors"]).to eq ["Invalid start: 2015"]
+    end
+
+    it 'validates end' do
+      get :competitions, end: "2014"
+      expect(response.status).to eq 422
+      json = JSON.parse(response.body)
+      expect(json["errors"]).to eq ["Invalid end: 2014"]
+    end
+
+    it 'validates country_iso2' do
+      get :competitions, country_iso2: "this is not a country"
+      expect(response.status).to eq 422
+      json = JSON.parse(response.body)
+      expect(json["errors"]).to eq ["Invalid country_iso2: this is not a country"]
+    end
+
     it 'can query by date' do
       last_feb_comp = FactoryGirl.create(:competition, starts: Date.new(2015, 2, 1))
       feb_comp = FactoryGirl.create(:competition, starts: Date.new(2016, 2, 1))

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -161,12 +161,11 @@ describe CompetitionsController do
         expect(flash[:success]).to eq "Successfully cloned #{competition.id}!"
         new_comp = assigns(:competition)
         expect(new_comp.id).to eq "Test2015"
-
-        new_comp_json = new_comp.as_json
+        expect(new_comp.name).to eq "Test 2015"
         # When cloning a competition, we don't want to clone its showAtAll and isConfirmed
         # attributes.
-        competition_json = competition.as_json.merge("id" => "Test2015", "name" => "Test 2015", "cellName" => "Test 2015", "showAtAll" => false, "isConfirmed" => false)
-        expect(new_comp_json).to eq competition_json
+        expect(new_comp.showAtAll).to eq false
+        expect(new_comp.isConfirmed).to eq false
 
         # Cloning a competition should clone its organizers.
         expect(new_comp.organizers.sort_by(&:id)).to eq competition.organizers.sort_by(&:id)

--- a/WcaOnRails/vendor/assets/javascripts/jquery.wca-autocomplete.js
+++ b/WcaOnRails/vendor/assets/javascripts/jquery.wca-autocomplete.js
@@ -59,11 +59,11 @@
           },
 
           competition: function(competition) {
-            var $div = $('<div class="wca-autocomplete-competition"><span class="name"></span><span class="cityName"></span>, <span class="countryId"></span> (<span class="id"></span>)</div>');
+            var $div = $('<div class="wca-autocomplete-competition"><span class="name"></span><i class="flag f16"></i> <span class="city"></span> (<span class="id"></span>)</div>');
             $div.find(".id").text(competition.id);
             $div.find(".name").text(competition.name);
-            $div.find(".cityName").text(competition.cityName);
-            $div.find(".countryId").text(competition.countryId);
+            $div.find(".city").text(competition.city);
+            $div.find(".flag").addClass(competition.country_iso2.toLowerCase());
             return $div[0].outerHTML;
           },
 


### PR DESCRIPTION
I decided to keep it simple. <http://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api> convinced me to use the HTTP Link specification for pagination, and to pretty print our JSON by default.

We're using the <https://github.com/davidcelis/api-pagination> gem to handle pagination.

I created a silly monkeyhack to pretty print JSON.

See the updated api_controller_spec.rb for "documentation", or try out the following queries on staging:

https://staging.worldcubeassociation.org/api/v0/competitions?country_iso2=FR&sort=-start_date
https://staging.worldcubeassociation.org/api/v0/competitions?country_iso2=FR&sort=start_date
https://staging.worldcubeassociation.org/api/v0/competitions?q=nationals&country_iso2=US

error checking:

https://staging.worldcubeassociation.org/api/v0/competitions?country_iso2=FR&sort=-start_dated
https://staging.worldcubeassociation.org/api/v0/competitions?country_iso2=FRa
https://staging.worldcubeassociation.org/api/v0/competitions?start=2015

@viroulep, could you take a quick look at this and let me know what you think?