### PR TITLE
Specify actions in JavaScript files rather than controllers only

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -1,4 +1,4 @@
-onPage('competitions', function() {
+onPage('competitions#new', function() {
   var $competitionSelect = $('#competition_competition_id_to_clone');
   if($competitionSelect.length > 0) {
     var selectize = $competitionSelect[0].selectize;
@@ -17,7 +17,9 @@ onPage('competitions', function() {
     selectize.on("change", competitionChanged);
     selectize.$control_input.on("input", competitionChanged);
   }
+});
 
+onPage('competitions#edit', function() {
   var $useWcaRegistrationInput = $('input[name="competition[use_wca_registration]"]');
   if($useWcaRegistrationInput.length > 0) {
     var $registrationOptionsAreas = $('.wca-registration-options');
@@ -25,7 +27,9 @@ onPage('competitions', function() {
       $registrationOptionsAreas.toggle(this.checked);
     }).trigger("change");
   }
+});
 
+onPage('competitions#index', function() {
   $('#clear-all-events').on('click', function() {
     $('#events input[type="checkbox"]').prop('checked', false);
   });

--- a/WcaOnRails/app/assets/javascripts/notifications.js
+++ b/WcaOnRails/app/assets/javascripts/notifications.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/WcaOnRails/app/assets/javascripts/registrations.js
+++ b/WcaOnRails/app/assets/javascripts/registrations.js
@@ -1,4 +1,4 @@
-onPage('registrations', function() {
+onPage('registrations#edit_registrations', function() {
   var $registrationsTable = $('table.registrations-table:not(.floatThead-table)');
   if($registrationsTable.length > 0) {
     var showHideActions = function(e) {

--- a/WcaOnRails/app/assets/javascripts/users.js
+++ b/WcaOnRails/app/assets/javascripts/users.js
@@ -1,4 +1,4 @@
-onPage('users', function() {
+onPage('users#edit', function() {
   // Hide/show senior delegate select based on what the user's role is.
   $('select[name="user[delegate_status]"]').on("change", function(e) {
     var delegateStatus = this.value;
@@ -39,7 +39,9 @@ onPage('users', function() {
     $unconfirmed_wca_id_profile_link.attr('href', "/results/p.php?i=" + unconfirmed_wca_id);
   });
   $unconfirmed_wca_id.trigger('input');
+});
 
+onPage('users#index', function() {
   // Change bootstrap-table pagination description
   var $table = $('.bootstrap-table');
   var options = $table.bootstrapTable('getOptions');


### PR DESCRIPTION
At the moment all the JS files that use the 'on ready' helper that I've added recently (#465) check only whether the controller is correct. I definitely suggest to add the actions too. It's not only about avoid running JS on non related pages in the same controller, but about readability. When we open JS file we should immediately know which part is related to which page. So we would probably have multiple 'on ready' per one file, but that would be certainly more convenient. Like so:
```javascript
onPage('users#index', function() {
// some code here
}

onPage('users#edit', function() {
// another code here
}
```

So I really want to ask you to use the helper for pages specific JS as described in #465.

This PR adds the appropriate actions to the specified controllers in all the necessary places in JavaScript files which we have so far.