### PR TITLE
Don't show results preview when there are no such.

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -483,7 +483,7 @@ class Competition < ActiveRecord::Base
   end
 
   def user_can_view_results?(user)
-    results_posted? || (user && user.can_admin_results?)
+    results_posted? || (!results.empty? && user && user.can_admin_results?)
   end
 
   def in_progress?


### PR DESCRIPTION
Missed here #594. We should enable the results preview for admins only when it makes sense. At the moment it's visible even if the competition is taking place in the future.