### PR TITLE
Do not display demoted team members

### DIFF
--- a/WcaOnRails/app/helpers/static_pages_helper.rb
+++ b/WcaOnRails/app/helpers/static_pages_helper.rb
@@ -1,11 +1,7 @@
 module StaticPagesHelper
   def format_team_members(team_friendly_id)
-    TeamMember.where(team_id: Team.find_by_friendly_id!(team_friendly_id).id).includes(:user).order(team_leader: :desc).order("users.name asc").map do |u|
-      s = u.user.name
-      if u.team_leader
-        s += " (leader)"
-      end
-      s
+    Team.find_by_friendly_id!(team_friendly_id).current_members.includes(:user).order(team_leader: :desc).order("users.name asc").map do |u|
+      u.user.name + (u.team_leader ? " (leader)" : "")
     end.join(", ")
   end
 end

--- a/WcaOnRails/app/helpers/static_pages_helper.rb
+++ b/WcaOnRails/app/helpers/static_pages_helper.rb
@@ -2,6 +2,6 @@ module StaticPagesHelper
   def format_team_members(team_friendly_id)
     Team.find_by_friendly_id!(team_friendly_id).current_members.includes(:user).order(team_leader: :desc).order("users.name asc").map do |u|
       u.user.name + (u.team_leader ? " (leader)" : "")
-    end.join(", ")
+    end.to_sentence(last_word_connector: " and ")
   end
 end

--- a/WcaOnRails/app/models/team.rb
+++ b/WcaOnRails/app/models/team.rb
@@ -1,5 +1,6 @@
 class Team < ActiveRecord::Base
   has_many :team_members, dependent: :destroy
+  has_many :current_members, -> { current }, class_name: "TeamMember"
 
   accepts_nested_attributes_for :team_members, reject_if: :all_blank, allow_destroy: true
 
@@ -16,9 +17,5 @@ class Team < ActiveRecord::Base
         end
       end
     end
-  end
-
-  def current_members
-    self.team_members.where("end_date IS NULL OR end_date > ?", Date.today)
   end
 end

--- a/WcaOnRails/app/models/team.rb
+++ b/WcaOnRails/app/models/team.rb
@@ -17,4 +17,8 @@ class Team < ActiveRecord::Base
       end
     end
   end
+
+  def current_members
+    self.team_members.where("end_date IS NULL OR end_date > ?", Date.today)
+  end
 end

--- a/WcaOnRails/app/models/team_member.rb
+++ b/WcaOnRails/app/models/team_member.rb
@@ -2,6 +2,8 @@ class TeamMember < ActiveRecord::Base
   belongs_to :team
   belongs_to :user
 
+  scope :current, -> { where("end_date IS NULL OR end_date > ?", Date.today) }
+
   attr_accessor :current_user
 
   def current_member?

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -311,6 +311,10 @@ class User < ActiveRecord::Base
     self.team_members.where(team_leader: true).select(&:current_member?).map!(&:team).uniq
   end
 
+  def current_teams
+    self.team_members.select(&:current_member?).map!(&:team).uniq
+  end
+
   def admin?
     software_team?
   end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -11,8 +11,10 @@ class User < ActiveRecord::Base
   belongs_to :person, foreign_key: "wca_id"
   belongs_to :unconfirmed_person, foreign_key: "unconfirmed_wca_id", class_name: "Person"
   belongs_to :delegate_to_handle_wca_id_claim, -> { where.not(delegate_status: nil ) }, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User"
-  has_many :teams, through: :team_members
   has_many :team_members, dependent: :destroy
+  has_many :teams, -> { distinct }, through: :team_members
+  has_many :current_team_members, -> { current }, class_name: "TeamMember"
+  has_many :current_teams, -> { distinct }, through: :current_team_members, source: :team
   has_many :users_claiming_wca_id, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User"
   has_many :oauth_applications, class_name: 'Doorkeeper::Application', as: :owner
 
@@ -309,10 +311,6 @@ class User < ActiveRecord::Base
 
   def teams_where_is_leader
     self.team_members.where(team_leader: true).select(&:current_member?).map!(&:team).uniq
-  end
-
-  def current_teams
-    self.team_members.select(&:current_member?).map!(&:team).uniq
   end
 
   def admin?

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -174,7 +174,7 @@
 
     <div class="form-group">
       <label>Member of</label>
-      <% @user.teams.each do |team| %>
+      <% @user.current_teams.each do |team| %>
         <%= link_to team.name, edit_team_path(team), class: "btn btn-xs btn-info #{"disabled" unless current_user.can_edit_team?(team)}" %>
       <% end %>
     </div>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -172,12 +172,14 @@
       <%= f.input :region, disabled: !editable_fields.include?(:region) %>
     <% end %>
 
-    <div class="form-group">
-      <label>Member of</label>
-      <% @user.current_teams.each do |team| %>
-        <%= link_to team.name, edit_team_path(team), class: "btn btn-xs btn-info #{"disabled" unless current_user.can_edit_team?(team)}" %>
-      <% end %>
-    </div>
+    <% unless @user.current_teams.empty? %>
+      <div class="form-group">
+        <label>Member of</label>
+        <% @user.current_teams.each do |team| %>
+          <%= link_to team.name, edit_team_path(team), class: "btn btn-xs btn-info #{"disabled" unless current_user.can_edit_team?(team)}" %>
+        <% end %>
+      </div>
+    <% end %>
 
     <%= f.submit 'Save', class: "btn btn-primary" %>
   <% end %>

--- a/WcaOnRails/spec/helpers/static_pages_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/static_pages_helper_spec.rb
@@ -11,7 +11,19 @@ describe StaticPagesHelper do
       FactoryGirl.create(:team_member, team_id: team.id, user_id: other_member.id, start_date: Date.today-1)
       FactoryGirl.create(:team_member, team_id: team.id, user_id: another_member.id, start_date: Date.today-1)
       string = helper.format_team_members(team.friendly_id)
-      expect(string).to eq "Jeremy (leader), Aaron, Pedro"
+      expect(string).to eq "Jeremy (leader), Aaron and Pedro"
+    end
+
+    it "does not include the demoted members" do
+      team = FactoryGirl.create(:team)
+      leader = FactoryGirl.create(:user, name: "Jeremy")
+      present_member = FactoryGirl.create(:user, name: "Pedro")
+      demoted_member = FactoryGirl.create(:user, name: "Aaron")
+      FactoryGirl.create(:team_member, team_id: team.id, user_id: leader.id, start_date: Date.today-1, team_leader: true)
+      FactoryGirl.create(:team_member, team_id: team.id, user_id: present_member.id, start_date: Date.today-1)
+      FactoryGirl.create(:team_member, team_id: team.id, user_id: demoted_member.id, start_date: Date.today-10, end_date: Date.today-1)
+      string = helper.format_team_members(team.friendly_id)
+      expect(string).to eq "Jeremy (leader) and Pedro"
     end
   end
 end

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -403,4 +403,17 @@ RSpec.describe User, type: :model do
       ]
     end
   end
+
+  it "#teams and #current_teams return unique team names" do
+    wrc_team = Team.find_by_friendly_id('wrc')
+    results_team = Team.find_by_friendly_id('results')
+    user = FactoryGirl.create(:user)
+
+    FactoryGirl.create(:team_member, team_id: wrc_team.id, user_id: user.id, start_date: Date.today - 20, end_date: Date.today - 10)
+    FactoryGirl.create(:team_member, team_id: results_team.id, user_id: user.id, start_date: Date.today - 5, end_date: Date.today + 5)
+    FactoryGirl.create(:team_member, team_id: results_team.id, user_id: user.id, start_date: Date.today + 6, end_date: Date.today + 10)
+
+    expect(user.teams).to match_array [wrc_team, results_team]
+    expect(user.current_teams).to match_array [results_team]
+  end
 end


### PR DESCRIPTION
Fixes issue reported by @Laura-O. We don't want to display demoted team members on the about and the contact pages, also do not show the labels on the members profiles.