### PR TITLE
Sign up polish

### DIFF
--- a/WcaOnRails/.rubocop.yml
+++ b/WcaOnRails/.rubocop.yml
@@ -26,3 +26,9 @@ Style/GuardClause:
 
 Metrics/ClassLength:
   Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Max: 23
+
+Metrics/PerceivedComplexity:
+  Max: 23

--- a/WcaOnRails/.rubocop_todo.yml
+++ b/WcaOnRails/.rubocop_todo.yml
@@ -94,10 +94,6 @@ Metrics/BlockNesting:
 Metrics/ClassLength:
   Max: 1853
 
-# Offense count: 19
-Metrics/CyclomaticComplexity:
-  Max: 18
-
 # Offense count: 864
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes.
 # URISchemes: http, https
@@ -113,10 +109,6 @@ Metrics/MethodLength:
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
   Max: 153
-
-# Offense count: 17
-Metrics/PerceivedComplexity:
-  Max: 20
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -85,6 +85,10 @@ class User < ActiveRecord::Base
   end
 
   attr_accessor :claiming_wca_id
+  def claiming_wca_id=(claiming_wca_id)
+    @claiming_wca_id = ActiveRecord::Type::Boolean.new.type_cast_from_database(claiming_wca_id)
+  end
+
   before_validation :maybe_clear_claimed_wca_id
   def maybe_clear_claimed_wca_id
     if !claiming_wca_id && unconfirmed_wca_id_was.present?
@@ -100,14 +104,7 @@ class User < ActiveRecord::Base
 
   validate :claim_wca_id_validations
   def claim_wca_id_validations
-    if unconfirmed_wca_id.present? && !delegate_id_to_handle_wca_id_claim.present?
-      errors.add(:delegate_id_to_handle_wca_id_claim, "required")
-    end
-
-    if !unconfirmed_wca_id.present? && delegate_id_to_handle_wca_id_claim.present?
-      errors.add(:unconfirmed_wca_id, "required")
-    end
-
+    already_assigned_to_user = false
     if unconfirmed_wca_id.present?
       already_assigned_to_user = unconfirmed_person && unconfirmed_person.user && !unconfirmed_person.user.dummy_account?
       if !unconfirmed_person
@@ -115,26 +112,34 @@ class User < ActiveRecord::Base
       elsif already_assigned_to_user
         errors.add(:unconfirmed_wca_id, "already assigned to a different user")
       end
-
-      if claiming_wca_id
-        dob_verification_date = Date.safe_parse(dob_verification, nil)
-        if unconfirmed_person
-          if !unconfirmed_person.dob
-            errors.add(:dob_verification, "WCA ID does not have a birthdate. Contact the Results team to resolve this.")
-          elsif !already_assigned_to_user && unconfirmed_person.dob != dob_verification_date
-            # Note that we don't verify DOB for WCA IDs that have already been
-            # claimed. This protects people from DOB guessing attacks.
-            errors.add(:dob_verification, "incorrect")
-          end
-        end
-        if person
-          errors.add(:unconfirmed_wca_id, "cannot claim a WCA ID because you already have WCA ID #{wca_id}")
-        end
-      end
     end
 
-    if delegate_id_to_handle_wca_id_claim.present? && !delegate_to_handle_wca_id_claim
-      errors.add(:delegate_id_to_handle_wca_id_claim, "not found")
+    if claiming_wca_id
+      if !delegate_id_to_handle_wca_id_claim.present?
+        errors.add(:delegate_id_to_handle_wca_id_claim, "required")
+      end
+
+      if !unconfirmed_wca_id.present?
+        errors.add(:unconfirmed_wca_id, "required")
+      end
+
+      dob_verification_date = Date.safe_parse(dob_verification, nil)
+      if unconfirmed_person
+        if !unconfirmed_person.dob
+          errors.add(:dob_verification, "WCA ID does not have a birthdate. Contact the Results team to resolve this.")
+        elsif !already_assigned_to_user && unconfirmed_person.dob != dob_verification_date
+          # Note that we don't verify DOB for WCA IDs that have already been
+          # claimed. This protects people from DOB guessing attacks.
+          errors.add(:dob_verification, "incorrect")
+        end
+      end
+      if person
+        errors.add(:unconfirmed_wca_id, "cannot claim a WCA ID because you already have WCA ID #{wca_id}")
+      end
+
+      if delegate_id_to_handle_wca_id_claim.present? && !delegate_to_handle_wca_id_claim
+        errors.add(:delegate_id_to_handle_wca_id_claim, "not found")
+      end
     end
   end
 

--- a/WcaOnRails/app/views/devise/registrations/new.html.erb
+++ b/WcaOnRails/app/views/devise/registrations/new.html.erb
@@ -72,6 +72,18 @@
       $('input[type="submit"]').attr('disabled', false);
     });
 
+    $('.tab-pane').find("input").attr("disabled", true);
+    $('.nav-tabs').on('hidden.bs.tab', function(e) {
+      var $hiddenPanel = $("#" + $(e.target).attr("aria-controls"));
+      // Disable all <input>s in the just hidden panel.
+      $hiddenPanel.find("input").attr("disabled", true);
+    });
+    $('.nav-tabs').on('shown.bs.tab', function(e) {
+      var $shownPanel = $("#" + $(e.target).attr("aria-controls"));
+      // Enable all <input>s in the just shown panel.
+      $shownPanel.find("input").attr("disabled", false);
+    });
+
     var $haveCompetedLink = $('#have-you-competed-nav a[href="#have-competed"]');
     if($claiming_wca_id.val() === "true") {
       $haveCompetedLink.tab('show');

--- a/WcaOnRails/spec/controllers/notifications_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/notifications_controller_spec.rb
@@ -48,10 +48,10 @@ RSpec.describe NotificationsController, type: :controller do
       it "shows WCA ID claims for confirmed accounts, but not for unconfirmed accounts" do
         person = FactoryGirl.create :person
         user = FactoryGirl.create :user
-        user.update_attributes!(unconfirmed_wca_id: person.id, delegate_to_handle_wca_id_claim: delegate)
+        user.update_attributes!(unconfirmed_wca_id: person.id, delegate_to_handle_wca_id_claim: delegate, dob_verification: person.dob)
 
         unconfirmed_user = FactoryGirl.create :user, :unconfirmed
-        unconfirmed_user.update_attributes!(unconfirmed_wca_id: person.id, delegate_to_handle_wca_id_claim: delegate)
+        unconfirmed_user.update_attributes!(unconfirmed_wca_id: person.id, delegate_to_handle_wca_id_claim: delegate, dob_verification: person.dob)
 
         get :index
         notifications = assigns(:notifications)
@@ -135,6 +135,7 @@ RSpec.describe NotificationsController, type: :controller do
           delegate = FactoryGirl.create :delegate
           user.unconfirmed_wca_id = person.id
           user.delegate_to_handle_wca_id_claim = delegate
+          user.dob_verification = person.dob
           user.save!
 
           get :index

--- a/WcaOnRails/spec/controllers/users_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/users_controller_spec.rb
@@ -57,7 +57,7 @@ describe UsersController do
   describe "approve wca id claim" do
     let(:delegate) { FactoryGirl.create(:delegate) }
     let(:person) { FactoryGirl.create(:person) }
-    let(:user) { FactoryGirl.create :user, unconfirmed_wca_id: person.id, delegate_to_handle_wca_id_claim: delegate }
+    let(:user) { FactoryGirl.create :user, unconfirmed_wca_id: person.id, delegate_to_handle_wca_id_claim: delegate, dob_verification: person.dob }
 
     before :each do
       sign_in delegate

--- a/WcaOnRails/spec/features/sign_up_spec.rb
+++ b/WcaOnRails/spec/features/sign_up_spec.rb
@@ -128,7 +128,6 @@ RSpec.feature "Sign up" do
       fill_in "user[password]", with: "wca"
       fill_in "user[password_confirmation]", with: "wca"
 
-
       click_on "I have competed in a WCA competition."
       selectize_input = page.find("div.user_unconfirmed_wca_id .selectize-control input")
       selectize_input.native.send_key(person.wca_id)
@@ -146,7 +145,6 @@ RSpec.feature "Sign up" do
       choose("user_delegate_id_to_handle_wca_id_claim_#{delegate.id}")
       # Now enter the wrong birthdate.
       fill_in "Birthdate", with: "1900-02-03"
-
 
       # We just filled some invalid information as if we were a returning competitor, but
       # now change our minds and fill out the form as if we're a noobie. We should only show

--- a/WcaOnRails/spec/mailers/wca_id_claim_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/wca_id_claim_mailer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe WcaIdClaimMailer, type: :mailer do
   describe "notify_board_of_confirmed_competition" do
     let(:delegate) { FactoryGirl.create :delegate }
     let(:person) { FactoryGirl.create :person }
-    let(:user_claiming_wca_id) { FactoryGirl.create :user, unconfirmed_wca_id: person.id, delegate_to_handle_wca_id_claim: delegate }
+    let(:user_claiming_wca_id) { FactoryGirl.create :user, unconfirmed_wca_id: person.id, delegate_to_handle_wca_id_claim: delegate, dob_verification: person.dob }
     let(:mail) { WcaIdClaimMailer.notify_delegate_of_wca_id_claim(user_claiming_wca_id) }
 
     it "renders" do

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -328,9 +328,19 @@ RSpec.describe User, type: :model do
       expect(user).to be_valid
     end
 
-    it "requires unconfirmed_wca_id" do
+    it "requires fields when claiming_wca_id" do
       user.unconfirmed_wca_id = nil
+      user.dob_verification = nil
+      user.delegate_id_to_handle_wca_id_claim = nil
       expect(user).to be_invalid
+      expect(user.errors.messages[:unconfirmed_wca_id]).to eq ['required']
+      expect(user.errors.messages[:delegate_id_to_handle_wca_id_claim]).to eq ['required']
+    end
+
+    it "requires unconfirmed_wca_id" do
+      user.unconfirmed_wca_id = ""
+      expect(user).to be_invalid
+      expect(user.errors.messages[:unconfirmed_wca_id]).to eq ['required']
     end
 
     it "requires dob verification" do
@@ -362,6 +372,7 @@ RSpec.describe User, type: :model do
     it "requires delegate_id_to_handle_wca_id_claim" do
       user.delegate_id_to_handle_wca_id_claim = nil
       expect(user).to be_invalid
+      expect(user.errors.messages[:delegate_id_to_handle_wca_id_claim]).to eq ['required']
     end
 
     it "delegate_id_to_handle_wca_id_claim must be a delegate" do

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -319,13 +319,34 @@ RSpec.describe User, type: :model do
   describe "unconfirmed_wca_id" do
     let(:person) { FactoryGirl.create :person, year: 1990, month: 01, day: 02 }
     let(:delegate) { FactoryGirl.create :delegate }
-    let(:user) { FactoryGirl.create :user, unconfirmed_wca_id: person.id, delegate_id_to_handle_wca_id_claim: delegate.id, claiming_wca_id: true, dob_verification: "1990-01-2" }
+    let(:user) do
+      u = FactoryGirl.create :user
+      u.unconfirmed_wca_id = person.id
+      u.delegate_id_to_handle_wca_id_claim = delegate.id
+      u.claiming_wca_id = true
+      u.dob_verification = "1990-01-2"
+
+      u
+    end
 
     let(:person_without_dob) { FactoryGirl.create :person, year: 0, month: 0, day: 0 }
     let(:user_with_wca_id) { FactoryGirl.create :user_with_wca_id }
 
     it "defines a valid user" do
       expect(user).to be_valid
+
+      # The database object without the unpersisted fields like dob_verification should
+      # also be valid.
+      expect(User.find(user.id)).to be_valid
+    end
+
+    it "doesn't allow user to change unconfirmed_wca_id" do
+      expect(user).to be_valid
+      user.claiming_wca_id = false
+      other_person = FactoryGirl.create :person, year: 1980, month: 02, day: 01
+      user.unconfirmed_wca_id = other_person.wca_id
+      expect(user).to be_invalid
+      expect(user.errors.messages[:dob_verification]).to eq ['incorrect']
     end
 
     it "requires fields when claiming_wca_id" do


### PR DESCRIPTION
Fixes #566 and #567. This was incredibly painful to do. Our user validations have become virtually unreadable (the only way I have any confidence this works is because of all our tests). Furthermore, devise made it painful/impossible to ignore signup fields at the backend, so I opted to write a little bit of javascript to disable input fields that aren't visible. I also wrote phantomjs based tests to make sure that works.

I think there's potential to refactor our user validations in the future.

I'll wait until Friday to merge this up, unless anyone comments before then.