### PR TITLE
Redirect http -> https -> https://www

### DIFF
--- a/chef/site-cookbooks/wca/templates/worldcubeassociation.org.conf.erb
+++ b/chef/site-cookbooks/wca/templates/worldcubeassociation.org.conf.erb
@@ -172,18 +172,3 @@ server {
 }
 <% end %>
 <% end %>
-
-<% if @server_name.start_with? "www." %>
-# Redirect naked domain HTTP traffic to HTTP(S) on www....
-server {
-  server_name <%= @server_name.sub(/^www./, '') %>;
-
-  listen 80;
-
-<% if @https %>
-  return 301 https://www.$server_name$request_uri;
-<% else %>
-  return 301 http://www.$server_name$request_uri;
-<% end %>
-}
-<% end %>


### PR DESCRIPTION
This is the proper order for HSTS.

It seems to me that the entire port 80 block is redundant, given the port 443 block above, but I haven't tested anything.