### PR TITLE
Move country flag back to the left of competition name.

### DIFF
--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -21,10 +21,10 @@
       </span>
       <span class="competition-info">
         <p class="competition-link">
+          <i class="flag f16 <%= competition.country.iso2.downcase %>"></i>
           <%= link_to competition.cellName, competition_path(competition) %>
         </p>
         <p class="location">
-          <i class="flag f16 <%= competition.country.iso2.downcase %>"></i>
           <strong><%= competition.country.name %></strong>, <%= competition.cityName %>
         </p>
         <div class="venue-link">


### PR DESCRIPTION
Since in the end we didn't have to move it because of the results icon.
(Also I liked it better that way)
![flag](https://cloud.githubusercontent.com/assets/1881933/15084392/7b26385e-13a9-11e6-80a4-f2e949748396.png)
