### PR TITLE
On the "My competitions" page show competitions without a date or country

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -309,12 +309,12 @@ class CompetitionsController < ApplicationController
   end
 
   def my_competitions
-    @competitions = (current_user.delegated_competitions + current_user.organized_competitions + current_user.competitions_registered_for)
+    competitions = (current_user.delegated_competitions + current_user.organized_competitions + current_user.competitions_registered_for)
     if current_user.person
-      @competitions += current_user.person.competitions
+      competitions += current_user.person.competitions
     end
-    @competitions = @competitions.uniq.sort_by { |comp| comp.start_date || Date.today + 20.year }.reverse
-    @past_competitions, @not_past_competitions = @competitions.partition(&:is_over?)
+    competitions = competitions.uniq.sort_by { |comp| comp.start_date || Date.today + 20.year }.reverse
+    @past_competitions, @not_past_competitions = competitions.partition(&:is_over?)
   end
 
   private def competition_params

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -139,11 +139,7 @@ class CompetitionsController < ApplicationController
 
   def post_announcement
     comp = Competition.find(params[:id])
-    if comp.start_date.nil? || comp.end_date.nil?
-      date_range_str = "unscheduled"
-    else
-      date_range_str = wca_date_range(comp.start_date, comp.end_date, format: :long)
-    end
+    date_range_str = wca_date_range(comp.start_date, comp.end_date, format: :long)
     title = "#{comp.name} on #{date_range_str} in #{comp.cityName}, #{comp.countryId}"
 
     body = "The [#{comp.name}](#{competition_url(comp)})"

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -313,9 +313,8 @@ class CompetitionsController < ApplicationController
     if current_user.person
       @competitions += current_user.person.competitions
     end
-    @competitions = @competitions.uniq.sort_by(&:start_date).reverse!
-    @not_past_competitions = @competitions.reject(&:is_over?)
-    @past_competitions = @competitions.select(&:is_over?)
+    @competitions = @competitions.uniq.sort_by { |comp| comp.start_date || Date.today + 20.year }.reverse
+    @past_competitions, @not_past_competitions = @competitions.partition(&:is_over?)
   end
 
   private def competition_params

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -123,8 +123,12 @@ module ApplicationHelper
   end
 
   def wca_date_range(from_date, to_date, options={})
-    options[:separator] = '-'
-    date_range(from_date, to_date, options)
+    if from_date && to_date
+      options[:separator] = '-'
+      date_range(from_date, to_date, options)
+    else
+      "unscheduled"
+    end
   end
 
   def alert(type, content=nil, note: false, &block)

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -127,7 +127,7 @@ module ApplicationHelper
       options[:separator] = '-'
       date_range(from_date, to_date, options)
     else
-      "unscheduled"
+      t "competitions.unscheduled"
     end
   end
 

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -2,7 +2,7 @@
   <div class="col-md-6">
     <dl class="dl-horizontal">
       <dt>Date</dt>
-      <dd><%= wca_date_range(competition.start_date, competition.end_date) %></dd>
+      <dd><%= competition.start_date && competition.end_date ? wca_date_range(competition.start_date, competition.end_date) : "Unscheduled" %></dd>
 
       <dt>City</dt>
       <dd><%= competition.cityName %>, <%= competition.country_name %> </dd>

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -2,7 +2,7 @@
   <div class="col-md-6">
     <dl class="dl-horizontal">
       <dt>Date</dt>
-      <dd><%= competition.start_date && competition.end_date ? wca_date_range(competition.start_date, competition.end_date) : "Unscheduled" %></dd>
+      <dd><%= wca_date_range(competition.start_date, competition.end_date) %></dd>
 
       <dt>City</dt>
       <dd><%= competition.cityName %>, <%= competition.country_name %> </dd>

--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -17,7 +17,7 @@
         <% else %>
           <%= icon('hourglass-start', title: "Starts in #{ pluralize((competition.start_date - Date.today).to_i, "day") }", data: { toggle: "tooltip" }) %>
         <% end %>
-        <%= wca_date_range(competition.start_date, competition.end_date)  %>
+        <%= competition.start_date && competition.end_date ? wca_date_range(competition.start_date, competition.end_date) : "Unscheduled" %>
       </span>
       <span class="competition-info">
         <p class="competition-link">

--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -17,7 +17,7 @@
         <% else %>
           <%= icon('hourglass-start', title: "Starts in #{ pluralize((competition.start_date - Date.today).to_i, "day") }", data: { toggle: "tooltip" }) %>
         <% end %>
-        <%= competition.start_date && competition.end_date ? wca_date_range(competition.start_date, competition.end_date) : "Unscheduled" %>
+        <%= wca_date_range(competition.start_date, competition.end_date) %>
       </span>
       <span class="competition-info">
         <p class="competition-link">

--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -36,7 +36,7 @@
           <tr class="<%= competition.isConfirmed ? "confirmed" : "not-confirmed" %> <%= competition.showAtAll ? "visible" : "not-visible" %> <%= !past ? "not-past" : "past" %>" data-toggle="tooltip" data-placement="top" data-container="body" title="<%= !past ? message : "" %>">
             <td><%= link_to competition.name, competition_path(competition) %></td>
             <td><%= competition.cityName %>, <%= competition.country ? competition.country.name : "" %></td>
-            <td><%= competition.start_date && competition.end_date ? wca_date_range(competition.start_date, competition.end_date) : "Unscheduled" %></td>
+            <td><%= wca_date_range(competition.start_date, competition.end_date) %></td>
             <td>
               <% if !past && current_user.can_manage_competition?(competition) %>
                 <%= link_to "Edit", edit_competition_path(competition) %>

--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -18,40 +18,40 @@
         <th class="big-column"></th>
       </tr>
     </thead>
-    <% competitions.each do |competition| %>
-      <% if competition.isConfirmed %>
-        <% if competition.showAtAll %>
-          <% message = "This competition is confirmed and visible." %>
+    <tbody>
+      <% competitions.each do |competition| %>
+        <% if competition.isConfirmed %>
+          <% if competition.showAtAll %>
+            <% message = "This competition is confirmed and visible." %>
+          <% else %>
+            <% message = "This competition is confirmed but not visible." %>
+          <% end %>
         <% else %>
-          <% message = "This competition is confirmed but not visible." %>
+          <% if competition.showAtAll %>
+            <% message = "This competition is not confirmed but is visible." %>
+          <% else %>
+            <% message = "This competition is not confirmed and not visible." %>
+          <% end %>
         <% end %>
-      <% else %>
-        <% if competition.showAtAll %>
-          <% message = "This competition is not confirmed but is visible." %>
-        <% else %>
-          <% message = "This competition is not confirmed and not visible." %>
-        <% end %>
+          <tr class="<%= competition.isConfirmed ? "confirmed" : "not-confirmed" %> <%= competition.showAtAll ? "visible" : "not-visible" %> <%= !past ? "not-past" : "past" %>" data-toggle="tooltip" data-placement="top" data-container="body" title="<%= !past ? message : "" %>">
+            <td><%= link_to competition.name, competition_path(competition) %></td>
+            <td><%= competition.cityName %>, <%= competition.country ? competition.country.name : "" %></td>
+            <td><%= competition.start_date && competition.end_date ? wca_date_range(competition.start_date, competition.end_date) : "Unscheduled" %></td>
+            <td>
+              <% if !past && current_user.can_manage_competition?(competition) %>
+                <%= link_to "Edit", edit_competition_path(competition) %>
+              <% elsif competition.results.length > 0 %>
+                <span class="glyphicon glyphicon-ok-sign" aria-hidden="true" data-toggle="tooltip" data-placement="top" data-container="body" title="Results are up!"></span>
+              <% end %>
+            </td>
+            <td>
+              <% if !past && competition.use_wca_registration? && current_user.can_manage_competition?(competition) %>
+                <%= link_to "Registrations", competition_edit_registrations_path(competition) %>
+              <% end %>
+            </td>
+            <td class="big-column"></td>
+          </tr>
       <% end %>
-      <tbody>
-        <tr class="<%= competition.isConfirmed ? "confirmed" : "not-confirmed" %> <%= competition.showAtAll ? "visible" : "not-visible" %> <%= !past ? "not-past" : "past" %>" data-toggle="tooltip" data-placement="top" data-container="body" title="<%= !past ? message : "" %>">
-          <td><%= link_to competition.name, competition_path(competition) %></td>
-          <td><%= competition.cityName %>, <%= competition.country.name %></td>
-          <td><%= wca_date_range(competition.start_date, competition.end_date) %></td>
-          <td>
-            <% if !past && current_user.can_manage_competition?(competition) %>
-              <%= link_to "Edit", edit_competition_path(competition) %>
-            <% elsif competition.results.length > 0 %>
-              <span class="glyphicon glyphicon-ok-sign" aria-hidden="true" data-toggle="tooltip" data-placement="top" data-container="body" title="Results are up!"></span>
-            <% end %>
-          </td>
-          <td>
-            <% if !past && competition.use_wca_registration? && current_user.can_manage_competition?(competition) %>
-              <%= link_to "Registrations", competition_edit_registrations_path(competition) %>
-            <% end %>
-          </td>
-          <td class="big-column"></td>
-        </tr>
-      </tbody>
-    <% end %>
+    </tbody>
   </table>
 <% end %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -266,6 +266,7 @@ en:
       missing_dob_html: "WCA ID %{link_id} does not have a birthdate assigned. Please contact the %{link_result_team} to fix this."
       unknown_wca_id_html: "WCA ID %{link_id} does not exist."
   competitions:
+    unscheduled: "unscheduled"
     new:
       create_competition: "Create competition"
     update:

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -571,4 +571,101 @@ describe CompetitionsController do
       end
     end
   end
+
+  describe 'GET #my_competitions' do
+    let!(:delegate) { FactoryGirl.create(:delegate) }
+    let!(:organizer) { FactoryGirl.create(:user) }
+    let!(:future_competition1) { FactoryGirl.create(:competition, :registration_open, starts: 3.week.from_now, organizers: [organizer], delegates: [delegate], eventSpecs: "222 333") }
+    let!(:future_competition2) { FactoryGirl.create(:competition, :registration_open, starts: 2.weeks.from_now, organizers: [organizer], eventSpecs: "222 333") }
+    let!(:future_competition3) { FactoryGirl.create(:competition, :registration_open, starts: 1.weeks.from_now, organizers: [organizer], eventSpecs: "222 333") }
+    let!(:past_competition1) { FactoryGirl.create(:competition, :registration_open, starts: 1.month.ago, organizers: [organizer], eventSpecs: "222 333") }
+    let!(:past_competition2) { FactoryGirl.create(:competition, starts: 2.month.ago, delegates: [delegate], eventSpecs: "222 333") }
+    let!(:past_competition3) { FactoryGirl.create(:competition, :registration_open, starts: 3.month.ago, delegates: [delegate], eventSpecs: "222 333") }
+    let!(:unscheduled_competition1) { FactoryGirl.create(:competition, delegates: [delegate], eventSpecs: "222 333", year: "0") }
+    let!(:registered_user) { FactoryGirl.create :user, name: "Jan-Ove Waldner" }
+    let!(:registration1) { FactoryGirl.create(:registration, competitionId: future_competition1.id, user: registered_user) }
+    let!(:registration2) { FactoryGirl.create(:registration, competitionId: future_competition3.id, user: registered_user) }
+    let!(:registration3) { FactoryGirl.create(:registration, competitionId: past_competition1.id, user: registered_user) }
+    let!(:registration4) { FactoryGirl.create(:registration, competitionId: past_competition3.id, user: organizer) }
+    let!(:registration5) { FactoryGirl.create(:registration, competitionId: future_competition3.id, user: delegate) }
+    let!(:results_person) { FactoryGirl.create(:person, id: "2014PLUM01", name: "Jeff Plumb") }
+    let!(:results_user) { FactoryGirl.create :user, name: "Jeff Plumb", wca_id: "2014PLUM01" }
+
+    context 'when not signed in' do
+      sign_out
+
+      it 'redirects to the sign in page' do
+        get :my_competitions
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context 'when signed in as user with results for a comp they did not register for' do
+      before do
+        sign_in results_user
+      end
+
+      it 'shows my upcoming and past competitions' do
+        Result.create!(
+          pos: 1,
+          personId: "2014PLUM01",
+          personName: "Jeff Plumb",
+          countryId: "AUS",
+          competitionId: past_competition1.id,
+          eventId: "333",
+          roundId: "f",
+          formatId: "a",
+          value1: 2000,
+          value2: 2000,
+          value3: 2000,
+          value4: 2000,
+          value5: 2000,
+          best: 2000,
+          average: 2000,
+          regionalSingleRecord: "WR",
+          regionalAverageRecord: "WR"
+        )
+        get :my_competitions
+        expect(assigns(:not_past_competitions)).to eq []
+        expect(assigns(:past_competitions)).to eq [past_competition1]
+      end
+    end
+
+    context 'when signed in as a regular user' do
+      before do
+        sign_in registered_user
+      end
+
+      it 'shows my upcoming and past competitions' do
+        get :my_competitions
+        expect(assigns(:not_past_competitions)).to eq [future_competition1, future_competition3]
+        expect(assigns(:past_competitions)).to eq [past_competition1]
+      end
+    end
+
+    context 'when signed in as an organizer' do
+      before do
+        sign_in organizer
+      end
+
+      it 'shows my upcoming and past competitions' do
+        get :my_competitions
+        expect(assigns(:not_past_competitions)).to eq [future_competition1, future_competition2, future_competition3]
+        expect(assigns(:past_competitions)).to eq [past_competition1, past_competition3]
+      end
+    end
+
+    context 'when signed in as a delegate' do
+      before do
+        sign_in delegate
+      end
+
+      it 'shows my upcoming and past competitions' do
+        unscheduled_competition1.update_columns(year: 0, month: 0, day: 0, endMonth: 0, endDay: 0)
+        get :my_competitions
+        expect(assigns(:not_past_competitions)).to eq [unscheduled_competition1, future_competition1, future_competition3]
+        expect(assigns(:past_competitions)).to eq [past_competition2, past_competition3]
+      end
+    end
+  end
 end

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -573,16 +573,16 @@ describe CompetitionsController do
   end
 
   describe 'GET #my_competitions' do
-    let!(:delegate) { FactoryGirl.create(:delegate) }
-    let!(:organizer) { FactoryGirl.create(:user) }
+    let(:delegate) { FactoryGirl.create(:delegate) }
+    let(:organizer) { FactoryGirl.create(:user) }
     let!(:future_competition1) { FactoryGirl.create(:competition, :registration_open, starts: 3.week.from_now, organizers: [organizer], delegates: [delegate], eventSpecs: "222 333") }
     let!(:future_competition2) { FactoryGirl.create(:competition, :registration_open, starts: 2.weeks.from_now, organizers: [organizer], eventSpecs: "222 333") }
     let!(:future_competition3) { FactoryGirl.create(:competition, :registration_open, starts: 1.weeks.from_now, organizers: [organizer], eventSpecs: "222 333") }
     let!(:past_competition1) { FactoryGirl.create(:competition, :registration_open, starts: 1.month.ago, organizers: [organizer], eventSpecs: "222 333") }
     let!(:past_competition2) { FactoryGirl.create(:competition, starts: 2.month.ago, delegates: [delegate], eventSpecs: "222 333") }
     let!(:past_competition3) { FactoryGirl.create(:competition, :registration_open, starts: 3.month.ago, delegates: [delegate], eventSpecs: "222 333") }
-    let!(:unscheduled_competition1) { FactoryGirl.create(:competition, delegates: [delegate], eventSpecs: "222 333", year: "0") }
-    let!(:registered_user) { FactoryGirl.create :user, name: "Jan-Ove Waldner" }
+    let!(:unscheduled_competition1) { FactoryGirl.create(:competition, starts: nil, ends: nil, delegates: [delegate], eventSpecs: "222 333", year: "0") }
+    let(:registered_user) { FactoryGirl.create :user, name: "Jan-Ove Waldner" }
     let!(:registration1) { FactoryGirl.create(:registration, competitionId: future_competition1.id, user: registered_user) }
     let!(:registration2) { FactoryGirl.create(:registration, competitionId: future_competition3.id, user: registered_user) }
     let!(:registration3) { FactoryGirl.create(:registration, competitionId: past_competition1.id, user: registered_user) }
@@ -590,6 +590,7 @@ describe CompetitionsController do
     let!(:registration5) { FactoryGirl.create(:registration, competitionId: future_competition3.id, user: delegate) }
     let!(:results_person) { FactoryGirl.create(:person, id: "2014PLUM01", name: "Jeff Plumb") }
     let!(:results_user) { FactoryGirl.create :user, name: "Jeff Plumb", wca_id: "2014PLUM01" }
+    let!(:result) { FactoryGirl.create(:result, person: results_person, competitionId: past_competition1.id) }
 
     context 'when not signed in' do
       sign_out
@@ -606,25 +607,6 @@ describe CompetitionsController do
       end
 
       it 'shows my upcoming and past competitions' do
-        Result.create!(
-          pos: 1,
-          personId: "2014PLUM01",
-          personName: "Jeff Plumb",
-          countryId: "AUS",
-          competitionId: past_competition1.id,
-          eventId: "333",
-          roundId: "f",
-          formatId: "a",
-          value1: 2000,
-          value2: 2000,
-          value3: 2000,
-          value4: 2000,
-          value5: 2000,
-          best: 2000,
-          average: 2000,
-          regionalSingleRecord: "WR",
-          regionalAverageRecord: "WR",
-        )
         get :my_competitions
         expect(assigns(:not_past_competitions)).to eq []
         expect(assigns(:past_competitions)).to eq [past_competition1]
@@ -661,7 +643,6 @@ describe CompetitionsController do
       end
 
       it 'shows my upcoming and past competitions' do
-        unscheduled_competition1.update_columns(year: 0, month: 0, day: 0, endMonth: 0, endDay: 0)
         get :my_competitions
         expect(assigns(:not_past_competitions)).to eq [unscheduled_competition1, future_competition1, future_competition3]
         expect(assigns(:past_competitions)).to eq [past_competition2, past_competition3]

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -623,7 +623,7 @@ describe CompetitionsController do
           best: 2000,
           average: 2000,
           regionalSingleRecord: "WR",
-          regionalAverageRecord: "WR"
+          regionalAverageRecord: "WR",
         )
         get :my_competitions
         expect(assigns(:not_past_competitions)).to eq []

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -11,8 +11,8 @@ FactoryGirl.define do
       ends { starts }
     end
 
-    start_date { starts.strftime("%F") }
-    end_date { ends.strftime("%F") }
+    start_date { starts.nil? ? nil : starts.strftime("%F") }
+    end_date { ends.nil? ? nil : ends.strftime("%F") }
 
     eventSpecs "333 333oh"
     venue "My backyard"


### PR DESCRIPTION
Fixes #495. I modified competitions_controller.rb to put all competitions without a start date first and then sort all competitions that have a start date in reverse order. To ensure the date_range was displayed without error I modified the wca_date_range method to only return the date_range if both a from_date and to_date are passed in. In the view I fixed a bug with <tbody> being shown for each row. Only display the country.name if the country has been selected.

Let me know your thoughts.