### PR TITLE
Allow the results team to view results before they are posted, but with a reminder warning

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -482,6 +482,10 @@ class Competition < ActiveRecord::Base
     self.showAtAll || (user && user.can_manage_competition?(self))
   end
 
+  def user_can_view_results?(user)
+    results_posted? || (user && user.can_admin_results?)
+  end
+
   def in_progress?
     (start_date..end_date).cover? Date.today
   end

--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div id="competition-nav">
       <% nav_items = [] %>
-      <% if @competition.results_posted? %>
+      <% if @competition.user_can_view_results?(current_user) %>
         <% nav_items << {
           text: "Results",
           path: competition_path(@competition),

--- a/WcaOnRails/app/views/competitions/_results_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_results_nav.html.erb
@@ -1,0 +1,12 @@
+<%= render layout: 'nav' do %>
+  <%= render "competition_info", competition: @competition %>
+
+  <% if @competition.user_can_view_results?(current_user) %>
+    <% if !@competition.results_posted? %>
+      <div class="alert alert-warning">
+        <strong>Note:</strong> You are viewing results that have not been posted yet.
+      </div>
+    <% end %>
+    <%= yield %>
+  <% end %>
+<% end %>

--- a/WcaOnRails/app/views/competitions/show.html.erb
+++ b/WcaOnRails/app/views/competitions/show.html.erb
@@ -1,9 +1,5 @@
 <% provide(:title, @competition.name) %>
 
-<%= render layout: 'nav' do %>
-  <%= render "competition_info", competition: @competition %>
-
-  <% if @competition.results_posted? %>
-    <%= render "results_table", results: @competition.winning_results, hide_pos: true, hide_round: true %>
-  <% end %>
+<%= render layout: 'results_nav' do %>
+  <%= render "results_table", results: @competition.winning_results, hide_pos: true, hide_round: true %>
 <% end %>

--- a/WcaOnRails/app/views/competitions/show_all_results.html.erb
+++ b/WcaOnRails/app/views/competitions/show_all_results.html.erb
@@ -1,8 +1,6 @@
 <% provide(:title, @competition.name) %>
 
-<%= render layout: 'nav' do %>
-  <%= render "competition_info", competition: @competition %>
-
+<%= render layout: 'results_nav' do %>
   <% cache @competition.result_cache_key("all_results") do %>
     <% @competition.events_with_rounds_with_results.each do |event, rounds_with_results| %>
 

--- a/WcaOnRails/app/views/competitions/show_podiums.html.erb
+++ b/WcaOnRails/app/views/competitions/show_podiums.html.erb
@@ -1,8 +1,6 @@
 <% provide(:title, @competition.name) %>
 
-<%= render layout: 'nav' do %>
-  <%= render "competition_info", competition: @competition %>
-
+<%= render layout: 'results_nav' do %>
   <% @competition.events_with_podium_results.each do |event, podium_results| %>
     <h3>
       <%= anchorable event.name, "e#{event.id}" %>

--- a/WcaOnRails/app/views/competitions/show_results_by_person.html.erb
+++ b/WcaOnRails/app/views/competitions/show_results_by_person.html.erb
@@ -1,8 +1,6 @@
 <% provide(:title, @competition.name) %>
 
-<%= render layout: 'nav' do %>
-  <%= render "competition_info", competition: @competition %>
-
+<%= render layout: 'results_nav' do %>
   <% cache @competition.result_cache_key("by_person") do %>
     <% @competition.person_names_with_results.each do |personName, results| %>
       <h3>

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Competition do
     expect(competition.warnings[:invisible]).to eq "This competition is not visible to the public."
   end
 
-  it "displays info if competition is finished but results aren't uploaded" do
+  it "displays info if competition is finished but results aren't posted" do
     competition = FactoryGirl.build :competition, starts: 1.month.ago
     expect(competition).to be_valid
     expect(competition.is_over?).to be true


### PR DESCRIPTION
See:

![image](https://cloud.githubusercontent.com/assets/277474/15099732/64861500-1512-11e6-9341-b466ee28b728.png)