### PR TITLE
Don't construct our own logger, because this just gets in the way when rails adds its own logger.

### DIFF
--- a/WcaOnRails/config/environments/development.rb
+++ b/WcaOnRails/config/environments/development.rb
@@ -52,9 +52,4 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-
-  # http://help.papertrailapp.com/kb/configuration/unicorn/
-  config.logger = Logger.new(STDOUT)
-  config.logger.level = Logger.const_get('DEBUG')
-  config.log_level = :debug
 end


### PR DESCRIPTION
 See
https://github.com/cubing/worldcubeassociation.org/issues/187#issuecomment-217261349
for some investigation.

This logger was added in 9e87d9d603da057cb6b2cbf7bec7d1bf5281d320, when
I probably was thinking that we'd run Unicorn in development mode.
Removing this might break things for people using Vagrant for
development (we might be using Unicorn in development mode there), but
the best solution for that is probably to change our Vagrant setup to
use `bin/rails s`. Or maybe we should just get rid of Vagrant and
dockerize all the things =)

This fixes #187.