### PR TITLE
Better message with unconfirmed email with claimed wca

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -316,7 +316,7 @@ class User < ActiveRecord::Base
   end
 
   def can_edit_users?
-    admin? || board_member? || any_kind_of_delegate?
+    admin? || board_member? || results_team? || any_kind_of_delegate?
   end
 
   def can_admin_results?

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -5,19 +5,31 @@
   <%= simple_form_for @user, html: { multipart: true, class: 'are-you-sure' } do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
 
-    <% if @user.unconfirmed_wca_id.present? %>
-      <div class="alert alert-warning">
-        This account is waiting for
-        <%= mail_to @user.delegate_to_handle_wca_id_claim.email, @user.delegate_to_handle_wca_id_claim.name, target: "_blank" %>
-        to confirm their claimed WCA ID
-        <%= render "shared/wca_id", wca_id: @user.unconfirmed_wca_id %>.
-      </div>
-    <% end %>
-    <% unless @user.confirmed_at %>
+    <% if !@user.confirmed_at %>
       <div class="alert alert-warning">
         This account's email address (<%= @user.email %>) is not confirmed.
       </div>
+      <% if @user.unconfirmed_wca_id.present? %>
+        <div class="alert alert-warning">
+          This user has claimed WCA ID
+          <%= render "shared/wca_id", wca_id: @user.unconfirmed_wca_id %>.
+          Their delegate
+          <%= mail_to @user.delegate_to_handle_wca_id_claim.email, @user.delegate_to_handle_wca_id_claim.name, target: "_blank" %>
+          will be notified of this request as soon as this account's email address
+          is confirmed.
+        </div>
+      <% end %>
+    <% else %>
+      <% if @user.unconfirmed_wca_id.present? %>
+        <div class="alert alert-warning">
+          This account is waiting for
+          <%= mail_to @user.delegate_to_handle_wca_id_claim.email, @user.delegate_to_handle_wca_id_claim.name, target: "_blank" %>
+          to confirm their claimed WCA ID
+          <%= render "shared/wca_id", wca_id: @user.unconfirmed_wca_id %>.
+        </div>
+      <% end %>
     <% end %>
+
     <% if @user.unconfirmed_email %>
       <div class="alert alert-warning">
         This account is pending confirmation of new email address <%= @user.unconfirmed_email %>.


### PR DESCRIPTION
# Before

![image](https://cloud.githubusercontent.com/assets/277474/14468763/095cec5c-0096-11e6-84b9-7226c35af627.png)

# After

![image](https://cloud.githubusercontent.com/assets/277474/14468734/ea7e6b12-0095-11e6-925b-305e3479a744.png)

Roman Ostapenko was confused by this for a full moment or two.

Also discovered a bug: the Results Team didn't have access to the /users page! That's totally silly, as we give them access to phpMyAdmin. @SAuroux, can you notify any members of the results team who weren't already delegates that they now have access to the /users page?

