### PR TITLE
Ensure competition names are not greater than 50 characters when visible

### DIFF
--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -135,22 +135,18 @@
       <h3><%= @competition.name %></h3>
       <hr />
 
-      <% if !@competition.showAtAll? %>
+      <% @competition.warnings.each do |field, message| %>
         <div class="alert alert-warning">
-          <strong>Note:</strong> This competition is not visible to the public.
+          <strong>Note:</strong>
+          <%= message %>
         </div>
       <% end %>
-      <% if !@competition.results_uploaded? %>
-        <% if @competition.is_over? %>
-          <div class="alert alert-info">
-            <strong>Note:</strong> This competition is over, we are working to upload the results as soon as possible!
-          </div>
-        <% end %>
-        <% if @competition.in_progress? %>
-          <div class="alert alert-info">
-            <strong>Note:</strong> This competition is ongoing. Come back after <%= @competition.end_date.to_formatted_s(:long) %> to see the results!
-          </div>
-        <% end %>
+
+      <% @competition.info.each do |field, message| %>
+        <div class="alert alert-info">
+          <strong>Note:</strong>
+          <%= message %>
+        </div>
       <% end %>
 
       <%= yield %>

--- a/WcaOnRails/app/views/competitions/edit.html.erb
+++ b/WcaOnRails/app/views/competitions/edit.html.erb
@@ -54,7 +54,7 @@
 
     <% if @competition_admin_view || !is_actually_confirmed %>
       <%= f.input :id %>
-      <%= f.input :name %>
+      <%= f.input :name, wrapper_html: { class: @competition.warnings[:name] ? "has-warning" : "" } %>
       <%= f.input :cellName %>
 
       <%= f.input :countryId, collection: Country.all, label_method: lambda { |c| c.name }, value_method: lambda { |c| c.id }  %>


### PR DESCRIPTION
 I realised that the change I made to ensure a competition name <= 32 characters when it's not visible removed the existing validation for when the competition is visible. So I added back the original validation and added a new test for it to ensure competition names are <= 50 characters when visible.