### PR TITLE
Fix order of some podium results

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -487,6 +487,7 @@ class Competition < ActiveRecord::Base
       results
         .where(roundId: Round.final_rounds.map(&:id))
         .where("pos >= 1 AND pos <= 3")
+        .order("pos")
     ).group_by(&:event)
       .sort_by { |event, _results| event.rank }
   end


### PR DESCRIPTION
Turns out we didn't order the results at all. This fixes #553.