### PR TITLE
Google Maps improvements

### DIFF
--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -50,6 +50,23 @@ wca.cancelPendingAjaxAndAjax = function(id, options) {
   return wca._pendingAjaxById[id];
 };
 
+wca._googleMapsLoaded = false;
+wca._onGoogleMapsLoaded = function() {
+  wca._googleMapsLoaded = true;
+  wca._googleMapsLoadedListeners.forEach(function(listener) {
+    listener();
+  });
+  wca._googleMapsLoadedListeners = null;
+};
+wca._googleMapsLoadedListeners = [];
+wca.addGoogleMapsLoadedListener = function(listener) {
+  if(wca._googleMapsLoaded) {
+    listener();
+  } else {
+    wca._googleMapsLoadedListeners.push(listener);
+  }
+};
+
 wca.competitionsToMarkers = function(map, competitions) {
   var markers = [];
 

--- a/WcaOnRails/app/views/competitions/_index_competitions_list.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_competitions_list.html.erb
@@ -44,9 +44,11 @@
         }
       end.to_json.html_safe %>;
 
-      var competitionMarkers = wca.competitionsToMarkers(getCompetitionsMap(), competitions);
-      wca.competitionsMarkerCluster.clearMarkers();
-      wca.competitionsMarkerCluster.addMarkers(competitionMarkers);
+      wca.addGoogleMapsLoadedListener(function() {
+        var competitionMarkers = wca.competitionsToMarkers(getCompetitionsMap(), competitions);
+        wca.competitionsMarkerCluster.clearMarkers();
+        wca.competitionsMarkerCluster.addMarkers(competitionMarkers);
+      });
     });
   </script>
 <% end %>

--- a/WcaOnRails/app/views/competitions/edit.html.erb
+++ b/WcaOnRails/app/views/competitions/edit.html.erb
@@ -1,4 +1,5 @@
 <% provide(:title, @competition.name) %>
+<% provide(:include_gmaps, true) %>
 
 <%= render layout: 'nav' do %>
 

--- a/WcaOnRails/app/views/competitions/edit.html.erb
+++ b/WcaOnRails/app/views/competitions/edit.html.erb
@@ -85,42 +85,61 @@
       </div>
       <script>
         (function() {
-          function roundToMicrodegrees($el) {
-            // To prevent are you sure? from firing even when nothing has changed,
-            // explicitly round coordinates to an integer number of microdegrees.
-            var rounded = Math.trunc(parseFloat($el.val())*1e9) / 1e9;
-            $el.val(rounded);
-          }
           var $map = $('#venue-map-wrapper .map');
-          $map.locationpicker({
-            zoom: 8,
-            location: {
-              latitude: <%= @competition.latitude_degrees %>,
-              longitude: <%= @competition.longitude_degrees %>,
-            },
-            radius: 0,
-            scrollwheel: false,
-            inputBinding: {
-              latitudeInput: $('#competition_latitude'),
-              longitudeInput: $('#competition_longitude'),
-              locationNameInput: $('#googleMapsLocationInput')
-            },
-            enableAutocomplete: true,
-            oninitialized: function(component) {
-              roundToMicrodegrees($('#competition_latitude'));
-              roundToMicrodegrees($('#competition_longitude'));
-            },
-            onchanged: function(currentLocation, radius, isMarkerDropped) {
-              setTimeout(function() {
-                // The locationpicker library calls 'onchanged' before actually updating the input fields.
-                // setTimeout lets us wait until the inputs have actually changed.
+          wca.addGoogleMapsLoadedListener(function() {
+            function roundToMicrodegrees($el) {
+              // To prevent are you sure? from firing even when nothing has changed,
+              // explicitly round coordinates to an integer number of microdegrees.
+              var rounded = Math.trunc(parseFloat($el.val())*1e9) / 1e9;
+              $el.val(rounded);
+            }
+            $map.locationpicker({
+              zoom: 8,
+              location: {
+                latitude: <%= @competition.latitude_degrees %>,
+                longitude: <%= @competition.longitude_degrees %>,
+              },
+              radius: 0,
+              scrollwheel: false,
+              inputBinding: {
+                latitudeInput: $('#competition_latitude'),
+                longitudeInput: $('#competition_longitude'),
+                locationNameInput: $('#googleMapsLocationInput')
+              },
+              enableAutocomplete: true,
+              oninitialized: function(component) {
                 roundToMicrodegrees($('#competition_latitude'));
                 roundToMicrodegrees($('#competition_longitude'));
-                wca.fetchNearbyCompetitions();
-              }, 0);
-            },
+              },
+              onchanged: function(currentLocation, radius, isMarkerDropped) {
+                setTimeout(function() {
+                  // The locationpicker library calls 'onchanged' before actually updating the input fields.
+                  // setTimeout lets us wait until the inputs have actually changed.
+                  roundToMicrodegrees($('#competition_latitude'));
+                  roundToMicrodegrees($('#competition_longitude'));
+                  wca.fetchNearbyCompetitions();
+                }, 0);
+              },
+            });
+            var locationpicker = $map.data('locationpicker');
+
+            var dangerCircle = new google.maps.Circle({
+              map: locationpicker.map,
+              radius: <%= (Competition::NEARBY_DISTANCE_KM_DANGER * 1000).to_json.html_safe %>,
+              strokeColor: '#d9534f', // @brand-danger
+              fillOpacity: 0.0,
+              clickable: false,
+            });
+            dangerCircle.bindTo('center', locationpicker.marker, 'position');
+            var warningCircle = new google.maps.Circle({
+              map: locationpicker.map,
+              radius: <%= (Competition::NEARBY_DISTANCE_KM_WARNING * 1000).to_json.html_safe %>,
+              strokeColor: '#f0ad4e', // @brand-warning
+              fillOpacity: 0.0,
+              clickable: false,
+            });
+            warningCircle.bindTo('center', locationpicker.marker, 'position');
           });
-          var locationpicker = $map.data('locationpicker');
 
           wca.fetchNearbyCompetitions = function() {
             $("#nearby-competitions").addClass('loading');
@@ -156,53 +175,38 @@
 
           wca._nearbyCompetitionById = {};
           wca.setNearbyCompetitions = function(nearbyCompetitions) {
-            var desiredNearbyCompetitionById = _.indexBy(nearbyCompetitions, 'id');
+            wca.addGoogleMapsLoadedListener(function() {
+              var desiredNearbyCompetitionById = _.indexBy(nearbyCompetitions, 'id');
 
-            var desiredIds = Object.keys(desiredNearbyCompetitionById);
-            var currentIds = Object.keys(wca._nearbyCompetitionById);
-            var idsToAdd = _.difference(desiredIds, currentIds);
-            var idsToRemove = _.difference(currentIds, desiredIds);
+              var desiredIds = Object.keys(desiredNearbyCompetitionById);
+              var currentIds = Object.keys(wca._nearbyCompetitionById);
+              var idsToAdd = _.difference(desiredIds, currentIds);
+              var idsToRemove = _.difference(currentIds, desiredIds);
 
-            // First, remove all uneeded markers.
-            idsToRemove.forEach(function(id) {
-              wca._nearbyCompetitionById[id].marker.setMap(null);
-              delete wca._nearbyCompetitionById[id];
-            });
-
-            // Now create all the new markers.
-            idsToAdd.forEach(function(id) {
-              var c = desiredNearbyCompetitionById[id];
-              c.marker = new google.maps.Marker({
-                map: locationpicker.map,
-                position: {
-                  lat: c.latitude_degrees,
-                  lng: c.longitude_degrees,
-                },
-                title: c.name,
+              // First, remove all uneeded markers.
+              idsToRemove.forEach(function(id) {
+                wca._nearbyCompetitionById[id].marker.setMap(null);
+                delete wca._nearbyCompetitionById[id];
               });
-              wca._nearbyCompetitionById[id] = c;
+
+              var locationpicker = $map.data('locationpicker');
+              // Now create all the new markers.
+              idsToAdd.forEach(function(id) {
+                var c = desiredNearbyCompetitionById[id];
+                c.marker = new google.maps.Marker({
+                  map: locationpicker.map,
+                  position: {
+                    lat: c.latitude_degrees,
+                    lng: c.longitude_degrees,
+                  },
+                  title: c.name,
+                });
+                wca._nearbyCompetitionById[id] = c;
+              });
             });
 
             $("#nearby-competitions").removeClass('loading');
           };
-
-          var dangerCircle = new google.maps.Circle({
-            map: locationpicker.map,
-            radius: <%= (Competition::NEARBY_DISTANCE_KM_DANGER * 1000).to_json.html_safe %>,
-            strokeColor: '#d9534f', // @brand-danger
-            fillOpacity: 0.0,
-            clickable: false,
-          });
-          dangerCircle.bindTo('center', locationpicker.marker, 'position');
-          var warningCircle = new google.maps.Circle({
-            map: locationpicker.map,
-            radius: <%= (Competition::NEARBY_DISTANCE_KM_WARNING * 1000).to_json.html_safe %>,
-            strokeColor: '#f0ad4e', // @brand-warning
-            fillOpacity: 0.0,
-            clickable: false,
-          });
-          warningCircle.bindTo('center', locationpicker.marker, 'position');
-
         })();
       </script>
 

--- a/WcaOnRails/app/views/competitions/index.html.erb
+++ b/WcaOnRails/app/views/competitions/index.html.erb
@@ -1,4 +1,5 @@
 <% provide(:title, 'Competitions') %>
+<% provide(:include_gmaps, true) %>
 
 <div class="container">
   <h2><%= yield(:title) %></h2>

--- a/WcaOnRails/app/views/layouts/application.html.erb
+++ b/WcaOnRails/app/views/layouts/application.html.erb
@@ -7,8 +7,10 @@
   <%= stylesheet_link_tag 'application', media: 'all' %>
   <%= javascript_include_tag 'application' %>
 
-  <% wca_gmaps_key_param = ENVied.WCA_LIVE_SITE ? "key=AIzaSyA-kN3GCsG78MnAp16CIRft221XNmioovk" : "" %>
-  <script type="text/javascript" src='//maps.google.com/maps/api/js?libraries=places?<%= wca_gmaps_key_param %>'></script>
+  <% if content_for :include_gmaps %>
+    <% wca_gmaps_key_param = ENVied.WCA_LIVE_SITE ? "key=AIzaSyA-kN3GCsG78MnAp16CIRft221XNmioovk" : "" %>
+    <script type="text/javascript" src='//maps.google.com/maps/api/js?libraries=places?<%= wca_gmaps_key_param %>'></script>
+  <% end %>
 
   <%= csrf_meta_tags %>
   <%= auto_discovery_link_tag(:rss, rss_url(format: :xml)) %>

--- a/WcaOnRails/app/views/layouts/application.html.erb
+++ b/WcaOnRails/app/views/layouts/application.html.erb
@@ -6,7 +6,10 @@
   <title><%= full_title(yield(:title)) %></title>
   <%= stylesheet_link_tag 'application', media: 'all' %>
   <%= javascript_include_tag 'application' %>
-  <script type="text/javascript" src='//maps.google.com/maps/api/js?libraries=places'></script>
+
+  <% wca_gmaps_key_param = ENVied.WCA_LIVE_SITE ? "key=AIzaSyA-kN3GCsG78MnAp16CIRft221XNmioovk" : "" %>
+  <script type="text/javascript" src='//maps.google.com/maps/api/js?libraries=places?<%= wca_gmaps_key_param %>'></script>
+
   <%= csrf_meta_tags %>
   <%= auto_discovery_link_tag(:rss, rss_url(format: :xml)) %>
   <% if ENVied.WCA_LIVE_SITE %>

--- a/WcaOnRails/app/views/layouts/application.html.erb
+++ b/WcaOnRails/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
 
   <% if content_for :include_gmaps %>
     <% wca_gmaps_key_param = ENVied.WCA_LIVE_SITE ? "key=AIzaSyA-kN3GCsG78MnAp16CIRft221XNmioovk" : "" %>
-    <script type="text/javascript" src='//maps.google.com/maps/api/js?libraries=places?<%= wca_gmaps_key_param %>'></script>
+    <script type="text/javascript" src='//maps.google.com/maps/api/js?libraries=places&callback=wca._onGoogleMapsLoaded&<%= wca_gmaps_key_param %>'></script>
   <% end %>
 
   <%= csrf_meta_tags %>


### PR DESCRIPTION
This fixes #434. I did three things:

1. Added a google maps api key that is only used if `ENVied.WCA_LIVE_SITE`.
2. Only embed the google maps `<script...` tag if the view opted in by calling `provide(:include_gmaps, true)`.
3. Don't start using the google maps api until it has actually loaded. Googe Maps only lets you specify a single callback (embedded in the url you use to request the google maps js). I used that parameter to build 2 util methods: `wca.addGoogleMapsLoadedListener` and `wca._onGoogleMapsLoaded`. Hopefully their purposes are clear.