### PR TITLE
A competition cannot possibly be in progress if its results are posted.

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -483,7 +483,7 @@ class Competition < ActiveRecord::Base
   end
 
   def in_progress?
-    (start_date..end_date).cover? Date.today
+    !results_posted? && (start_date..end_date).cover?(Date.today)
   end
 
   def is_over?

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -154,6 +154,10 @@ RSpec.describe Competition do
     expect(competition).to be_valid
     expect(competition.in_progress?).to be true
     expect(competition.info[:in_progress]).to eq "This competition is ongoing. Come back after #{competition.end_date.to_formatted_s(:long)} to see the results!"
+
+    competition.results_posted_at = Time.now
+    expect(competition.in_progress?).to be false
+    expect(competition.info[:in_progress]).to eq nil
   end
 
   it "knows the calendar" do


### PR DESCRIPTION
This just happened with [Xiamen Open 2016](https://www.worldcubeassociation.org/competitions/XiamenOpen2016):

![image](https://cloud.githubusercontent.com/assets/277474/15099486/25355764-150b-11e6-9e04-af4c1cc7614a.png)