### PR TITLE
Remove the trailing whitespace after event icon

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -30,6 +30,10 @@ $competition-nav-padding: 50px;
     .list-group-item a.active {
       color: $list-group-active-bg;
     }
+
+    .list-group-item a:hover {
+      text-decoration: none;
+    }
   }
 }
 


### PR DESCRIPTION
This removes the ugly trailing whitespace in html link containing icons, such as in the navigation bar of the competition page.

Here is the visual diff (before/after) : 
![diff](https://cloud.githubusercontent.com/assets/1007485/14990714/26c58fd2-115e-11e6-9cfb-a395c6624136.png)

Here is the generated html diff : 
Before :
```
                <span class="list-group-item">
                    <a title="" class="" data-toggle="tooltip" data-placement="top" data-container="body" href="http://localhost:3000/competitions/My107Comp2015/results/all#e333" data-original-title="Rubik&#39;s Cube">
                                <span class="cubing-icon fa-fw icon-333"></span>

</a>                    <a title="" class="" data-toggle="tooltip" data-placement="top" data-container="body" href="http://localhost:3000/competitions/My107Comp2015/results/all#e333oh" data-original-title="Rubik&#39;s Cube: One-handed">
                                <span class="cubing-icon fa-fw icon-333oh"></span>

</a>                    <a title="" class="" data-toggle="tooltip" data-placement="top" data-container="body" href="http://localhost:3000/competitions/My107Comp2015/results/all#emagic" data-original-title="Rubik&#39;s Magic">
                                <span class="cubing-icon fa-fw icon-magic"></span>

</a>                </span>
```

After :
```
                <span class="list-group-item">
                    <a title="" class="" data-toggle="tooltip" data-placement="top" data-container="body" href="http://localhost:3000/competitions/My107Comp2015/results/all#e333" data-original-title="Rubik&#39;s Cube"><span class="cubing-icon fa-fw icon-333"></span></a>
                    <a title="" class="" data-toggle="tooltip" data-placement="top" data-container="body" href="http://localhost:3000/competitions/My107Comp2015/results/all#e333oh" data-original-title="Rubik&#39;s Cube: One-handed"><span class="cubing-icon fa-fw icon-333oh"></span></a>
                    <a title="" class="" data-toggle="tooltip" data-placement="top" data-container="body" href="http://localhost:3000/competitions/My107Comp2015/results/all#emagic" data-original-title="Rubik&#39;s Magic"><span class="cubing-icon fa-fw icon-magic"></span></a>
                </span>
```

The `.concat` is not needed but it makes the generated html "nicer".