### PR TITLE
Edit registrations table footer

### DIFF
--- a/WcaOnRails/app/views/registrations/_edit_registrations_table_footer.html.erb
+++ b/WcaOnRails/app/views/registrations/_edit_registrations_table_footer.html.erb
@@ -1,0 +1,19 @@
+<tfoot>
+  <tr>
+    <td colspan="4">
+      <%= render "registration_info_people", registrations: registrations %>
+    </td>
+    <% country_count = registrations.map(&:countryId).uniq.length %>
+    <td><%= country_count %> <%= "country".pluralize(country_count) %></td>
+    <td colspan="2"></td>
+    <% @competition.events.each do |event| %>
+      <td><%= registrations.select { |r| r.events.include?(event) }.length %></td>
+    <% end %>
+    <td>
+      <% if @competition.guests_enabled? %>
+        <%= registrations.sum :guests %>
+      <% end %>
+    </td>
+    <td colspan="3"></td>
+  </tr>
+</tfoot>

--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -100,26 +100,7 @@
           <% end %>
         </tbody>
 
-        <tfoot>
-          <tr>
-            <td colspan="4">
-              <%= render "registration_info_people", registrations: registrations %>
-            </td>
-            <% country_count = registrations.map(&:countryId).uniq.length %>
-            <td><%= country_count %> <%= "country".pluralize(country_count) %></td>
-            <td></td>
-            <td></td>
-            <% @competition.events.each do |event| %>
-              <td><%= registrations.select { |r| r.events.include?(event) }.length %></td>
-            <% end %>
-            <td>
-              <% if @competition.guests_enabled? %>
-                <%= registrations.map(&:guests).reduce { |sum, guests| sum + guests } %>
-              <% end %>
-            </td>
-            <td colspan="3"></td>
-          </tr>
-        </tfoot>
+        <%= render "edit_registrations_table_footer", registrations: registrations %>
       <% end %>
     <% end %>
 

--- a/WcaOnRails/app/views/registrations/update_all.js.erb
+++ b/WcaOnRails/app/views/registrations/update_all.js.erb
@@ -38,3 +38,9 @@ $acceptedTable.find('tbody tr').removeClass('registration-pending').addClass('re
 
 $registrationsTable.bootstrapTable('uncheckAll');
 $registrationsTable.find('tr.selected').removeClass('selected');
+
+// Update registration table footers with summary info
+<% [:pending, :accepted].each do |status| %>
+  <% registrations = @competition.registrations.send(status) %>
+  $<%= status %>Table.find('tfoot').replaceWith('<%=j render "edit_registrations_table_footer", registrations: registrations %>');
+<% end %>

--- a/WcaOnRails/db/seeds/development/competitions.seeds.rb
+++ b/WcaOnRails/db/seeds/development/competitions.seeds.rb
@@ -1,4 +1,11 @@
 after "development:users" do
+  class << self
+    def random_event_ids
+      all_official = Event.all_official.map(&:id)
+      all_official.sample(rand(1..all_official.count))
+    end
+  end
+
   delegate = User.find_by(delegate_status: "delegate")
 
   users = User.where.not(wca_id: nil).sample(93)
@@ -6,7 +13,8 @@ after "development:users" do
   # Create some past competitions with results
   2.times do |i|
     day = i.days.ago
-    eventIds = %w(333 333oh magic)
+    eventIds = random_event_ids
+
     competition = Competition.create!(
       id: "My#{i}ResultsComp#{day.year}",
       name: "My #{i} Comp With Results #{day.year}",
@@ -58,9 +66,11 @@ after "development:users" do
   end
 
   # Create a bunch of competitions just to fill up the competitions list
+
+  # Past competitions
   500.times do |i|
     day = i.days.ago
-    eventIds = %w(333 333oh magic)
+    eventIds = random_event_ids
     Competition.create!(
       id: "My#{i}Comp#{day.year}",
       name: "My #{i} Best Comp #{day.year}",
@@ -104,35 +114,15 @@ after "development:users" do
     )
   end
 
-  day = Date.today
-  eventIds = %w(333 333oh magic)
-  future_competition = Competition.create!(
-    id: "NewComp#{day.year}",
-    name: "New Comp #{day.year}",
-    cellName: "New Comp #{day.year}",
-    cityName: "Paris",
-    countryId: "France",
-    information: "Information!",
-    start_date: day.strftime("%F"),
-    end_date: day.strftime("%F"),
-    eventSpecs: eventIds.join(" "),
-    venue: "National Stadium",
-    website: "https://www.worldcubeassociation.org",
-    showAtAll: true,
-    delegates: [delegate],
-    organizers: User.all.sample(2),
-    use_wca_registration: true,
-    registration_open: 2.weeks.ago,
-    registration_close: day - (1.week),
-  )
-
+  # Upcoming competitions
   500.times do |i|
+    eventIds = random_event_ids
+
     start_day = (i+1).days.from_now
     end_day = start_day + (0..5).to_a.sample.days
     end_day = start_day if start_day.year != end_day.year
 
-    eventIds = %w(333 333oh 333bf)
-    Competition.create!(
+    competition = Competition.create!(
       id: "MyComp#{i+1}#{start_day.year}",
       name: "My #{i+1} Comp #{start_day.year}",
       cellName: "My #{i+1} Comp #{start_day.year}",
@@ -153,29 +143,32 @@ after "development:users" do
       latitude_degrees: Random.new.rand(-90.0..90.0),
       longitude_degrees: Random.new.rand(-180.0..180.0),
     )
-  end
 
-  users.each_with_index do |user, i|
-    status = i % 4 == 0 ? "a" : "p"
-    if i % 2 == 0
-      Registration.new(
-        competition: future_competition,
-        name: Faker::Name.name,
-        personId: user.wca_id,
-        countryId: Faker::Address.country.slice(0, 50), # Ensure that the length of an address won't cause database error.
-        gender: "m",
-        birthYear: 1990,
-        birthMonth: 6,
-        birthDay: 4,
-        email: Faker::Internet.email,
-        guests: rand(10),
-        comments: Faker::Lorem.paragraph,
-        ip: "1.1.1.1",
-        status: status,
-        eventIds: eventIds.sample(i).join(" "),
-      ).save!(validate: false)
-    else
-      FactoryGirl.create(:registration, user: user, competition: future_competition, status: status)
+    # Create registrations for some competitions taking place far in the future
+    next if i < 480
+    users.each_with_index do |user, i|
+      status = i % 4 == 0 ? "a" : "p"
+      registrationEventIds = eventIds.sample(rand(1..eventIds.count)).join(" ")
+      if i % 2 == 0
+        Registration.new(
+          competition: competition,
+          name: Faker::Name.name,
+          personId: user.wca_id,
+          countryId: Country::ALL_COUNTRIES.sample.id,
+          gender: "m",
+          birthYear: 1990,
+          birthMonth: 6,
+          birthDay: 4,
+          email: Faker::Internet.email,
+          guests: rand(10),
+          comments: Faker::Lorem.paragraph,
+          ip: "1.1.1.1",
+          status: status,
+          eventIds: registrationEventIds,
+        ).save!(validate: false)
+      else
+        FactoryGirl.create(:registration, user: user, competition: competition, status: status, eventIds: registrationEventIds)
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes #526 and updates the wrong competitions seeds (produces registrations with events which aren't on a competition, this leads to validation errors). Also randomizes competition events.