### PR TITLE
Team page improvements

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/teams.scss
+++ b/WcaOnRails/app/assets/stylesheets/teams.scss
@@ -1,16 +1,43 @@
-.members {
-  border-top: 1px solid $gray;
-  padding-top: 2px;
+table.team-members {
+  tr {
+    th {
+      text-align: center;
+    }
 
-  input.date_picker.form-control {
-    width: 120px;
+    td {
+      vertical-align: middle;
+      &.team-leader {
+        text-align: center;
+      }
+    }
   }
 
-  div.selectize-control {
-    width: 280px;
+  .member {
+    &.past-member {
+      background-color: $past-member-color;
+    }
+
+    .form-group {
+      margin: 0;
+    }
+
+    input.date_picker.form-control {
+      width: 120px;
+      position: static;
+    }
+
+    div.selectize-control {
+      width: 300px;
+    }
   }
 }
 
-.past-member {
-  background-color: $past-member-color;
+// Prevent .table-responsive from hiding a DataTimePicker when it overflows.
+.team-members-wrapper .table-responsive {
+  overflow-x: visible;
+}
+
+.form-actions {
+  text-align: center;
+  margin-top: 15px;
 }

--- a/WcaOnRails/app/assets/stylesheets/teams.scss
+++ b/WcaOnRails/app/assets/stylesheets/teams.scss
@@ -41,3 +41,13 @@ table.team-members {
   text-align: center;
   margin-top: 15px;
 }
+
+.new-team {
+  text-align: center;
+}
+
+table.teams-table {
+  tr td {
+    vertical-align: middle;
+  }
+}

--- a/WcaOnRails/app/assets/stylesheets/teams.scss
+++ b/WcaOnRails/app/assets/stylesheets/teams.scss
@@ -23,7 +23,6 @@ table.team-members {
 
     input.date_picker.form-control {
       width: 120px;
-      position: static;
     }
 
     div.selectize-control {

--- a/WcaOnRails/app/models/team.rb
+++ b/WcaOnRails/app/models/team.rb
@@ -6,7 +6,7 @@ class Team < ActiveRecord::Base
 
   validate :membership_periods_cannot_overlap_for_single_user
   def membership_periods_cannot_overlap_for_single_user
-    team_members.group_by(&:user).each do |user, memberships|
+    team_members.select(&:valid?).group_by(&:user).each do |user, memberships|
       memberships.combination(2).to_a.each do |memberships_pair|
         first, second = memberships_pair
         first_period = first.start_date..(first.end_date || Date::Infinity.new)

--- a/WcaOnRails/app/models/team_member.rb
+++ b/WcaOnRails/app/models/team_member.rb
@@ -12,7 +12,7 @@ class TeamMember < ActiveRecord::Base
 
   validate :start_date_must_be_earlier_than_end_date
   def start_date_must_be_earlier_than_end_date
-    if end_date != nil && start_date >= end_date
+    if start_date && end_date && start_date >= end_date
       errors.add(:start_date, "must be earlier than end_date")
     end
   end

--- a/WcaOnRails/app/views/teams/_team_member_fields.html.erb
+++ b/WcaOnRails/app/views/teams/_team_member_fields.html.erb
@@ -1,6 +1,7 @@
-<div class="members">
-  <%= f.input :user_id, required: true, as: :user_ids, only_one: true %>
-  <%= f.input :start_date, as: :date_picker, required: true %>
-  <%= f.input :end_date, as: :date_picker %>
-  <%= f.input :team_leader %>
-</div>
+<tr class="member <%= f.object.current_member? ? '' : 'past-member'%>">
+  <td><%= f.input :user_id, required: true, as: :user_ids, only_one: true, label: false %></td>
+  <td><%= f.input :start_date, as: :date_picker, required: true, label: false %></td>
+  <td><%= f.input :end_date, as: :date_picker, label: false %></td>
+  <td class="team-leader"><%= f.input :team_leader, label: false %></td>
+  <td></td> <!-- Extra column for .table-greedy-last-column -->
+</tr>

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -1,7 +1,6 @@
 <% provide(:title, "Editing team #{@team.friendly_id}") %>
 
 <div class="container">
-
   <h3><%= yield(:title) %></h3>
 
   <%= simple_form_for @team, html: { class: 'form-horizontal are-you-sure no-submit-on-enter' }, wrapper: :horizontal_form,
@@ -17,38 +16,46 @@
     <%= f.input :name %>
     <%= f.input :description %>
 
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        Members
-      </div>
-      <div class="panel-body form-inline">
-        <%= f.simple_fields_for :team_members do |t| %>
-          <div class="members <%= t.object.current_member? ? '' : 'past-member'%>">
-            <%= t.input :user_id, required: true, as: :user_ids, only_one: true %>
-            <%= t.input :start_date, as: :date_picker, required: true %>
-            <%= t.input :end_date, as: :date_picker %>
-            <%= t.input :team_leader %>
-          </div>
+      <div class="team-members-wrapper">
+        <h3>Members</h3>
+        <%= wca_table table_class: "team-members", hover: false, striped: false do %>
+          <thead>
+            <tr>
+              <th>User</th>
+              <th>Start date</th>
+              <th>End date</th>
+              <th>Team leader</th>
+              <th></th> <!-- Extra column for .table-greedy-last-column -->
+            </tr>
+          </thead>
+          <tbody>
+          <% # We need to use `sort_by` instead of `order` to keep the new builded, unsaved objects.
+             team_members = @team.team_members.sort_by do |m|
+               # We call `to_s` on the dates to avoid an exception when one of them is nil.
+               [(m.end_date.nil? ? 1 : 0), m.end_date.to_s, m.start_date.to_s]
+             end.reverse!
+          %>
+          <%= f.simple_fields_for :team_members, team_members do |t| %>
+            <%= render "team_member_fields", f: t %>
+          <% end %>
+          </tbody>
         <% end %>
 
         <div class="links">
-          <%= link_to_add_association button_tag('Add member', type: "button", class: "btn btn-primary add"), f, :team_members %>
+          <%= link_to_add_association button_tag(icon("plus", "Add member"), type: "button", class: "btn btn-primary add"), f, :team_members,
+                                      data: { association_insertion_node: '.team-members:not(.floatThead-table)', association_insertion_method: 'append' } %>
         </div>
       </div>
-    </div>
 
-    <div class="form-group">
-      <div class="col-sm-offset-2 col-sm-10">
-        <%= f.button :submit, class: "btn-primary" %>
-      </div>
+    <div class="form-group form-actions">
+      <%= link_to icon("undo", "Back to Teams"), teams_path, class: "btn btn-default teams-home" %>
+      <%= f.button :submit, class: "btn btn-primary" %>
     </div>
   <% end %>
-  <%= link_to 'Back to Teams', teams_path, class: "teams-home" %>
-
 </div>
 
 <script>
-$(".panel-body").on('cocoon:after-insert', function() {
+$(".team-members-wrapper").on('cocoon:after-insert', function() {
   $('input.wca-autocomplete').wcaAutocomplete();
 
   wca.datetimepicker();

--- a/WcaOnRails/app/views/teams/index.html.erb
+++ b/WcaOnRails/app/views/teams/index.html.erb
@@ -32,7 +32,7 @@
     </div>
   <% end %>
 
-  <% if current_user.can_edit_users? %>
+  <% if current_user.can_manage_teams? %>
     <%= link_to icon("plus", "New team"), new_team_path, class: "btn btn-primary" %>
   <% end %>
 </div>

--- a/WcaOnRails/app/views/teams/index.html.erb
+++ b/WcaOnRails/app/views/teams/index.html.erb
@@ -3,35 +3,36 @@
 <div class="container">
   <h1><%= yield(:title) %></h1>
 
-  <% can_edit = current_user.can_edit_users? %>
-  <% if can_edit %>
-    <%= link_to "New team", new_team_path %>
-  <% end %>
-
   <% if @teams.empty? %>
     <div class="alert alert-warning">There are currently no teams.</div>
   <% else %>
-    <table class="table">
-      <tr>
-        <th>ID</th>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Members</th>
-        <th>Leader(s)</th>
-        <th></th>
-      </tr>
-      <% @teams.each do |team| %>
+    <div class="table-responsive">
+      <table class="table teams-table">
         <tr>
-          <td><%= team.friendly_id %></td>
-          <td><%= team.name %></td>
-          <td><%= team.description %></td>
-          <td><%= team.current_members.map { |member| member.user.name }.to_sentence %></td>
-          <td>
-            <%= team.current_members.where(team_leader: true).map { |leader| leader.user.name }.sort.to_sentence %>
-          </td>
-          <td><%= link_to "Manage team", edit_team_path(team) %></td>
+          <th>ID</th>
+          <th>Name</th>
+          <th>Description</th>
+          <th>Members</th>
+          <th>Leader(s)</th>
+          <th></th>
         </tr>
-      <% end %>
-    </table>
+        <% @teams.each do |team| %>
+          <tr>
+            <td><%= team.friendly_id %></td>
+            <td><%= team.name %></td>
+            <td><%= team.description %></td>
+            <td><%= team.current_members.map { |member| member.user.name }.to_sentence %></td>
+            <td>
+              <%= team.current_members.where(team_leader: true).map { |leader| leader.user.name }.sort.to_sentence %>
+            </td>
+            <td><%= link_to icon("pencil-square-o", "Manage"), edit_team_path(team), class: "btn btn-success" %></td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
+  <% end %>
+
+  <% if current_user.can_edit_users? %>
+    <%= link_to icon("plus", "New team"), new_team_path, class: "btn btn-primary" %>
   <% end %>
 </div>

--- a/WcaOnRails/app/views/teams/new.html.erb
+++ b/WcaOnRails/app/views/teams/new.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, 'Create team') %>
 
 <div class="container new-team">
-  <h1><%= yield(:title) %></h1>
+  <h1>Create a new team</h1>
 
   <%= simple_form_for @team, html: { class: 'form-horizontal are-you-sure no-submit-on-enter' }, wrapper: :horizontal_form do |f| %>
     <%= f.input :name, required: true %>

--- a/WcaOnRails/app/views/teams/new.html.erb
+++ b/WcaOnRails/app/views/teams/new.html.erb
@@ -1,11 +1,12 @@
 <% provide(:title, 'Create team') %>
 
-<div class="container">
+<div class="container new-team">
   <h1><%= yield(:title) %></h1>
 
   <%= simple_form_for @team, html: { class: 'form-horizontal are-you-sure no-submit-on-enter' }, wrapper: :horizontal_form do |f| %>
     <%= f.input :name, required: true %>
 
+    <%= link_to icon("undo", "Back to Teams"), teams_path, class: "btn btn-default teams-home" %>
     <button type="submit" class="btn btn-success">Create team</button>
   <% end %>
 </div>

--- a/WcaOnRails/spec/controllers/teams_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/teams_controller_spec.rb
@@ -185,19 +185,17 @@ describe TeamsController do
         expect(invalid_team).to be_invalid
       end
 
-      it 'does not see an exception when tries to add another membership for the same user without start_date' do
+      it 'cannot add another membership for the same user without start_date' do
         member = FactoryGirl.create :user
-        expect do
-          patch :update, id: team, team: { team_members_attributes: { "0" => { user_id: member.id, start_date: Date.today+10, end_date: Date.today+5 },
-                                                                      "1" => { user_id: member.id, start_date: nil, end_date: Date.today+10 } } }
-        end.to_not raise_error
+        patch :update, id: team, team: { team_members_attributes: { "0" => { user_id: member.id, start_date: Date.today+10, end_date: Date.today+5 },
+                                                                    "1" => { user_id: member.id, start_date: nil, end_date: Date.today+10 } } }
+        expect(team.reload.team_members.count).to eq 0
       end
 
-      it 'does not see an exception when tries to add a member with end_date but without the start_date' do
+      it 'cannot add a membership with end_date but without start_date' do
         member = FactoryGirl.create :user
-        expect do
-          patch :update, id: team, team: { team_members_attributes: { "0" => { user_id: member.id, start_date: nil, end_date: Date.today+5 } } }
-        end.to_not raise_error
+        patch :update, id: team, team: { team_members_attributes: { "0" => { user_id: member.id, start_date: nil, end_date: Date.today+5 } } }
+        expect(team.reload.team_members.count).to eq 0
       end
     end
   end

--- a/WcaOnRails/spec/controllers/teams_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/teams_controller_spec.rb
@@ -180,9 +180,24 @@ describe TeamsController do
       it 'cannot add overlapping membership periods for the same user'do
         member = FactoryGirl.create :user
         patch :update, id: team, team: { team_members_attributes: {"0" => { user_id: member.id, start_date: Date.today, end_date: Date.today+10, team_leader: false },
-                                                                   "1" => { user_id: member.id, start_date: Date.today+9, end_date: Date.today+20, team_leader: false }} }
+                                                                   "1" => { user_id: member.id, start_date: Date.today+9, end_date: Date.today+20, team_leader: false } } }
         invalid_team = assigns(:team)
         expect(invalid_team).to be_invalid
+      end
+
+      it 'does not see an exception when tries to add another membership for the same user without start_date' do
+        member = FactoryGirl.create :user
+        expect do
+          patch :update, id: team, team: { team_members_attributes: { "0" => { user_id: member.id, start_date: Date.today+10, end_date: Date.today+5 },
+                                                                      "1" => { user_id: member.id, start_date: nil, end_date: Date.today+10 } } }
+        end.to_not raise_error
+      end
+
+      it 'does not see an exception when tries to add a member with end_date but without the start_date' do
+        member = FactoryGirl.create :user
+        expect do
+          patch :update, id: team, team: { team_members_attributes: { "0" => { user_id: member.id, start_date: nil, end_date: Date.today+5 } } }
+        end.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
This changes the team pages interface.

- Team members section on the team edit page:
    - Uses `wca_table`
    - Sorts team members by `end_date` (and by `start_date` if `end_date`s are equal)

    ![image](https://cloud.githubusercontent.com/assets/17034772/14936625/c2a25ca6-0ef1-11e6-9bce-061938833cc1.png)

- New team page:

    ![image](https://cloud.githubusercontent.com/assets/17034772/14936601/3b9c770a-0ef1-11e6-976a-c9f6772e2bf2.png)

- Teams intex page:

    ![image](https://cloud.githubusercontent.com/assets/17034772/14936603/4904ed00-0ef1-11e6-9abb-04433ce7f544.png)