### PR TITLE
Move loading indicator to the top, so it's actually visible when the competitions list is long

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -299,8 +299,12 @@ $venue-map-wrapper-height: 400px;
   background-color: transparentize(white, 0.5);
   .spinner-wrapper {
     position: absolute;
-    top: 10px;
+    top: 30px;
     left: 50%;
-    transform: translate(-50%, 0);
+    transform: translate(-50%, -50%);
   }
+}
+
+.competitions-map #loading .spinner-wrapper {
+  top: 50%;
 }

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -299,8 +299,8 @@ $venue-map-wrapper-height: 400px;
   background-color: transparentize(white, 0.5);
   .spinner-wrapper {
     position: absolute;
-    top: 50%;
+    top: 10px;
     left: 50%;
-    transform: translate(-50%, -50%);
+    transform: translate(-50%, 0);
   }
 }

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -188,6 +188,37 @@ $venue-map-wrapper-height: 400px;
 
 #search-results {
   position: relative;
+
+  #loading {
+    display: none;
+    position: absolute;
+    margin: 0 15px;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 10;
+    background-color: transparentize(white, 0.5);
+    .spinner-wrapper {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+  }
+
+  &.competitions-list #loading .spinner-wrapper {
+    top: 30px;
+  }
+
+  &.competitions-list #competitions-map {
+    display: none;
+  }
+
+  &.competitions-map #competitions-list {
+    display: none;
+  }
+
   #competitions-list {
 
     li:nth-child(odd) {
@@ -285,26 +316,4 @@ $venue-map-wrapper-height: 400px;
   height: 40px;
   margin-top: -40px;
   visibility: hidden;
-}
-
-#loading {
-  display: none;
-  position: absolute;
-  margin: 0 15px;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 10;
-  background-color: transparentize(white, 0.5);
-  .spinner-wrapper {
-    position: absolute;
-    top: 30px;
-    left: 50%;
-    transform: translate(-50%, -50%);
-  }
-}
-
-.competitions-map #loading .spinner-wrapper {
-  top: 50%;
 }

--- a/WcaOnRails/app/views/competitions/index.html.erb
+++ b/WcaOnRails/app/views/competitions/index.html.erb
@@ -8,7 +8,7 @@
     <%= render 'index_form' %>
   <% end %>
 
-  <div id="search-results" class="row">
+  <div id="search-results" class="row competitions-<%= params[:display] == "list" ? "list" : "map" %>">
     <div id="loading">
       <div class="spinner-wrapper"><i class="fa fa-spinner fa-spin fa-5x"></i></div>
     </div>
@@ -20,7 +20,3 @@
     </div>
   </div>
 </div>
-
-<script>
-  $('#competitions-<%= params[:display] == "list" ? "map" : "list" %>').hide();
-</script>

--- a/WcaOnRails/app/views/competitions/index.js.erb
+++ b/WcaOnRails/app/views/competitions/index.js.erb
@@ -2,10 +2,5 @@ history.pushState(null, document.title, <%= current_url.to_json.html_safe %>);
 
 $('#competitions-list').html('<%=j render 'index_competitions_list', competitions: @competitions %>');
 
-<% if params[:display] == "list" %>
-  $('#competitions-map').hide();
-  $('#competitions-list').show();
-<% else %>
-  $('#competitions-list').hide();
-  $('#competitions-map').show();
-<% end %>
+$('#search-results').removeClass('competitions-list').removeClass('competitions-map');
+$('#search-results').addClass('competitions-<%= params[:display] == "list" ? "list" : "map" %>');


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/277474/14930406/9796a6ea-0e18-11e6-9f78-231981eaf979.png)

After:

![image](https://cloud.githubusercontent.com/assets/277474/14930531/66f21d02-0e19-11e6-97c4-79d0566ed349.png)

@jonatanklosko, could you take a quick look? Thanks!