### PR TITLE
Teams improvements

### DIFF
--- a/WcaOnRails/app/controllers/application_controller.rb
+++ b/WcaOnRails/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
 
   private def redirect_unless_user(action, *args)
     unless current_user && current_user.send(action, *args)
-      flash[:danger] = "You are not allowed to #{action.to_s.humanize.downcase.gsub('can', '').chomp('?')}"
+      flash[:danger] = "You are not allowed to #{action.to_s.sub(/^can_/, '').chomp('?').humanize.downcase}"
       redirect_to root_url
     end
   end

--- a/WcaOnRails/app/controllers/application_controller.rb
+++ b/WcaOnRails/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
 
   private def redirect_unless_user(action, *args)
     unless current_user && current_user.send(action, *args)
-      flash[:danger] = "You are not allowed to #{action}"
+      flash[:danger] = "You are not allowed to #{action.to_s.humanize.downcase.gsub('can', '').chomp('?')}"
       redirect_to root_url
     end
   end

--- a/WcaOnRails/app/controllers/teams_controller.rb
+++ b/WcaOnRails/app/controllers/teams_controller.rb
@@ -1,8 +1,7 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action -> { redirect_unless_user(:can_manage_teams?) }, except: [:edit, :update]
-  before_action :assign_team, only: [:edit, :update]
-  before_action -> { redirect_unless_user(:can_edit_team?, @team) }, only: [:edit, :update]
+  before_action -> { redirect_unless_user(:can_edit_team?, team_from_params) }, only: [:edit, :update]
 
   def index
     @teams = Team.all
@@ -24,9 +23,11 @@ class TeamsController < ApplicationController
   end
 
   def edit
+    @team = team_from_params
   end
 
   def update
+    @team = team_from_params
     if @team.update_attributes(team_params)
       flash[:success] = "Updated team"
       redirect_to edit_team_path(@team)
@@ -46,7 +47,7 @@ class TeamsController < ApplicationController
     return team_params
   end
 
-  private def assign_team
-    @team = Team.find(params[:id])
+  private def team_from_params
+    Team.find(params[:id])
   end
 end

--- a/WcaOnRails/app/controllers/teams_controller.rb
+++ b/WcaOnRails/app/controllers/teams_controller.rb
@@ -1,6 +1,8 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
-  before_action -> { redirect_unless_user(:can_edit_teams?) }
+  before_action -> { redirect_unless_user(:can_manage_teams?) }, except: [:edit, :update]
+  before_action :assign_team, only: [:edit, :update]
+  before_action -> { redirect_unless_user(:can_edit_team?, @team) }, only: [:edit, :update]
 
   def index
     @teams = Team.all
@@ -22,11 +24,9 @@ class TeamsController < ApplicationController
   end
 
   def edit
-    @team = Team.find(params[:id])
   end
 
   def update
-    @team = Team.find(params[:id])
     if @team.update_attributes(team_params)
       flash[:success] = "Updated team"
       redirect_to edit_team_path(@team)
@@ -36,7 +36,7 @@ class TeamsController < ApplicationController
     end
   end
 
-  def team_params
+  private def team_params
     team_params = params.require(:team).permit(:name, :description, :friendly_id, team_members_attributes: [:id, :team_id, :user_id, :start_date, :end_date, :team_leader, :_destroy])
     if team_params[:team_members_attributes]
       team_params[:team_members_attributes].each do |member|
@@ -44,5 +44,9 @@ class TeamsController < ApplicationController
       end
     end
     return team_params
+  end
+
+  private def assign_team
+    @team = Team.find(params[:id])
   end
 end

--- a/WcaOnRails/app/models/team.rb
+++ b/WcaOnRails/app/models/team.rb
@@ -6,12 +6,13 @@ class Team < ActiveRecord::Base
   validate :membership_periods_cannot_overlap_for_single_user
   def membership_periods_cannot_overlap_for_single_user
     team_members.group_by(&:user).each do |user, memberships|
-      memberships.combination(2).to_h.each do |first, second|
+      memberships.combination(2).to_a.each do |memberships_pair|
+        first, second = memberships_pair
         first_period = first.start_date..(first.end_date || Date::Infinity.new)
         second_period = second.start_date..(second.end_date || Date::Infinity.new)
         if first_period.overlaps? second_period
-          message = "Membership periods overlap for user #{user.name}"
-          errors[:base] << message unless errors[:base].include?(message)
+          errors[:base] << "Membership periods overlap for user #{user.name}"
+          break # One overlapping period for the user is found, skip to the next one
         end
       end
     end

--- a/WcaOnRails/app/models/team.rb
+++ b/WcaOnRails/app/models/team.rb
@@ -2,4 +2,18 @@ class Team < ActiveRecord::Base
   has_many :team_members, dependent: :destroy
 
   accepts_nested_attributes_for :team_members, reject_if: :all_blank, allow_destroy: true
+
+  validate :membership_periods_cannot_overlap_for_single_user
+  def membership_periods_cannot_overlap_for_single_user
+    team_members.group_by(&:user).each do |user, memberships|
+      memberships.combination(2).to_h.each do |first, second|
+        first_period = first.start_date..(first.end_date || Date::Infinity.new)
+        second_period = second.start_date..(second.end_date || Date::Infinity.new)
+        if first_period.overlaps? second_period
+          message = "Membership periods overlap for user #{user.name}"
+          errors[:base] << message unless errors[:base].include?(message)
+        end
+      end
+    end
+  end
 end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -327,7 +327,7 @@ class User < ActiveRecord::Base
     admin? || board_member? || results_team?
   end
 
-  # Returns true if the user can perform every action for competitions.
+  # Returns true if the user can perform every action for teams.
   def can_manage_teams?
     admin? || board_member? || results_team?
   end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -307,6 +307,10 @@ class User < ActiveRecord::Base
     self.team_members.where(team_id: Team.find_by_friendly_id!(team_friendly_id).id, team_leader: true).any?(&:current_member?)
   end
 
+  def teams_where_is_leader
+    self.team_members.where(team_leader: true).select(&:current_member?).map!(&:team).uniq
+  end
+
   def admin?
     software_team?
   end
@@ -323,10 +327,14 @@ class User < ActiveRecord::Base
     admin? || board_member? || results_team?
   end
 
-  # Team leaders should be able to edit their team.
-  # See https://github.com/cubing/worldcubeassociation.org/issues/427
-  def can_edit_teams?
+  # Returns true if the user can perform every action for competitions.
+  def can_manage_teams?
     admin? || board_member? || results_team?
+  end
+
+  # Returns true if the user can edit the given team.
+  def can_edit_team?(team)
+    can_manage_teams? || team_leader?(team.friendly_id)
   end
 
   def can_create_competitions?

--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -136,6 +136,16 @@
                 <li><%= link_to "New post", new_post_path %></li>
               <% end %>
 
+              <% unless current_user.teams_where_is_leader.empty? %>
+                <li class="divider"></li>
+                <li role="presentation" class="dropdown-header">
+                  Team leader
+                </li>
+                <% current_user.teams_where_is_leader.each do |team| %>
+                  <li><%= link_to team.name, edit_team_path(team) %></li>
+                <% end %>
+              <% end %>
+
               <li class="divider"></li>
               <li><%= link_to "API", api_path %></li>
               <li><%= link_to "Manage your applications", oauth_applications_path %></li>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -174,7 +174,7 @@
 
     <div class="form-group">
       <% @user.teams.each do |team| %>
-        <%= link_to team.name, edit_team_path(team), class: "btn btn-info #{"disabled" unless current_user.can_edit_teams?}" %>
+        <%= link_to team.name, edit_team_path(team), class: "btn btn-info #{"disabled" unless current_user.can_edit_team?(team)}" %>
       <% end %>
     </div>
 

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -172,6 +172,12 @@
       <%= f.input :region, disabled: !editable_fields.include?(:region) %>
     <% end %>
 
+    <div class="form-group">
+      <% @user.teams.each do |team| %>
+        <%= link_to team.name, edit_team_path(team), class: "btn btn-info #{"disabled" unless current_user.can_edit_teams?}" %>
+      <% end %>
+    </div>
+
     <%= f.submit 'Save', class: "btn btn-primary" %>
   <% end %>
 </div>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -173,8 +173,9 @@
     <% end %>
 
     <div class="form-group">
+      <label>Member of</label>
       <% @user.teams.each do |team| %>
-        <%= link_to team.name, edit_team_path(team), class: "btn btn-info #{"disabled" unless current_user.can_edit_team?(team)}" %>
+        <%= link_to team.name, edit_team_path(team), class: "btn btn-xs btn-info #{"disabled" unless current_user.can_edit_team?(team)}" %>
       <% end %>
     </div>
 

--- a/WcaOnRails/spec/controllers/teams_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/teams_controller_spec.rb
@@ -176,6 +176,14 @@ describe TeamsController do
         invalid_team = assigns(:team)
         expect(invalid_team).to be_invalid
       end
+
+      it 'cannot add overlapping membership periods for the same user'do
+        member = FactoryGirl.create :user
+        patch :update, id: team, team: { team_members_attributes: {"0" => { user_id: member.id, start_date: Date.today, end_date: Date.today+10, team_leader: false },
+                                                                   "1" => { user_id: member.id, start_date: Date.today+9, end_date: Date.today+20, team_leader: false }} }
+        invalid_team = assigns(:team)
+        expect(invalid_team).to be_invalid
+      end
     end
   end
 end

--- a/WcaOnRails/spec/controllers/teams_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/teams_controller_spec.rb
@@ -89,6 +89,33 @@ describe TeamsController do
     end
   end
 
+  describe 'GET #edit' do
+    context 'when signed in as a team leader without rights to manage all teams' do
+      let(:team_where_is_leader) { Team.find_by_friendly_id('wrc') }
+      let(:team_where_is_not_leader) { Team.find_by_friendly_id('software') }
+      let(:leader) do
+        user = FactoryGirl.create(:user)
+        FactoryGirl.create(:team_member, team_id: team_where_is_leader.id, user_id: user.id, team_leader: true)
+        user
+      end
+
+      before :each do
+        sign_in leader
+      end
+
+      it 'can edit his team' do
+        get :edit, id: team_where_is_leader.id
+        expect(response).to render_template :edit
+      end
+
+      it 'cannot edit other teams' do
+        get :edit, id: team_where_is_not_leader.id
+        expect(response).to redirect_to root_url
+        expect(flash[:danger]).to_not be_nil
+      end
+    end
+  end
+
   describe 'POST #update' do
     context 'when signed in as an admin' do
       let(:admin) { FactoryGirl.create :admin }


### PR DESCRIPTION
Fixes #428, #427 and #425.

New 'Team leader' group in navigation:
![image](https://cloud.githubusercontent.com/assets/17034772/14587229/e2e43ec2-04af-11e6-93a8-e0d86956a20d.png)

Profile as an admin:
![image](https://cloud.githubusercontent.com/assets/17034772/14587231/fe3bccee-04af-11e6-92f3-a1f0e8a9c23c.png)

Profile as a wrc leader:
![image](https://cloud.githubusercontent.com/assets/17034772/14587248/49bfb8ba-04b0-11e6-826e-f67054dc3544.png)

Profile as a normal member without rights to edit teams:
![image](https://cloud.githubusercontent.com/assets/17034772/14587251/6901120a-04b0-11e6-9bd6-b91de8575936.png)

Example of error message when membership periods of the same user overlap each other:
![image](https://cloud.githubusercontent.com/assets/17034772/14587288/19e6837a-04b1-11e6-91db-94f0ac673e09.png)

