### PR TITLE
Warn when competition names are > 32 chars #443

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -17,11 +17,10 @@ class Competition < ActiveRecord::Base
   PATTERN_LINK_RE = /\[\{([^}]+)}\{((https?:|mailto:)[^}]+)}\]/
   PATTERN_TEXT_WITH_LINKS_RE = /\A[^{}]*(#{PATTERN_LINK_RE.source}[^{}]*)*\z/
   MAX_ID_LENGTH = 32
+  MAX_NAME_LENGTH = 32
   validates :id, presence: true, uniqueness: true, length: { maximum: MAX_ID_LENGTH },
                  format: { with: /\A[a-zA-Z0-9]+\Z/ }
-  validates :name, length: { maximum: 50 },
-                   format: { with: ENDS_WITH_YEAR_RE }
-  MAX_CELL_NAME_LENGTH = 45
+  MAX_CELL_NAME_LENGTH = 32
   validates :cellName, length: { maximum: MAX_CELL_NAME_LENGTH },
                        format: { with: ENDS_WITH_YEAR_RE }
   validates :venue, format: { with: PATTERN_TEXT_WITH_LINKS_RE }
@@ -37,6 +36,16 @@ class Competition < ActiveRecord::Base
 
   # https://www.worldcubeassociation.org/regulations/guidelines.html#8a4++
   SHOULD_BE_ANNOUNCED_GTE_THIS_MANY_DAYS = 29
+
+  validate :competition_name_validations
+  def competition_name_validations
+    if name.length > MAX_NAME_LENGTH && !self.showAtAll?
+      errors.add(:name, "Competition name can't be longer than 32 characters")
+    end
+    if !ENDS_WITH_YEAR_RE.match(name)
+      errors.add(:name, "The competition name must end in a year.")
+    end
+  end
 
   # We have stricter validations for confirming a competition
   [:cityName, :countryId, :venue, :venueAddress, :website, :latitude, :longitude].each do |field|

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Competition do
     expect(competition).to be_valid
     expect(competition.id).to eq "AlexanderandtheTerribleHorri2015"
     expect(competition.name).to eq "Alexander and the Terrible, Horrible, No Good 2015"
-    expect(competition.cellName).to eq "Alexander and the Terrible, Horrible,... 2015"
+    expect(competition.cellName).to eq "Alexander and the Terrib... 2015"
   end
 
   it "saves without losing data" do
@@ -54,6 +54,7 @@ RSpec.describe Competition do
   it "requires that name end in a year" do
     competition = FactoryGirl.build :competition, name: "Name without year"
     expect(competition).to be_invalid
+    expect(competition.errors.messages[:name]).to eq ["The competition name must end in a year."]
   end
 
   it "requires that cellName end in a year" do
@@ -114,6 +115,20 @@ RSpec.describe Competition do
     competition.start_date = "1987-12-06"
     competition.end_date = "1988-12-07"
     expect(competition).to be_invalid
+  end
+
+  it "requires unapproved competition name is not greater than 32 characters" do
+    competition = FactoryGirl.create :competition
+    competition.showAtAll = false
+    competition.name = "A really long competition name 2016"
+    expect(competition).to be_invalid
+  end
+
+  it "competition name can be greater than 32 characters when approved" do
+    competition = FactoryGirl.create :competition
+    competition.showAtAll = true
+    competition.name = "A really long competition name 2016"
+    expect(competition).to be_valid
   end
 
   it "knows the calendar" do


### PR DESCRIPTION
Hi Jeremy,

I had a go at fixing #443 by adding a flash message when the competition name has more than 32 characters. The message does not get triggered if the competition is already confirmed and it's the organiser view since at that point the name cannot be edited.

As I mentioned I haven't worked with Ruby on Rails before so would love some feedback about this change.