### PR TITLE
Fix permanent loading of the competitions index when using Safari.

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -96,8 +96,14 @@ onPage('competitions#index', function() {
     }
   });
 
-  // Reaload the page when back/forward is clicked.
-  $(window).on('popstate', function() {
-    location.reload();
+  // Necessary hack because Safari fires a popstate event on document load
+  $(window).load(function() {
+    setTimeout(function() {
+      // When back/forward is clicked the url changes since we use pushState,
+      // but the content is not reloaded so we have to do this manually.
+      $(window).on('popstate', function() {
+        location.reload();
+      });
+    }, 0);
   });
 });


### PR DESCRIPTION
Fixes [this](https://www.speedsolving.com/forum/threads/possible-worldcubeassociation-org-bug.60635/).