### PR TITLE
Show competition warnings only when it's not visible to the public.

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -70,11 +70,12 @@ class Competition < ActiveRecord::Base
 
   def warnings
     warnings = {}
-    if self.name.length > 32
-      warnings[:name] = "The competition name is too long (maximum is 32 characters)"
-    end
     if !self.showAtAll
       warnings[:invisible] = "This competition is not visible to the public."
+
+      if self.name.length > 32
+        warnings[:name] = "The competition name is longer than 32 characters. We prefer shorter ones and we will be glad if you change it."
+      end
     end
     warnings
   end

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -123,10 +123,16 @@ RSpec.describe Competition do
     expect(competition.errors.messages[:name]).to eq ["is too long (maximum is 50 characters)"]
   end
 
-  it "warns if competition name is greater than 32 characters" do
-    competition = FactoryGirl.build :competition, name: "A really long competition name 2016"
+  it "warns if competition name is greater than 32 characters and it's not publicly visible" do
+    competition = FactoryGirl.build :competition, name: "A really long competition name 2016", showAtAll: false
     expect(competition).to be_valid
-    expect(competition.warnings[:name]).to eq "The competition name is too long (maximum is 32 characters)"
+    expect(competition.warnings[:name]).to eq "The competition name is longer than 32 characters. We prefer shorter ones and we will be glad if you change it."
+  end
+
+  it "does not warn about name greater than 32 when competition is publicly visible" do
+    competition = FactoryGirl.build :competition, name: "A really long competition name 2016", showAtAll: true
+    expect(competition).to be_valid
+    expect(competition.warnings[:name]).to eq nil
   end
 
   it "warns if competition is not visible" do


### PR DESCRIPTION
Fixes #573.