### PR TITLE
Fix race condition in sign_up_spec.rb

### DIFF
--- a/WcaOnRails/spec/features/sign_up_spec.rb
+++ b/WcaOnRails/spec/features/sign_up_spec.rb
@@ -105,6 +105,8 @@ RSpec.feature "Sign up" do
 
       click_button "Sign up"
 
+      expect(page).to have_content "A message with a confirmation link has been sent to your email address."
+
       u = User.find_by_email!("jack@example.com")
       expect(u.gender).to eq "m"
     end


### PR DESCRIPTION
When using the JS driver of Capybara the web server runs in a different
process than the specs, so writing expectations against the DB might
fail if the web server is not fast enough. Using an explicit

    expect(page).to have_content

forces Capybara to wait until the web server finished processing the
request.

This fixes #475.