### PR TITLE
Some cleanup now possible because @jonatanklosko pulled registration

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -39,14 +39,14 @@ class RegistrationsController < ApplicationController
     @event = Event.find(params[:event_id])
     @preferred_format = @event.preferred_formats.first
 
-    # TODO - pull registered events out into a join table
-    # https://github.com/cubing/worldcubeassociation.org/issues/275#issuecomment-167347053
-    @registrations = @competition.registrations.accepted.all.select { |r|
-      r.events.include?(@event)
-    }.sort_by { |r|
-      has_competed = !!r.world_rank(@event, @preferred_format.sort_by)
-      [ has_competed ? 0 : 1, r.world_rank(@event, @preferred_format.sort_by) || Float::INFINITY, r.world_rank(@event, @preferred_format.sort_by_second) || Float::INFINITY, r.name ]
-    }
+    @registrations = @competition.registrations.
+                                  accepted.
+                                  joins(:registration_events).
+                                  where("registration_events.event_id=?", @event.id).
+                                  sort_by do |r|
+                                    has_competed = !!r.world_rank(@event, @preferred_format.sort_by)
+                                    [ has_competed ? 0 : 1, r.world_rank(@event, @preferred_format.sort_by) || Float::INFINITY, r.world_rank(@event, @preferred_format.sort_by_second) || Float::INFINITY, r.name ]
+                                  end
 
     @registrations.each_with_index do |registration, i|
       prev_registration = i > 0 ? @registrations[i - 1] : nil

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -93,19 +93,7 @@ class Registration < ActiveRecord::Base
   validate :must_register_for_gte_one_event
   private def must_register_for_gte_one_event
     if events.length == 0
-      errors.add(:events, "must register for at least one event")
-    end
-  end
-
-  validate :events_must_be_offered
-  private def events_must_be_offered
-    if !competition
-      errors.add(:competitionId, "invalid")
-      return
-    end
-    invalid_events = events - competition.events
-    unless invalid_events.empty?
-      errors.add(:events, "invalid event ids: #{invalid_events.map(&:id).join(',')}")
+      errors.add(:registration_events, "must register for at least one event")
     end
   end
 

--- a/WcaOnRails/app/models/registration_event.rb
+++ b/WcaOnRails/app/models/registration_event.rb
@@ -2,6 +2,12 @@ class RegistrationEvent < ActiveRecord::Base
   belongs_to :registration
 
   validates :event_id, inclusion: { in: Event.all.map(&:id) }
+  validate :event_must_be_offered
+  private def event_must_be_offered
+    if registration && !registration.competition.events.include?(event_object)
+      errors.add(:events, "invalid event id: #{event_id}")
+    end
+  end
 
   def event_object
     Event.find(event_id)

--- a/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
+++ b/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
@@ -18,7 +18,8 @@ Variables:
      associated_events.find_by_event_id(event.id) || associated_events.build(event_id: event.id)
    end %>
 
-<div class="form-group">
+<% errors = form_builder.object.errors.messages[events_association_name] || [] %>
+<div class="form-group <%= "has-error" unless errors.empty? %>">
   <%= label_tag events_association_name, label, class: "associated-events-label" %>
   <div id="<%= events_association_name %>" class="associated-events">
     <%= form_builder.simple_fields_for events_association_name, all_events do |f| %>
@@ -30,6 +31,12 @@ Variables:
           <%= content_tag(:span, "", class: "cubing-icon icon-#{event.id}", data: { toggle: "tooltip", placement: "top" }, title: event.name ) %>
         <% end %>
         <%= f.hidden_field :id %>
+      </span>
+    <% end %>
+
+    <% errors.each do |error| %>
+      <span class="help-block">
+        <%= error %>
       </span>
     <% end %>
   </div>

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe RegistrationsController do
 
       patch :update, id: registration.id, registration: { registration_events_attributes: [ {event_id: "333"}, {event_id: "222"} ] }
       registration = assigns(:registration)
-      expect(registration.errors.messages[:events]).to eq ["invalid event ids: 222"]
+      expect(registration.errors.messages[:"registration_events.events"]).to eq ["invalid event id: 222"]
     end
 
     it 'cannot change registration of a different competition' do

--- a/WcaOnRails/spec/models/registration_spec.rb
+++ b/WcaOnRails/spec/models/registration_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Registration do
   it "requires a competitionId" do
     registration.competitionId = nil
     expect(registration).not_to be_valid
-    expect(registration.errors.messages[:competitionId]).to eq ["invalid"]
+    expect(registration.errors.messages[:competition]).to eq ["Competition not found"]
   end
 
   it "requires a valid competitionId" do
     registration.competitionId = "foobar"
     expect(registration).not_to be_valid
-    expect(registration.errors.messages[:competitionId]).to eq ["invalid"]
+    expect(registration.errors.messages[:competition]).to eq ["Competition not found"]
   end
 
   it "cannot create a registration for a competition without wca registration" do
@@ -56,11 +56,11 @@ RSpec.describe Registration do
   it "requires at least one event" do
     registration.registration_events = []
     expect(registration).to be_invalid
-    expect(registration.errors[:events]).to eq ["must register for at least one event"]
+    expect(registration.errors[:registration_events]).to eq ["must register for at least one event"]
   end
 
   it "requires events be offered by competition" do
-    registration.registration_events.create!(event_id: "777")
+    registration.registration_events.build(event_id: "777")
     expect(registration).to be_invalid
   end
 


### PR DESCRIPTION
events out into a separate join table. This is the start of work for #275.

Also fixed a bug where the validation error on events was not being rendered. See fixed version here:

![image](https://cloud.githubusercontent.com/assets/277474/15095103/5df3bb34-146d-11e6-8954-f3bbba037a42.png)

@jonatanklosko, this involved touching your `_associated_events_picker.html.erb`, can you let me know what you think? Thanks!