### PR TITLE
Separate table for registration events

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -69,27 +69,6 @@ $competition-nav-padding: 50px;
   display: inline-block;
 }
 
-.event-checkbox {
-  label {
-    margin-bottom: 0;
-  }
-  input[type=checkbox] {
-    display: none;
-    + span.cubing-icon {
-      color: #ccc;
-    }
-    &:checked + span.cubing-icon {
-      color: black;
-    }
-  }
-
-  &:not(.disabled) {
-    label {
-      cursor: pointer;
-    }
-  }
-}
-
 $venue-map-wrapper-height: 400px;
 #venue-map-wrapper {
   height: $venue-map-wrapper-height;

--- a/WcaOnRails/app/assets/stylesheets/users.scss
+++ b/WcaOnRails/app/assets/stylesheets/users.scss
@@ -28,10 +28,6 @@ input[type="radio"].center-vertically {
   height: 100%;
 }
 
-.user_preferred_event_ids > span {
-  display: block;
-}
-
 #edit-user-tabs .tab-pane {
   border: 0;
 }

--- a/WcaOnRails/app/assets/stylesheets/wca.scss
+++ b/WcaOnRails/app/assets/stylesheets/wca.scss
@@ -298,3 +298,36 @@ table.wca-results {
 textarea {
   resize: none;
 }
+
+// Style for event pickers
+.event-checkbox {
+  label {
+    margin-bottom: 0;
+  }
+  input[type=checkbox] {
+    display: none;
+    + span.cubing-icon {
+      color: #ccc;
+    }
+    &:checked + span.cubing-icon {
+      color: black;
+    }
+  }
+
+  &:not(.disabled) {
+    label {
+      cursor: pointer;
+    }
+  }
+}
+
+// _associated_events_picker.html.erb specyfic styles
+.form-horizontal {
+  label[for="associated_events"] {
+    @extend .col-sm-2, .control-label;
+  }
+
+  #associated_events {
+    @extend .col-sm-9;
+  }
+}

--- a/WcaOnRails/app/assets/stylesheets/wca.scss
+++ b/WcaOnRails/app/assets/stylesheets/wca.scss
@@ -321,13 +321,13 @@ textarea {
   }
 }
 
-// _associated_events_picker.html.erb specyfic styles
+// _associated_events_picker.html.erb specific styles
 .form-horizontal {
-  label[for="associated_events"] {
+  .associated-events-label {
     @extend .col-sm-2, .control-label;
   }
 
-  #associated_events {
+  .associated-events {
     @extend .col-sm-9;
   }
 }

--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -228,17 +228,11 @@ class RegistrationsController < ApplicationController
       :birthday,
       :guests,
       :comments,
-      event_ids: Event.all.map(&:id),
+      registration_events_attributes: [:id, :event_id, :_destroy]
     ]
     if current_user.can_manage_competition?(competition_from_params)
       permitted_params << :status
     end
-    registration_params = params.require(:registration).permit(*permitted_params)
-
-    if registration_params.key?(:event_ids)
-      registration_params[:eventIds] = registration_params[:event_ids].select { |k, v| v == "1" }.keys.join " "
-      registration_params.delete(:event_ids)
-    end
-    registration_params
+    params.require(:registration).permit(*permitted_params)
   end
 end

--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -228,7 +228,7 @@ class RegistrationsController < ApplicationController
       :birthday,
       :guests,
       :comments,
-      registration_events_attributes: [:id, :event_id, :_destroy]
+      registration_events_attributes: [:id, :event_id, :_destroy],
     ]
     if current_user.can_manage_competition?(competition_from_params)
       permitted_params << :status

--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -111,8 +111,7 @@ class UsersController < ApplicationController
 
   private def user_params
     permitted_params = current_user.editable_fields_of_user(user_to_edit).to_a
-    permitted_params.delete :preferred_event_ids
-    permitted_params.push(preferred_event_ids: Event.all_official.map(&:id))
+    permitted_params.push(user_preferred_events_attributes: [:id, :event_id, :_destroy])
 
     user_params = params.require(:user).permit(permitted_params)
     if user_params.key?(:delegate_status) && !User.delegate_status_allows_senior_delegate(user_params[:delegate_status])
@@ -120,9 +119,6 @@ class UsersController < ApplicationController
     end
     if user_params.key?(:wca_id)
       user_params[:wca_id] = user_params[:wca_id].upcase
-    end
-    if user_params.key?(:preferred_event_ids)
-      user_params[:preferred_event_ids] = user_params[:preferred_event_ids].select { |_k, v| v == "1" }.keys
     end
     user_params
   end

--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -110,10 +110,7 @@ class UsersController < ApplicationController
   end
 
   private def user_params
-    permitted_params = current_user.editable_fields_of_user(user_to_edit).to_a
-    permitted_params.push(user_preferred_events_attributes: [:id, :event_id, :_destroy])
-
-    user_params = params.require(:user).permit(permitted_params)
+    user_params = params.require(:user).permit(current_user.editable_fields_of_user(user_to_edit).to_a)
     if user_params.key?(:delegate_status) && !User.delegate_status_allows_senior_delegate(user_params[:delegate_status])
       user_params["senior_delegate_id"] = nil
     end

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -23,7 +23,7 @@ class Registration < ActiveRecord::Base
   end
 
   def events
-    (eventIds || "").split.map { |e| Event.find_by_id(e) }.sort_by &:rank
+    registration_events.map(&:event_object).sort_by(&:rank)
   end
 
   def name
@@ -107,11 +107,6 @@ class Registration < ActiveRecord::Base
     unless invalid_events.empty?
       errors.add(:events, "invalid event ids: #{invalid_events.map(&:id).join(',')}")
     end
-  end
-
-  before_save :normalize_event_ids
-  private def normalize_event_ids
-    self.eventIds = events.map(&:id).join(" ")
   end
 
   before_validation :unpack_dates

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -5,6 +5,10 @@ class Registration < ActiveRecord::Base
 
   belongs_to :competition, foreign_key: "competitionId"
   belongs_to :user
+  has_many :registration_events
+
+  accepts_nested_attributes_for :registration_events, allow_destroy: true
+
   validates :user, presence: true, on: [:create]
 
   validates_numericality_of :guests, greater_than_or_equal_to: 0

--- a/WcaOnRails/app/models/registration_event.rb
+++ b/WcaOnRails/app/models/registration_event.rb
@@ -1,7 +1,7 @@
 class RegistrationEvent < ActiveRecord::Base
   belongs_to :registration
 
-  validates :event_id, inclusion: { in: Event.all_official.map(&:id) }
+  validates :event_id, inclusion: { in: Event.all.map(&:id) }
 
   def event_object
     Event.find(event_id)

--- a/WcaOnRails/app/models/registration_event.rb
+++ b/WcaOnRails/app/models/registration_event.rb
@@ -1,0 +1,9 @@
+class RegistrationEvent < ActiveRecord::Base
+  belongs_to :registration
+
+  validates :event_id, inclusion: { in: Event.all_official.map(&:id) }
+
+  def event_object
+    Event.find(event_id)
+  end
+end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -456,6 +456,7 @@ class User < ActiveRecord::Base
       fields << :password << :password_confirmation
       fields << :email
       fields << :preferred_events
+      fields << { user_preferred_events_attributes: [:id, :event_id, :_destroy] }
     end
     if admin? || board_member?
       fields << :delegate_status

--- a/WcaOnRails/app/views/registrations/edit.html.erb
+++ b/WcaOnRails/app/views/registrations/edit.html.erb
@@ -31,7 +31,7 @@
       <%= f.input :countryId, collection: Country.all_real, value_method: :id, label_method: :name %>
     <% end %>
 
-    <%= f.input :event_ids, as: :events_picker, allowed_events: @competition.events, selected_events: @registration.events %>
+    <%= render "shared/associated_events_picker", form_builder: f, events_association_name: :registration_events, allowed_events: @competition.events, selected_events: @registration.events %>
 
     <% if @competition.guests_enabled? %>
       <%= f.input :guests %>

--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -86,7 +86,8 @@
         }  do |f| %>
 
           <% selected_events = @registration.events.empty? ? @registration.user.preferred_events : @registration.events %>
-          <%= f.input :event_ids, as: :events_picker, allowed_events: @competition.events, selected_events: selected_events, disabled: !current_user.can_edit_registration?(@registration) %>
+          <%= render "shared/associated_events_picker", form_builder: f, disabled: !current_user.can_edit_registration?(@registration),
+                      events_association_name: :registration_events, allowed_events: @competition.events, selected_events: selected_events %>
 
           <% if @competition.guests_enabled? %>
             <%= f.input :guests, disabled: !current_user.can_edit_registration?(@registration) %>

--- a/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
+++ b/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
@@ -1,0 +1,28 @@
+<%#
+Variables:
+ - form_builder
+ - label
+ - events_association_name -> name of the associated events relation
+ - selected_events -> an Array of Event objects that whould be marked as selected
+%>
+
+<%# Note: form_builder.object is the object having associated events. %>
+<% associated_events = form_builder.object.send(events_association_name)
+   all_events = Event.all_official.map do |event|
+     associated_events.find_by_event_id(event.id) || associated_events.build(event_id: event.id)
+   end %>
+
+<%= label_tag "associated_events", label %>
+<div id="associated_events">
+  <%= form_builder.simple_fields_for events_association_name, all_events do |f| %>
+    <span class="event-checkbox">
+      <% event = f.object.event_object %>
+      <%= f.hidden_field :event_id %>
+      <%= label_tag "checkbox-#{event.id}" do %>
+        <%= f.check_box "_destroy", { checked: selected_events.include?(event), id: "checkbox-#{event.id}" }, "0", "1" %>
+        <%= content_tag(:span, "", class: "cubing-icon icon-#{event.id}", data: { toggle: "tooltip", placement: "top" }, title: event.name ) %>
+      <% end %>
+      <%= f.hidden_field :id %>
+    </span>
+  <% end %>
+</div>

--- a/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
+++ b/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
@@ -2,27 +2,35 @@
 Variables:
  - form_builder
  - label
+ - disabled
  - events_association_name -> name of the associated events relation
+ - allowed_events -> an Array of Event objects that should be shown (all by default)
  - selected_events -> an Array of Event objects that whould be marked as selected
 %>
 
+<% label ||= "Events" %>
+<% disabled ||= false %>
+<% allowed_events ||= Event.all_official %>
+
 <%# Note: form_builder.object is the object having associated events. %>
 <% associated_events = form_builder.object.send(events_association_name)
-   all_events = Event.all_official.map do |event|
+   all_events = allowed_events.map do |event|
      associated_events.find_by_event_id(event.id) || associated_events.build(event_id: event.id)
    end %>
 
-<%= label_tag "associated_events", label %>
-<div id="associated_events">
-  <%= form_builder.simple_fields_for events_association_name, all_events do |f| %>
-    <span class="event-checkbox">
-      <% event = f.object.event_object %>
-      <%= f.hidden_field :event_id %>
-      <%= label_tag "checkbox-#{event.id}" do %>
-        <%= f.check_box "_destroy", { checked: selected_events.include?(event), id: "checkbox-#{event.id}" }, "0", "1" %>
-        <%= content_tag(:span, "", class: "cubing-icon icon-#{event.id}", data: { toggle: "tooltip", placement: "top" }, title: event.name ) %>
-      <% end %>
-      <%= f.hidden_field :id %>
-    </span>
-  <% end %>
+<div class="form-group">
+  <%= label_tag "associated_events", label %>
+  <div id="associated_events">
+    <%= form_builder.simple_fields_for events_association_name, all_events do |f| %>
+      <span class="event-checkbox <%= "disabled" if disabled %>">
+        <% event = f.object.event_object %>
+        <%= f.hidden_field :event_id %>
+        <%= label_tag "checkbox-#{event.id}" do %>
+          <%= f.check_box "_destroy", { checked: selected_events.include?(event), id: "checkbox-#{event.id}", disabled: disabled }, "0", "1" %>
+          <%= content_tag(:span, "", class: "cubing-icon icon-#{event.id}", data: { toggle: "tooltip", placement: "top" }, title: event.name ) %>
+        <% end %>
+        <%= f.hidden_field :id %>
+      </span>
+    <% end %>
+  </div>
 </div>

--- a/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
+++ b/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
@@ -19,8 +19,8 @@ Variables:
    end %>
 
 <div class="form-group">
-  <%= label_tag "associated_events", label %>
-  <div id="associated_events">
+  <%= label_tag events_association_name, label, class: "associated-events-label" %>
+  <div id="<%= events_association_name %>" class="associated-events">
     <%= form_builder.simple_fields_for events_association_name, all_events do |f| %>
       <span class="event-checkbox <%= "disabled" if disabled %>">
         <% event = f.object.event_object %>

--- a/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
+++ b/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
@@ -25,8 +25,8 @@ Variables:
       <span class="event-checkbox <%= "disabled" if disabled %>">
         <% event = f.object.event_object %>
         <%= f.hidden_field :event_id %>
-        <%= label_tag "checkbox-#{event.id}" do %>
-          <%= f.check_box "_destroy", { checked: selected_events.include?(event), id: "checkbox-#{event.id}", disabled: disabled }, "0", "1" %>
+        <%= label_tag "#{events_association_name}_#{event.id}" do %>
+          <%= f.check_box "_destroy", { checked: selected_events.include?(event), id: "#{events_association_name}_#{event.id}", disabled: disabled }, "0", "1" %>
           <%= content_tag(:span, "", class: "cubing-icon icon-#{event.id}", data: { toggle: "tooltip", placement: "top" }, title: event.name ) %>
         <% end %>
         <%= f.hidden_field :id %>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -187,11 +187,9 @@
         <%= simple_form_for @user do |f| %>
           <%= hidden_field_tag "section", "preferences" %>
 
-          <% if editable_fields.include?(:preferred_events) %>
-            <%= render "shared/associated_events_picker", form_builder: f, label: "Preferred events",
-                                                          events_association_name: :user_preferred_events, selected_events: @user.preferred_events %>
-            <span class="help-block">Selecting your preferred events makes registration for competitions quicker.</span>
-          <% end %>
+          <%= render "shared/associated_events_picker", form_builder: f, label: "Preferred events", disabled: ! editable_fields.include?(:preferred_events),
+                                                        events_association_name: :user_preferred_events, selected_events: @user.preferred_events %>
+          <span class="help-block">Selecting your preferred events makes registration for competitions quicker.</span>
 
           <%= f.submit 'Save', class: "btn btn-primary" %>
         <% end %>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -187,7 +187,7 @@
         <%= simple_form_for @user do |f| %>
           <%= hidden_field_tag "section", "preferences" %>
 
-          <%= render "shared/associated_events_picker", form_builder: f, label: "Preferred events", disabled: ! editable_fields.include?(:preferred_events),
+          <%= render "shared/associated_events_picker", form_builder: f, label: "Preferred events", disabled: !editable_fields.include?(:preferred_events),
                                                         events_association_name: :user_preferred_events, selected_events: @user.preferred_events %>
           <span class="help-block">Selecting your preferred events makes registration for competitions quicker.</span>
 

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -186,8 +186,12 @@
       <div class="tab-pane active" id="preferences">
         <%= simple_form_for @user do |f| %>
           <%= hidden_field_tag "section", "preferences" %>
-          <%= f.input :preferred_event_ids, as: :events_picker, allowed_events: Event.all_official, selected_events: @user.preferred_events,
-                                            disabled: !editable_fields.include?(:preferred_event_ids), hint: "Selecting your preferred events makes registration for competitions quicker." %>
+
+          <% if editable_fields.include?(:preferred_events) %>
+            <%= render "shared/associated_events_picker", form_builder: f, label: "Preferred events",
+                                                          events_association_name: :user_preferred_events, selected_events: @user.preferred_events %>
+            <span class="help-block">Selecting your preferred events makes registration for competitions quicker.</span>
+          <% end %>
 
           <%= f.submit 'Save', class: "btn btn-primary" %>
         <% end %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -65,7 +65,6 @@ en:
     labels:
       defaults:
         event_ids: "Events"
-        preferred_event_ids: "Preferred events"
       competition:
         id: "ID"
     hints:

--- a/WcaOnRails/db/migrate/20160505231300_create_registration_events.rb
+++ b/WcaOnRails/db/migrate/20160505231300_create_registration_events.rb
@@ -9,7 +9,7 @@ class CreateRegistrationEvents < ActiveRecord::Migration
     # Move the data to the new table.
     Registration.all.each do |registration|
       (registration.eventIds || "").split.each do |event_id|
-        RegistrationEvent.create(registration_id: registration.id, event_id: event_id)
+        RegistrationEvent.create!(registration_id: registration.id, event_id: event_id)
       end
     end
 

--- a/WcaOnRails/db/migrate/20160505231300_create_registration_events.rb
+++ b/WcaOnRails/db/migrate/20160505231300_create_registration_events.rb
@@ -1,0 +1,19 @@
+class CreateRegistrationEvents < ActiveRecord::Migration
+  def change
+    create_table :registration_events do |t|
+      t.references :registration
+      t.string :event_id
+    end
+    add_index :registration_events, [:registration_id, :event_id], unique: true
+
+    # Move the data to the new table.
+    Registration.all.each do |registration|
+      (registration.eventIds || "").split.each do |event_id|
+        RegistrationEvent.create(registration_id: registration.id, event_id: event_id)
+      end
+    end
+
+    # Finally remove the unnecessary column.
+    remove_column :Preregs, :eventIds
+  end
+end

--- a/WcaOnRails/db/seeds/development/competitions.seeds.rb
+++ b/WcaOnRails/db/seeds/development/competitions.seeds.rb
@@ -152,13 +152,13 @@ after "development:users" do
     next if i < 480
     users.each_with_index do |user, i|
       status = i % 4 == 0 ? "a" : "p"
-      registrationEventIds = eventIds.sample(rand(1..eventIds.count)).join(" ")
+      registration_event_ids = eventIds.sample(rand(1..eventIds.count))
       if i % 2 == 0
         Registration.new(
           competition: competition,
           name: Faker::Name.name,
           personId: user.wca_id,
-          countryId: Country::ALL_COUNTRIES.sample.id,
+          countryId: Country.all_real.sample.id,
           gender: "m",
           birthYear: 1990,
           birthMonth: 6,
@@ -168,10 +168,10 @@ after "development:users" do
           comments: Faker::Lorem.paragraph,
           ip: "1.1.1.1",
           status: status,
-          eventIds: registrationEventIds,
+          registration_events_attributes: registration_event_ids.map { |event_id| {event_id: event_id} },
         ).save!(validate: false)
       else
-        FactoryGirl.create(:registration, user: user, competition: competition, status: status, eventIds: registrationEventIds)
+        FactoryGirl.create(:registration, user: user, competition: competition, status: status, event_ids: registration_event_ids)
       end
     end
   end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13  Distrib 5.6.26, for osx10.10 (x86_64)
+-- MySQL dump 10.13  Distrib 5.7.12, for Linux (x86_64)
 --
 -- Host: 127.0.0.1    Database: wca_development
 -- ------------------------------------------------------
--- Server version	5.6.26
+-- Server version	5.7.12-0ubuntu1
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -285,7 +285,6 @@ CREATE TABLE `Preregs` (
   `comments` text COLLATE utf8_unicode_ci NOT NULL,
   `ip` varchar(16) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `status` char(1) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'p',
-  `eventIds` text COLLATE utf8_unicode_ci NOT NULL,
   `user_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -602,6 +601,22 @@ CREATE TABLE `posts` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `registration_events`
+--
+
+DROP TABLE IF EXISTS `registration_events`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `registration_events` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `registration_id` int(11) DEFAULT NULL,
+  `event_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `index_registration_events_on_registration_id_and_event_id` (`registration_id`,`event_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `schema_migrations`
 --
 
@@ -764,7 +779,7 @@ CREATE TABLE `votes` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-04-08  3:31:14
+-- Dump completed on 2016-05-06  1:31:08
 INSERT INTO schema_migrations (version) VALUES ('20150501004846');
 
 INSERT INTO schema_migrations (version) VALUES ('20150504022234');
@@ -883,5 +898,8 @@ INSERT INTO schema_migrations (version) VALUES ('20160407210623');
 
 INSERT INTO schema_migrations (version) VALUES ('20160504170758');
 
+<<<<<<< d819de4e79f19f7463c100e921b4983899a3b769
 INSERT INTO schema_migrations (version) VALUES ('20160504230105');
-
+=======
+INSERT INTO schema_migrations (version) VALUES ('20160505231300');
+>>>>>>> Set up database background.

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -898,8 +898,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160407210623');
 
 INSERT INTO schema_migrations (version) VALUES ('20160504170758');
 
-<<<<<<< d819de4e79f19f7463c100e921b4983899a3b769
 INSERT INTO schema_migrations (version) VALUES ('20160504230105');
-=======
+
 INSERT INTO schema_migrations (version) VALUES ('20160505231300');
->>>>>>> Set up database background.

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe RegistrationsController do
     it 'can set name, email, events, countryId for registrations without user' do
       patch :update, id: registration_without_user.id, registration: { name: "test name", email: "foo@bar.com", countryId: "smerbia",
                                                                        registration_events_attributes: [ {event_id: "222"} ] }
-                                                                       # This registration's registration_event with event_id = '333' is already in the databse
       registration_without_user.reload
       expect(registration_without_user.name).to eq "test name"
+      # This registration's registration_event with event_id = '333' is already in the databse and we've just added 2x2x2
       expect(registration_without_user.events.map(&:id)).to eq %w(333 222)
       expect(registration_without_user.email).to eq "foo@bar.com"
       expect(registration_without_user.countryId).to eq "smerbia"

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -34,10 +34,12 @@ RSpec.describe RegistrationsController do
     end
 
     it 'can set name, email, events, countryId for registrations without user' do
-      patch :update, id: registration_without_user.id, registration: { name: "test name", event_ids: {"222" => "1", "333" => "1" }, email: "foo@bar.com", countryId: "smerbia" }
+      patch :update, id: registration_without_user.id, registration: { name: "test name", email: "foo@bar.com", countryId: "smerbia",
+                                                                       registration_events_attributes: [ {event_id: "222"} ] }
+                                                                       # This registration's registration_event with event_id = '333' is already in the databse
       registration_without_user.reload
       expect(registration_without_user.name).to eq "test name"
-      expect(registration_without_user.eventIds).to eq "333 222"
+      expect(registration_without_user.events.map(&:id)).to eq %w(333 222)
       expect(registration_without_user.email).to eq "foo@bar.com"
       expect(registration_without_user.countryId).to eq "smerbia"
     end
@@ -45,7 +47,7 @@ RSpec.describe RegistrationsController do
     it 'cannot set events that are not offered' do
       competition.update_column(:eventSpecs, "333")
 
-      patch :update, id: registration.id, registration: { event_ids: { "222" => "1", "333" => "1" } }
+      patch :update, id: registration.id, registration: { registration_events_attributes: [ {event_id: "333"}, {event_id: "222"} ] }
       registration = assigns(:registration)
       expect(registration.errors.messages[:events]).to eq ["invalid event ids: 222"]
     end
@@ -174,7 +176,7 @@ RSpec.describe RegistrationsController do
       expect(RegistrationsMailer).to receive(:notify_organizers_of_new_registration).and_call_original
       expect(RegistrationsMailer).to receive(:notify_registrant_of_new_registration).and_call_original
       expect do
-        post :create, competition_id: competition.id, registration: { event_ids: { "333" => "1" }, guests: 1, comments: "" }
+        post :create, competition_id: competition.id, registration: { registration_events_attributes: [ {event_id: "333"} ], guests: 1, comments: "" }
       end.to change { ActionMailer::Base.deliveries.length }.by(2)
 
       registration = Registration.find_by_user_id(user.id)
@@ -215,7 +217,7 @@ RSpec.describe RegistrationsController do
     end
 
     it "cannot create accepted registration" do
-      post :create, competition_id: competition.id, registration: { event_ids: { "333" => "1" }, guests: 0, comments: "", status: Registration::statuses[:accepted] }
+      post :create, competition_id: competition.id, registration: { registration_events_attributes: [ {event_id: "333"} ], guests: 0, comments: "", status: Registration::statuses[:accepted] }
       registration = Registration.find_by_user_id(user.id)
       expect(registration.pending?).to be true
     end
@@ -225,7 +227,7 @@ RSpec.describe RegistrationsController do
       competition.registration_close = 1.week.ago
       competition.save!
 
-      post :create, competition_id: competition.id, registration: { event_ids: { "333" => "1" }, guests: 1, comments: "", status: :accepted }
+      post :create, competition_id: competition.id, registration: { registration_events_attributes: [ {event_id: "333"} ], guests: 1, comments: "", status: :accepted }
       expect(response).to redirect_to competition_path(competition)
       expect(flash[:danger]).to eq "You cannot register for this competition, registration is closed"
     end
@@ -378,18 +380,18 @@ RSpec.describe RegistrationsController do
     end
 
     it "sorts 444 by average and handles ties" do
-      registration1 = FactoryGirl.create(:registration, :accepted, competition: competition, eventIds: "444")
+      registration1 = FactoryGirl.create(:registration, :accepted, competition: competition, event_ids: %w(444))
       FactoryGirl.create :ranks_average, rank: 10, best: 4242, eventId: "444", personId: registration1.personId
       FactoryGirl.create :ranks_single, rank: 20, best: 2000, eventId: "444", personId: registration1.personId
 
-      registration2 = FactoryGirl.create(:registration, :accepted, competition: competition, eventIds: "444")
+      registration2 = FactoryGirl.create(:registration, :accepted, competition: competition, event_ids: %w(444))
       FactoryGirl.create :ranks_average, rank: 10, best: 4242, eventId: "444", personId: registration2.personId
       FactoryGirl.create :ranks_single, rank: 10, best: 2000, eventId: "444", personId: registration2.personId
 
-      registration3 = FactoryGirl.create(:registration, :accepted, competition: competition, eventIds: "444")
+      registration3 = FactoryGirl.create(:registration, :accepted, competition: competition, event_ids: %w(444))
       FactoryGirl.create :ranks_average, rank: 9, best: 4242, eventId: "444", personId: registration3.personId
 
-      registration4 = FactoryGirl.create(:registration, :accepted, competition: competition, eventIds: "444")
+      registration4 = FactoryGirl.create(:registration, :accepted, competition: competition, event_ids: %w(444))
       FactoryGirl.create :ranks_average, rank: 11, best: 4242, eventId: "444", personId: registration4.personId
 
       get :psych_sheet_event, competition_id: competition.id, event_id: "444"
@@ -401,15 +403,15 @@ RSpec.describe RegistrationsController do
 
     it "handles missing average" do
       # Missing an average
-      registration1 = FactoryGirl.create(:registration, :accepted, competition: competition, eventIds: "444")
+      registration1 = FactoryGirl.create(:registration, :accepted, competition: competition, event_ids: %w(444))
       FactoryGirl.create :ranks_single, rank: 2, best: 200, eventId: "444", personId: registration1.personId
 
-      registration2 = FactoryGirl.create(:registration, :accepted, competition: competition, eventIds: "444")
+      registration2 = FactoryGirl.create(:registration, :accepted, competition: competition, event_ids: %w(444))
       FactoryGirl.create :ranks_average, rank: 10, best: 4242, eventId: "444", personId: registration2.personId
       FactoryGirl.create :ranks_single, rank: 10, best: 2000, eventId: "444", personId: registration2.personId
 
       # Never competed
-      registration3 = FactoryGirl.create(:registration, :accepted, competition: competition, eventIds: "444")
+      registration3 = FactoryGirl.create(:registration, :accepted, competition: competition, event_ids: %w(444))
 
       get :psych_sheet_event, competition_id: competition.id, event_id: "444"
       registrations = assigns(:registrations)
@@ -418,7 +420,7 @@ RSpec.describe RegistrationsController do
     end
 
     it "handles 1 registration" do
-      registration = FactoryGirl.create(:registration, :accepted, competition: competition, eventIds: "444")
+      registration = FactoryGirl.create(:registration, :accepted, competition: competition, event_ids: %w(444))
       RanksAverage.create!(
         personId: registration.personId,
         eventId: "444",
@@ -435,7 +437,7 @@ RSpec.describe RegistrationsController do
     end
 
     it "sorts 333bf by single" do
-      registration1 = FactoryGirl.create(:registration, :accepted, competition: competition, eventIds: "333bf")
+      registration1 = FactoryGirl.create(:registration, :accepted, competition: competition, event_ids: %w(333bf))
       RanksAverage.create!(
         personId: registration1.personId,
         eventId: "333bf",
@@ -453,7 +455,7 @@ RSpec.describe RegistrationsController do
         countryRank: 1,
       )
 
-      registration2 = FactoryGirl.create(:registration, :accepted, competition: competition, eventIds: "333bf")
+      registration2 = FactoryGirl.create(:registration, :accepted, competition: competition, event_ids: %w(333bf))
       RanksAverage.create!(
         personId: registration2.personId,
         eventId: "333bf",
@@ -478,7 +480,7 @@ RSpec.describe RegistrationsController do
     end
 
     it "shows first timers on bottom" do
-      registration1 = FactoryGirl.create(:registration, :accepted, competition: competition, eventIds: "333bf")
+      registration1 = FactoryGirl.create(:registration, :accepted, competition: competition, event_ids: %w(333bf))
       RanksAverage.create!(
         personId: registration1.personId,
         eventId: "333bf",
@@ -498,11 +500,11 @@ RSpec.describe RegistrationsController do
 
       # Someone who has never competed in a WCA competition
       user2 = FactoryGirl.create(:user, name: "Zzyzx")
-      registration2 = FactoryGirl.create(:registration, :accepted, user: user2, competition: competition, eventIds: "333bf")
+      registration2 = FactoryGirl.create(:registration, :accepted, user: user2, competition: competition, event_ids: %w(333bf))
 
       # Someone who has never competed in 333bf
       user3 = FactoryGirl.create(:user, :wca_id, name: "Aaron")
-      registration3 = FactoryGirl.create(:registration, :accepted, user: user3, competition: competition, eventIds: "333bf")
+      registration3 = FactoryGirl.create(:registration, :accepted, user: user3, competition: competition, event_ids: %w(333bf))
 
       get :psych_sheet_event, competition_id: competition.id, event_id: "333bf"
       registrations = assigns(:registrations)
@@ -511,7 +513,7 @@ RSpec.describe RegistrationsController do
     end
 
     it "handles 1 registration" do
-      registration = FactoryGirl.create(:registration, :accepted, competition: competition, eventIds: "444")
+      registration = FactoryGirl.create(:registration, :accepted, competition: competition, event_ids: %w(444))
       RanksAverage.create!(
         personId: registration.personId,
         eventId: "444",

--- a/WcaOnRails/spec/controllers/users_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/users_controller_spec.rb
@@ -126,7 +126,7 @@ describe UsersController do
 
     it "user can change his preferred events" do
       sign_in user
-      patch :update, id: user.id, user: { preferred_event_ids: { "333" => "1", "444" => "1", "clock" => "1" } }
+      patch :update, id: user.id, user: { user_preferred_events_attributes: [ {event_id: "333"}, {event_id: "444"}, {event_id: "clock"} ] }
       expect(user.reload.preferred_events.map(&:id)).to eq %w(333 444 clock)
     end
 

--- a/WcaOnRails/spec/factories/registrations.rb
+++ b/WcaOnRails/spec/factories/registrations.rb
@@ -3,12 +3,18 @@ FactoryGirl.define do
     transient do
       competition { FactoryGirl.create(:competition, :registration_open) }
       user { FactoryGirl.create(:user, :wca_id) }
+      event_ids ["333"]
     end
     competitionId { competition.id }
     user_id { user ? user.id : nil }
-    eventIds "333"
     guests 10
     comments ""
+    # Using accept_nested_attributes_for
+    registration_events_attributes do
+      event_ids.map do |event_id|
+        { event_id: event_id }
+      end
+    end
 
     trait :accepted do
       status "a"

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -8,6 +8,16 @@ FactoryGirl.define do
     password "wca"
     password_confirmation { "wca" }
 
+    transient do
+      preferred_event_ids []
+    end
+    # Using accept_nested_attributes_for
+    user_preferred_events_attributes do
+      preferred_event_ids.map do |event_id|
+        { event_id: event_id }
+      end
+    end
+
     before(:create) { |user| user.skip_confirmation! }
     trait :unconfirmed do
       before(:create) { |user| user.confirmed_at = nil }

--- a/WcaOnRails/spec/features/register_for_competition_spec.rb
+++ b/WcaOnRails/spec/features/register_for_competition_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Registering for a competition" do
 
     scenario "User registers for a competition" do
       visit competition_register_path(competition)
-      check "checkbox-333"
+      check "registration_events_333"
       click_button "Register!"
       expect(page).to have_text("Successfully registered!")
       registration = competition.registrations.find_by_user_id(user.id)
@@ -24,9 +24,9 @@ RSpec.feature "Registering for a competition" do
       competition.update_attribute :eventSpecs, "444 555 666"
 
       visit competition_register_path(competition)
-      expect(find("#checkbox-444")).to be_checked
-      expect(find("#checkbox-555")).to be_checked
-      expect(find("#checkbox-666")).to_not be_checked
+      expect(find("#registration_events_444")).to be_checked
+      expect(find("#registration_events_555")).to be_checked
+      expect(find("#registration_events_666")).to_not be_checked
     end
   end
 

--- a/WcaOnRails/spec/features/register_for_competition_spec.rb
+++ b/WcaOnRails/spec/features/register_for_competition_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Registering for a competition" do
 
     scenario "User registers for a competition" do
       visit competition_register_path(competition)
-      check "registration_event_ids_333"
+      check "checkbox-333"
       click_button "Register!"
       expect(page).to have_text("Successfully registered!")
       registration = competition.registrations.find_by_user_id(user.id)
@@ -20,13 +20,13 @@ RSpec.feature "Registering for a competition" do
     end
 
     scenario "User with preferred events goes to register page" do
-      user.update_attribute :preferred_event_ids, %w(333 444 555)
+      user.update_attribute :user_preferred_events_attributes, [ {event_id: "333"}, {event_id: "444"}, {event_id: "555"} ]
       competition.update_attribute :eventSpecs, "444 555 666"
 
       visit competition_register_path(competition)
-      expect(find("#registration_event_ids_444")).to be_checked
-      expect(find("#registration_event_ids_555")).to be_checked
-      expect(find("#registration_event_ids_666")).to_not be_checked
+      expect(find("#checkbox-444")).to be_checked
+      expect(find("#checkbox-555")).to be_checked
+      expect(find("#checkbox-666")).to_not be_checked
     end
   end
 

--- a/WcaOnRails/spec/models/registration_spec.rb
+++ b/WcaOnRails/spec/models/registration_spec.rb
@@ -54,13 +54,13 @@ RSpec.describe Registration do
   end
 
   it "requires at least one event" do
-    registration.registration_events.destroy_all
+    registration.registration_events = []
     expect(registration).to be_invalid
     expect(registration.errors[:events]).to eq ["must register for at least one event"]
   end
 
   it "requires events be offered by competition" do
-    registration.registration_events.create(event_id: "777")
+    registration.registration_events.create!(event_id: "777")
     expect(registration).to be_invalid
   end
 

--- a/WcaOnRails/spec/models/registration_spec.rb
+++ b/WcaOnRails/spec/models/registration_spec.rb
@@ -54,13 +54,13 @@ RSpec.describe Registration do
   end
 
   it "requires at least one event" do
-    registration.eventIds = ""
+    registration.registration_events.destroy_all
     expect(registration).to be_invalid
     expect(registration.errors[:events]).to eq ["must register for at least one event"]
   end
 
   it "requires events be offered by competition" do
-    registration.eventIds = "777"
+    registration.registration_events.create(event_id: "777")
     expect(registration).to be_invalid
   end
 

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -510,25 +510,4 @@ RSpec.describe User, type: :model do
       end
     end
   end
-
-  describe "preferred events" do
-    let(:user) { FactoryGirl.create(:user) }
-
-    it "can be set by updating the preferred_event_ids" do
-      user.update_attribute :preferred_event_ids, %w(333 444 555)
-      # Updates the user_preferred_events table in the database
-      expect(user.reload.user_preferred_events.count).to eq 3
-      # The appropriate method works
-      expect(user.preferred_events.map(&:id)).to eq %w(333 444 555)
-    end
-
-    it "user_preferred_events table is updated correctly when preferred_event_ids change" do
-      # Set some preferred events
-      user.update_attribute :preferred_event_ids, %w(333 444 555)
-      # Change them to be something else
-      user.reload.update_attribute :preferred_event_ids, %w(333 clock)
-      # user_preferred_events table in the database should be updated
-      expect(user.reload.user_preferred_events.pluck(:event_id)).to eq %w(333 clock)
-    end
-  end
 end

--- a/WcaOnRails/spec/views/registrations/export.csv.erb_spec.rb
+++ b/WcaOnRails/spec/views/registrations/export.csv.erb_spec.rb
@@ -12,7 +12,7 @@ describe "registrations/export.csv.erb" do
       birthDay: 1,
       gender: "m",
       email: "bob@bob.com",
-      eventIds: "333",
+      registration_events_attributes: [ {event_id: "333"} ],
       guests: 1,
       guests_old: 'jane', # will go away. https://github.com/cubing/worldcubeassociation.org/issues/403
     )


### PR DESCRIPTION
This follows the #568 by adding a separate table for registration events. Also this make use of `accept_nested_attributes_for` when updating associated events.