### PR TITLE
Fix delegates table appearance on mobile and clean wca-user element

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/delegates.scss
+++ b/WcaOnRails/app/assets/stylesheets/delegates.scss
@@ -13,12 +13,9 @@ tr.candidate-delegate {
 }
 
 .avatar-thumbnail {
-  display: inline-block;
   background-size: cover;
   width: 50px;
   height: 50px;
-
-  vertical-align: middle;
 
   &.avatar-thumbnail-lg {
     width: 100px;

--- a/WcaOnRails/app/assets/stylesheets/wca.scss
+++ b/WcaOnRails/app/assets/stylesheets/wca.scss
@@ -47,18 +47,26 @@ table.table {
 }
 
 .wca-user {
-  white-space: nowrap;
-
+  .avatar-thumbnail,
+  .info {
+    display: inline-block;
+    vertical-align: middle;
+  }
   .avatar-thumbnail {
-    // Put thumbnail to the left of both name and wca-id.
-    float: left;
     margin-right: 5px;
   }
   .name {
+    white-space: nowrap;
   }
   .wca-id {
-    // Put wca-id on a new line.
-    display: block;
+  }
+}
+
+.wca-user-link:hover,
+.wca-user-link:focus {
+  text-decoration: none;
+  .info {
+    text-decoration: underline;
   }
 }
 

--- a/WcaOnRails/app/views/shared/_user.html.erb
+++ b/WcaOnRails/app/views/shared/_user.html.erb
@@ -1,7 +1,9 @@
 <div class="wca-user">
   <%= render "shared/user_avatar", user: user %>
-  <span class="name"><%= user.name %></span>
-  <% if user.wca_id %>
-    <span class="wca-id"><%= user.wca_id %></span>
-  <% end %>
+  <div class="info">
+    <div class="name"><%= user.name %></div>
+    <% if user.wca_id %>
+      <div class="wca-id"><%= user.wca_id %></div>
+    <% end %>
+  </div>
 </div>

--- a/WcaOnRails/app/views/static_pages/_delegate_row.html.erb
+++ b/WcaOnRails/app/views/static_pages/_delegate_row.html.erb
@@ -10,7 +10,7 @@
     <% end %>
   </td>
   <td>
-    <%= link_to "/results/p.php?i=#{delegate.wca_id}" do %>
+    <%= link_to "/results/p.php?i=#{delegate.wca_id}", class: "wca-user-link" do %>
       <%= render "shared/user", user: delegate %>
     <% end %>
   </td>

--- a/WcaOnRails/app/views/static_pages/_delegates_in_region_table.html.erb
+++ b/WcaOnRails/app/views/static_pages/_delegates_in_region_table.html.erb
@@ -1,23 +1,25 @@
 <% if delegates.length > 0 %>
-  <table class="table delegates-table">
-    <colgroup>
-      <col />
-      <col class="col-md-4" />
-      <col class="col-md-4" />
-      <col class="col-md-4" />
-    </colgroup>
-    <thead>
-      <tr>
-        <th></th>
-        <th>Name</th>
-        <th>Role</th>
-        <th>Region</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% delegates.each do |delegate| %>
-        <%= render "delegate_row", delegate: delegate %>
-      <% end %>
-    </tbody>
-  </table>
+  <div class="table-responsive">
+    <table class="table delegates-table">
+      <colgroup>
+        <col />
+        <col class="col-md-4" />
+        <col class="col-md-4" />
+        <col class="col-md-4" />
+      </colgroup>
+      <thead>
+        <tr>
+          <th></th>
+          <th>Name</th>
+          <th>Role</th>
+          <th>Region</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% delegates.each do |delegate| %>
+          <%= render "delegate_row", delegate: delegate %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 <% end %>

--- a/WcaOnRails/vendor/assets/javascripts/jquery.wca-autocomplete.js
+++ b/WcaOnRails/vendor/assets/javascripts/jquery.wca-autocomplete.js
@@ -47,7 +47,7 @@
         var toHtmlByClass = {
           user: function(user) {
             // Copied from app/views/shared/user.html.erb
-            var $div = $('<div class="wca-user"><span class="avatar-thumbnail"></span> <span class="name"></span> <span class="wca-id"></span></div>');
+            var $div = $('<div class="wca-user"> <div class="avatar-thumbnail"></div> <div class="info"><div class="name"></div><div class="wca-id"></div></div> </div>');
             $div.find(".name").text(user.name);
             $div.find(".avatar-thumbnail").css('background-image', 'url("' + user.avatar.thumb_url + '")');
             if(user.wca_id) {


### PR DESCRIPTION
Fixes #508. Also cleans 'wca-user' element.

Search and table still looks good.
![image](https://cloud.githubusercontent.com/assets/17034772/14590767/750d4d36-0503-11e6-9645-d7a47c78eb01.png)

The table is now horizontally scrollable on a phone and cells don't overlap each other.
![image](https://cloud.githubusercontent.com/assets/17034772/14590772/9c419312-0503-11e6-952a-c9e763bf6d07.png)
