### PR TITLE
Competitions index - lightweight changes

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -152,9 +152,7 @@ $venue-map-wrapper-height: 400px;
 }
 
 .competition-select.form-inline {
-  background-color: #fff;
   width: 100%;
-  padding-bottom: 10px;
   position: relative;
   top: 5px;
 
@@ -169,8 +167,11 @@ $venue-map-wrapper-height: 400px;
     width: 100px;
   }
 
-  .btn-group {
+  #submit-buttons {
     display: block;
+    width: 100%;
+    margin-top: 20px;
+    text-align: center;
   }
 }
 
@@ -298,7 +299,7 @@ $comp-list-nav-height: 39px;
 }
 
 #comp-query-form {
-  margin-bottom: 15px;
+  margin: 20px 0;
 }
 
 .competition-info {

--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -31,15 +31,12 @@
   <%= text_field_tag "search", params[:search], class: "form-control" %>
 </div>
 
-<div class="form-group">
-  <label>&nbsp;</label>
-  <div class="btn-group">
-    <%= button_tag(type: 'submit', name: "display", value: "List", class: "btn btn-info") do %>
-      <i class="glyphicon glyphicon-list"></i> List
-    <% end %>
+<div id="submit-buttons" class="form-group">
+  <%= button_tag(type: 'submit', name: "display", value: "List", class: "btn btn-info") do %>
+    <i class="glyphicon glyphicon-list"></i> List
+  <% end %>
 
-    <%= button_tag(type: 'submit', name: "display", value: "Map", class: "btn btn-primary") do %>
-      <i class="glyphicon glyphicon-map-marker"></i> Map
-    <% end %>
-  </div>
+  <%= button_tag(type: 'submit', name: "display", value: "Map", class: "btn btn-primary") do %>
+    <i class="glyphicon glyphicon-map-marker"></i> Map
+  <% end %>
 </div>

--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -1,5 +1,5 @@
 <ul class="list-group">
-  <li class="list-group-item"><strong><%= title %></strong></li>
+  <li class="list-group-item"><strong><%= "#{title} (#{competitions.count})" %></strong></li>
   <% competitions.each_with_index do |competition, index| %>
     <% if index > 0 && competition.year != competitions[index - 1].year && params[:event_ids].empty? %>
       <li class="list-group-item break"><%= competition.year %></li>


### PR DESCRIPTION
This is a lightweight part of improvements from #490, as noted [here](https://github.com/cubing/worldcubeassociation.org/pull/490#issuecomment-208032451).
Changes:
- show the number of competitions found, in the list description in parentheses
- improve appearance of the competitions searching form