### PR TITLE
A divider (<!--break-->) can be used to display a preview for posts

### DIFF
--- a/WcaOnRails/app/models/post.rb
+++ b/WcaOnRails/app/models/post.rb
@@ -5,6 +5,21 @@ class Post < ActiveRecord::Base
   validates :body, presence: true
   validates :slug, presence: true, uniqueness: true
 
+  BREAK_TAG_RE = /<!--\s*break\s*-->/
+
+  def body_full
+    body.sub(BREAK_TAG_RE, "")
+  end
+
+  def body_teaser
+    split = body.split(BREAK_TAG_RE)
+    teaser = split.first
+    if split.length > 1
+      teaser += "\n\n[Read more....](" + Rails.application.routes.url_helpers.post_path(slug) + ")"
+    end
+    teaser
+  end
+
   before_validation :compute_slug
   private def compute_slug
     self.slug = title.parameterize

--- a/WcaOnRails/app/views/posts/_post.html.erb
+++ b/WcaOnRails/app/views/posts/_post.html.erb
@@ -26,6 +26,6 @@
         <em>Announced by <%= post.author.name %> on <%= wca_local_time(post.created_at) %></em>
       <% end %>
     </div>
-    <%=md post.body %>
+    <%=md render_teaser ? post.body_teaser : post.body_full %>
   </div>
 </div>

--- a/WcaOnRails/app/views/posts/index.html.erb
+++ b/WcaOnRails/app/views/posts/index.html.erb
@@ -1,4 +1,4 @@
 <div class="container">
-  <%= render @posts, render_permalink: true %>
+  <%= render @posts, render_permalink: true, render_teaser: true %>
   <%= paginate @posts %>
 </div>

--- a/WcaOnRails/app/views/posts/rss.xml.builder
+++ b/WcaOnRails/app/views/posts/rss.xml.builder
@@ -9,7 +9,7 @@ xml.rss :version => "2.0", "xmlns:dc" => "http://purl.org/dc/elements/1.1/" do
       xml.item do
         xml.title post.title
         xml.description do
-          xml << cdata_section(md(post.body))
+          xml << cdata_section(md(post.body_full))
         end
         xml.pubDate post.created_at.to_s(:rfc822)
         xml.tag! "dc:creator", post.author.name

--- a/WcaOnRails/app/views/posts/show.html.erb
+++ b/WcaOnRails/app/views/posts/show.html.erb
@@ -1,5 +1,5 @@
 <% provide(:title, @post.title) %>
 
 <div class="container">
-  <%= render @post, render_permalink: false %>
+  <%= render @post, render_permalink: false, render_teaser: false %>
 </div>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -79,6 +79,8 @@ en:
         cityName: "Name of the city and state (if applicable) where the competition takes place. Do not include country (e.g., Paris OR San Francisco, California)."
         venueDetails: "Details about the venue (e.g., On the first floor far in the back, follow the signs)."
         information: "Some information text about the competition (e.g., Euro 2006 is open to citizens of the European countries and Israel)."
+      post:
+        body: "Use the &lt;!-- break --&gt; tag to show a preview on the home page. Any post on the home page will show all text before this divider. The actual post will display the full body."
     options:
       registration:
         status:

--- a/WcaOnRails/spec/models/post_spec.rb
+++ b/WcaOnRails/spec/models/post_spec.rb
@@ -8,4 +8,22 @@ describe Post do
   it "delegates crash course post is not world_readable" do
     expect(Post.crash_course_post.world_readable).to be false
   end
+
+  it "displays body teaser and body full when break present" do
+    post = FactoryGirl.build :post, title: "My First Post", slug: "my-first-post", body: "This post has a preview.<!--break--> And some more text."
+    expect(post.body_teaser).to eq "This post has a preview.\n\n[Read more....](/posts/my-first-post)"
+    expect(post.body_full).to eq "This post has a preview. And some more text."
+    post.body = "This post also has a preview.<!-- break --> And then some more text."
+    expect(post.body_teaser).to eq "This post also has a preview.\n\n[Read more....](/posts/my-first-post)"
+    expect(post.body_full).to eq "This post also has a preview. And then some more text."
+    post.body = "This post also has a preview.<!--     break   --> And then some more text."
+    expect(post.body_teaser).to eq "This post also has a preview.\n\n[Read more....](/posts/my-first-post)"
+    expect(post.body_full).to eq "This post also has a preview. And then some more text."
+  end
+
+  it "displays body teaser and body full when break not present" do
+    post = FactoryGirl.build :post, title: "My Second Post", slug: "my-second-post", body: "This post does not have a preview."
+    expect(post.body_teaser).to eq post.body
+    expect(post.body_full).to eq post.body
+  end
 end


### PR DESCRIPTION
Here's my attempt at solving issue #99. Please let me know of any feedback you have.

Here's a screenshot of the home page where the second post listed has a divider tag.
![image](https://cloud.githubusercontent.com/assets/4403168/15076225/f8b139b2-13eb-11e6-8577-66b6f4438852.png)

And here's a screenshot of the full post after the Read more link is clicked:
![image](https://cloud.githubusercontent.com/assets/4403168/15076250/1bc00a3c-13ec-11e6-8a35-91bb1b5a83fd.png)