### PR TITLE
Add a handy alert helper

### DIFF
--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -127,7 +127,8 @@ module ApplicationHelper
     date_range(from_date, to_date, options)
   end
 
-  def alert(type, content, note: false)
+  def alert(type, content=nil, note: false, &block)
+    content = capture(&block) if block_given?
     content.prepend("<strong>Note:</strong> ") if note
     content_tag :div, content.html_safe, class: "alert alert-#{type}"
   end

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -129,7 +129,7 @@ module ApplicationHelper
 
   def alert(type, content=nil, note: false, &block)
     content = capture(&block) if block_given?
-    content.prepend("<strong>Note:</strong> ") if note
-    content_tag :div, content.html_safe, class: "alert alert-#{type}"
+    content.prepend content_tag(:strong, "Note: ") if note
+    content_tag :div, content, class: "alert alert-#{type}"
   end
 end

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -126,4 +126,9 @@ module ApplicationHelper
     options[:separator] = '-'
     date_range(from_date, to_date, options)
   end
+
+  def alert(type, content, note: false)
+    content.prepend("<strong>Note:</strong> ") if note
+    content_tag :div, content.html_safe, class: "alert alert-#{type}"
+  end
 end

--- a/WcaOnRails/app/views/competitions/_index_competitions_list.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_competitions_list.html.erb
@@ -1,14 +1,13 @@
 <% if params[:display] == "list" %>
   <% if competitions.empty? %>
     <div class="col-md-12">
-      <div class="alert alert-warning">
-        <%= unless params[:event_ids].empty?
+      <%= alert :warning do
+        unless params[:event_ids].empty?
           "We didn't find any competitions with those #{ pluralize(params[:event_ids].count, "event" )}! Try searching for fewer events."
         else
           "No competitions found."
-        end %>
-      </div>
-    </div>
+        end
+      end %>
   <% else %>
     <% if params[:state] == "past" %>
       <div class="col-md-12" id="past-comps">

--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -1,11 +1,11 @@
 <% if competitions.length < 1 %>
-  <div class="alert alert-info" role="alert">
+  <%= alert :info do %>
     <% if !past %>
       You currently have no upcoming competitions! Check out the <%= link_to 'competitions list', competitions_path %>.
     <% else %>
       You have no past competitions.
     <% end %>
-  </div>
+  <% end %>
 <% else %>
   <table class="table competitions-table floatThead <%= past ? "table-striped" : "" %>">
     <thead>

--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -136,17 +136,11 @@
       <hr />
 
       <% @competition.warnings.each do |field, message| %>
-        <div class="alert alert-warning">
-          <strong>Note:</strong>
-          <%= message %>
-        </div>
+        <%= alert :info, message, note: true %>
       <% end %>
 
       <% @competition.info.each do |field, message| %>
-        <div class="alert alert-info">
-          <strong>Note:</strong>
-          <%= message %>
-        </div>
+        <%= alert :info, message, note: true %>
       <% end %>
 
       <%= yield %>

--- a/WcaOnRails/app/views/competitions/_nearby_competitions.html.erb
+++ b/WcaOnRails/app/views/competitions/_nearby_competitions.html.erb
@@ -12,17 +12,17 @@
     <% if @competition.has_date? && @competition.has_location? %>
       <% nearby_competitions = @competition.nearby_competitions(Competition::NEARBY_DAYS_WARNING, Competition::NEARBY_DISTANCE_KM_WARNING)[0, 10] %>
       <% if nearby_competitions.empty? %>
-        <div class="alert alert-success" role="alert"><%= t '.no_comp_nearby' %></div>
+        <%= alert :success, t('.no_comp_nearby') %>
       <% else %>
         <%= render 'nearby_competitions_table', nearby_competitions: nearby_competitions %>
       <% end %>
     <% else %>
       <% nearby_competitions = [] %>
-      <% if !@competition.has_date? %>
-        <div class="alert alert-danger" role="alert"><%= t '.no_date_yet' %></div>
+      <% unless @competition.has_date? %>
+        <%= alert :danger, t('.no_date_yet') %>
       <% end %>
-      <% if !@competition.has_location? %>
-        <div class="alert alert-danger" role="alert"><%= t '.no_location_yet' %></div>
+      <% unless @competition.has_location? %>
+        <%= alert :danger, t('.no_location_yet') %>
       <% end %>
     <% end %>
   </div>

--- a/WcaOnRails/app/views/competitions/_results_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_results_nav.html.erb
@@ -3,9 +3,7 @@
 
   <% if @competition.user_can_view_results?(current_user) %>
     <% if !@competition.results_posted? %>
-      <div class="alert alert-warning">
-        <strong>Note:</strong> You are viewing results that have not been posted yet.
-      </div>
+      <%= alert :warning, t('.results_preview_alert'), note: true %>
     <% end %>
     <%= yield %>
   <% end %>

--- a/WcaOnRails/app/views/competitions/edit.html.erb
+++ b/WcaOnRails/app/views/competitions/edit.html.erb
@@ -32,23 +32,15 @@
       <%= f.input :isConfirmed %>
       <%= f.input :showAtAll %>
     <% else %>
-      <% if is_actually_confirmed && @competition.showAtAll? %>
-        <div class="alert alert-success">
-          <%= t '.locked_edit_html', board: mail_to_wca_board %>
-        </div>
-      <% elsif is_actually_confirmed && !@competition.showAtAll? %>
-        <div class="alert alert-warning">
-          <%= t '.confirmed_not_visible_html', board: mail_to_wca_board %>
-        </div>
-      <% elsif !is_actually_confirmed && @competition.showAtAll? %>
-        <div class="alert alert-danger">
-          <%= t '.is_visible' %>
-        </div>
-      <% elsif !is_actually_confirmed && !@competition.showAtAll? %>
-        <div class="alert alert-warning">
-          <%= t '.awaiting_confirmation_html', board: mail_to_wca_board %>
-        </div>
-      <% end %>
+      <%= if is_actually_confirmed && @competition.showAtAll?
+            alert :success, t('.locked_edit_html', board: mail_to_wca_board)
+          elsif is_actually_confirmed && !@competition.showAtAll?
+            alert :warning, t('.confirmed_not_visible_html', board: mail_to_wca_board)
+          elsif !is_actually_confirmed && @competition.showAtAll?
+            alert :danger, t('.is_visible')
+          elsif !is_actually_confirmed && !@competition.showAtAll?
+            alert :warning, t('.awaiting_confirmation_html', board: mail_to_wca_board)
+          end %>
     <% end %>
 
     <% if @competition_admin_view || !is_actually_confirmed %>

--- a/WcaOnRails/app/views/devise/_conversion_message.html.erb
+++ b/WcaOnRails/app/views/devise/_conversion_message.html.erb
@@ -4,13 +4,13 @@
   <% wca_id = user.login.upcase %>
   <% person = Person.find_by_id(wca_id) %>
   <% if person && !person.user %>
-    <div class="alert alert-info">
+    <%= alert :info do %>
       Hi, <%= person.name %>! It looks like you have not created a WCA website account yet.      Please create one
       <%= link_to "here", new_user_registration_path %>. Afterwards, you
       can request that it be connected to your WCA ID
       (<%= render "shared/wca_id", wca_id: wca_id %>).
       <% conversion_shown = true %>
-    </div>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/WcaOnRails/app/views/oauth/applications/_form.html.erb
+++ b/WcaOnRails/app/views/oauth/applications/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_for application, url: doorkeeper_submit_path(application), html: {class: 'form-horizontal', role: 'form'} do |f| %>
   <% if application.errors.any? %>
-    <div class="alert alert-danger" data-alert><p><%= t('doorkeeper.applications.form.error') %></p></div>
+    <%= alert :danger, t('doorkeeper.applications.form.error') %>
   <% end %>
 
   <%= content_tag :div, class: "form-group#{' has-error' if application.errors[:name].present?}" do %>

--- a/WcaOnRails/app/views/polls/edit.html.erb
+++ b/WcaOnRails/app/views/polls/edit.html.erb
@@ -6,15 +6,11 @@
 
   <% is_actually_confirmed = Poll.find(@poll.id).confirmed? %>
   <% if is_actually_confirmed %>
-    <% if @poll.over? %>
-      <div class="alert alert-danger">
-        This poll is closed (deadline has passed). Check out the <%= link_to "results", polls_results_path(@poll) %>.
-    </div>
-    <% else %>
-      <div class="alert alert-info">
-        This poll is open to <%= link_to "voting", polls_vote_path(@poll) %>. Editing question or options is not allowed.
-      </div>
-    <% end %>
+    <%= if @poll.over?
+          alert :danger, "This poll is closed (deadline has passed). Check out the #{link_to "results", polls_results_path(@poll)}"
+        else
+          alert :info, "This poll is open to #{link_to "voting", polls_vote_path(@poll)}. Editing question or options is not allowed."
+        end %>
     <script>
     $(document).ready(function() {
       $("#poll_question").prop("disabled", true);
@@ -27,9 +23,8 @@
     });
     </script>
   <% else %>
-    <div class="alert alert-info">
-      This poll is not open to voting. You can see a preview <%= link_to 'here', polls_vote_path, target: '_blank' %>. Click confirm when you're ready to enable voting!
-    </div>
+    <%= alert :info, "This poll is not open to voting. You can see a preview #{link_to 'here', polls_vote_path, target: '_blank'}.
+                      Click confirm when you're ready to enable voting!" %>
   <% end %>
 
   <%= simple_form_for @poll, html: { class: 'form-horizontal are-you-sure no-submit-on-enter' }, wrapper: :horizontal_form,

--- a/WcaOnRails/app/views/polls/edit.html.erb
+++ b/WcaOnRails/app/views/polls/edit.html.erb
@@ -6,11 +6,15 @@
 
   <% is_actually_confirmed = Poll.find(@poll.id).confirmed? %>
   <% if is_actually_confirmed %>
-    <%= if @poll.over?
-          alert :danger, "This poll is closed (deadline has passed). Check out the #{link_to "results", polls_results_path(@poll)}"
-        else
-          alert :info, "This poll is open to #{link_to "voting", polls_vote_path(@poll)}. Editing question or options is not allowed."
-        end %>
+    <%= if @poll.over? %>
+      <%= alert :danger do %>
+        This poll is closed (deadline has passed). Check out the <%= link_to "results", polls_results_path(@poll) %>.
+      <% end %>
+    <% else %>
+      <%= alert :info do %>
+        This poll is open to <%= link_to "voting", polls_vote_path(@poll) %>. Editing question or options is not allowed.
+      <% end %>
+    <% end %>
     <script>
     $(document).ready(function() {
       $("#poll_question").prop("disabled", true);
@@ -23,8 +27,10 @@
     });
     </script>
   <% else %>
-    <%= alert :info, "This poll is not open to voting. You can see a preview #{link_to 'here', polls_vote_path, target: '_blank'}.
-                      Click confirm when you're ready to enable voting!" %>
+    <%= alert :info do %>
+      This poll is not open to voting. You can see a preview <%= link_to 'here', polls_vote_path, target: '_blank'} %>.
+      Click confirm when you're ready to enable voting!
+    <% end %>
   <% end %>
 
   <%= simple_form_for @poll, html: { class: 'form-horizontal are-you-sure no-submit-on-enter' }, wrapper: :horizontal_form,

--- a/WcaOnRails/app/views/polls/index.html.erb
+++ b/WcaOnRails/app/views/polls/index.html.erb
@@ -10,7 +10,7 @@
   </h1>
 
   <% if @polls.empty? %>
-    <div class="alert alert-warning">There are currently no polls.</div>
+    <%= alert :warning, "There are currently no polls." %>
   <% else %>
     <h4>Open polls</h4>
     <%= render 'polls_list', polls: @open_polls %>

--- a/WcaOnRails/app/views/polls/results.html.erb
+++ b/WcaOnRails/app/views/polls/results.html.erb
@@ -40,9 +40,8 @@
       </tr>
     </table>
   <% else %>
-    <div class="alert alert-warning">
-      Voting is not closed yet. Please come back on <%= wca_local_time(@poll.deadline) %>, in <%= distance_of_time_in_words_to_now(@poll.deadline) %> to see the results.
-    </div>
+    <%= alert :warning, "Voting is not closed yet. Please come back on #{wca_local_time(@poll.deadline)},
+                         in #{distance_of_time_in_words_to_now(@poll.deadline)} to see the results." %>
   <% end %>
   <%= link_to icon("undo", "Back to Polls"), polls_path, class: "btn btn-default" %>
 </div>

--- a/WcaOnRails/app/views/polls/results.html.erb
+++ b/WcaOnRails/app/views/polls/results.html.erb
@@ -40,8 +40,10 @@
       </tr>
     </table>
   <% else %>
-    <%= alert :warning, "Voting is not closed yet. Please come back on #{wca_local_time(@poll.deadline)},
-                         in #{distance_of_time_in_words_to_now(@poll.deadline)} to see the results." %>
+    <%= alert :warning do %>
+      Voting is not closed yet. Please come back on <%= wca_local_time(@poll.deadline) %>,
+      in <%= distance_of_time_in_words_to_now(@poll.deadline) %> to see the results.
+    <% end %>
   <% end %>
   <%= link_to icon("undo", "Back to Polls"), polls_path, class: "btn btn-default" %>
 </div>

--- a/WcaOnRails/app/views/registrations/edit.html.erb
+++ b/WcaOnRails/app/views/registrations/edit.html.erb
@@ -12,8 +12,9 @@
     <%= f.hidden_field :updated_at %>
 
     <% if @registration.user %>
-      <%= alert :info, "This person registered with an account. You can edit their personal information #{link_to "here", edit_user_path(@registration.user)}" %>
-
+      <%= alert :info do %>
+        This person registered with an account. You can edit their personal information <%= link_to "here", edit_user_path(@registration.user) %>.
+      <% end %>
       <%= @registration.name %>
     <% else %>
       <%= alert :info, "This person did not register with an account. You can edit their personal information below." %>

--- a/WcaOnRails/app/views/registrations/edit.html.erb
+++ b/WcaOnRails/app/views/registrations/edit.html.erb
@@ -12,17 +12,11 @@
     <%= f.hidden_field :updated_at %>
 
     <% if @registration.user %>
-      <div class="alert alert-info">
-        This person registered with an account. You can edit their personal information
-        <%= link_to "here", edit_user_path(@registration.user) %>.
-      </div>
+      <%= alert :info, "This person registered with an account. You can edit their personal information #{link_to "here", edit_user_path(@registration.user)}" %>
 
       <%= @registration.name %>
     <% else %>
-      <div class="alert alert-info">
-        This person did not register with an account. You can edit their personal
-        information below.
-      </div>
+      <%= alert :info, "This person did not register with an account. You can edit their personal information below." %>
 
       <%# We can remove this code once competitions only have registrations with accounts. See https://github.com/cubing/worldcubeassociation.org/issues/275 %>
       <%= f.input :name %>

--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -1,31 +1,20 @@
 <% provide(:title, "Register for #{@competition.name}") %>
 
 <%= render layout: "nav" do %>
-  <% if !@competition.registration_opened? %>
+  <% opens_in_days = distance_of_time_in_words_to_now(@competition.registration_open) %>
+  <% closes_in_days = distance_of_time_in_words_to_now(@competition.registration_close) %>
+  <% unless @competition.registration_opened? %>
     <% if @competition.registration_not_yet_opened? %>
-      <div class="alert alert-info">
-        <% #This internationally works because datetime.distance_in_words.x_days is translated.%>
-        <%= t '.registration.will_open_html',
-              days: distance_of_time_in_words_to_now(@competition.registration_open),
-              time: wca_local_time(@competition.registration_open) %>
-      </div>
+      <%= alert :info, t('.registration.will_open_html', days: opens_in_days, time: wca_local_time(@competition.registration_open)) %>
     <% end %>
     <% if @competition.registration_past? %>
-      <div class="alert alert-danger">
-        <%= t '.registration.closed_html',
-              days: distance_of_time_in_words_to_now(@competition.registration_close),
-              time: wca_local_time(@competition.registration_close) %>
-      </div>
+      <%= alert :danger, t('.registration.closed_html', days: closes_in_days, time: wca_local_time(@competition.registration_close)) %>
     <% end %>
   <% else %>
-    <div class="alert alert-info">
-      <%= t '.registration.will_close_html',
-            days: distance_of_time_in_words_to_now(@competition.registration_close),
-            time: wca_local_time(@competition.registration_close) %>
-    </div>
+    <%= alert :info, t('.registration.will_close_html', days: closes_in_days, time: wca_local_time(@competition.registration_close)) %>
   <% end %>
 
-  <% if !current_user %>
+  <% unless current_user %>
     <% if @competition.registration_past? %>
       <%= t '.registration.please_sign_in_past_html',
         sign_in: link_to(t('.registration.sign_in'), competition_register_require_sign_in_path(@competition)),
@@ -74,16 +63,10 @@
             <% end %>
 
             <% if @registration.pending? %>
-              <div class="alert alert-warning">
-                <% waiting_list_info = @registration.waiting_list_info %>
-                <%= t '.registration.waiting_list',
-                      i: waiting_list_info.index + 1,
-                      n: waiting_list_info.length %>
-              </div>
+              <% waiting_list_info = @registration.waiting_list_info %>
+              <%= alert :warning, t('.registration.waiting_list', i: waiting_list_info.index + 1, n: waiting_list_info.length) %>
             <% else %>
-              <div class="alert alert-success">
-                <%= t '.registration.accepted' %>
-              </div>
+              <%= alert :success, t('.registration.accepted') %>
             <% end %>
           <% end %>
         </div>

--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -33,16 +33,14 @@
 
     <% if @competition.registration_opened? %>
       <% if current_user.preferred_events.empty? %>
-        <div class="alert alert-info">
-          To speed up registration in the future, you can set your preferred events <%= link_to "here", profile_edit_path(current_user, section: :preferences) %>.
-        </div>
+        <%= alert :info, t('.registration.preferred_events_prompt', link: link_to(t('common.here'), profile_edit_path(current_user, section: :preferences))) %>
       <% end %>
       <p>
       <%= t '.registration.greeting', name: current_user.name %>
       </p>
 
       <% if current_user.cannot_register_for_competition_reasons.length > 0 %>
-        <div class="alert alert-danger">
+        <%= alert :danger do %>
           <%= t '.registration.please_fix_profile_html', comp: @competition.name,
                 profile: link_to(t('.registration.profile'), profile_edit_path) %>
           <ul>
@@ -50,7 +48,7 @@
               <li><%= reason %></li>
             <% end %>
           </ul>
-        </div>
+        <% end %>
       <% else %>
         <div>
           <% if @registration.new_record? %>

--- a/WcaOnRails/app/views/shared/_error_messages.html.erb
+++ b/WcaOnRails/app/views/shared/_error_messages.html.erb
@@ -1,12 +1,12 @@
 <% if object.errors.any? %>
   <div id="error_explanation">
-    <div class="alert alert-danger">
+    <%= alert :danger do %>
       <%= t 'errors.messages.form_error', x_error: pluralize(object.errors.count, t('errors.messages.error')) %>
       <ul>
         <% object.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>
         <% end %>
       </ul>
-    </div>
+    <% end %>
   </div>
 <% end %>

--- a/WcaOnRails/app/views/static_pages/contact.html.erb
+++ b/WcaOnRails/app/views/static_pages/contact.html.erb
@@ -3,10 +3,10 @@
 <div class="container">
   <h1><%= yield(:title) %></h1>
 
-  <div class="alert alert-info" role="alert">
+  <%= alert :info do %>
     Before contacting any of the teams on this page,
     please take a look at our <%= link_to "frequently asked questions", faq_path %>!
-  </div>
+  <% end %>
 
   <p>
     For website questions, comments, and suggestions, use this

--- a/WcaOnRails/app/views/teams/index.html.erb
+++ b/WcaOnRails/app/views/teams/index.html.erb
@@ -4,7 +4,7 @@
   <h1><%= yield(:title) %></h1>
 
   <% if @teams.empty? %>
-    <div class="alert alert-warning">There are currently no teams.</div>
+    <%= alert :warning, "There are currently no teams." %>
   <% else %>
     <div class="table-responsive">
       <table class="table teams-table">

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -4,32 +4,20 @@
   <h1 class="text-center"><%= yield(:title) %> (<%= mail_to @user.email %>)</h1>
   <%= render 'shared/error_messages', object: @user %>
 
-  <% if !@user.confirmed_at %>
+  <% unless @user.confirmed_at %>
     <%= alert :warning, t('.unconfirmed_email', email: @user.email) %>
-    <% if @user.unconfirmed_wca_id.present? %>
-      <div class="alert alert-warning">
-        <%= t '.pending_claim_mail_confirmation_html',
-              delegate: mail_to(@user.delegate_to_handle_wca_id_claim.email, @user.delegate_to_handle_wca_id_claim.name, target: "_blank"),
-              wca_id: render("shared/wca_id", wca_id: @user.unconfirmed_wca_id)
-        %>
-      </div>
-    <% end %>
-  <% else %>
-    <% if @user.unconfirmed_wca_id.present? %>
-      <div class="alert alert-warning">
-        <%= t '.pending_claim_confirmation_html',
-              delegate: mail_to(@user.delegate_to_handle_wca_id_claim.email, @user.delegate_to_handle_wca_id_claim.name, target: "_blank"),
-              wca_id: render("shared/wca_id", wca_id: @user.unconfirmed_wca_id)
-        %>
-      </div>
-    <% end %>
   <% end %>
-
+  <% if @user.unconfirmed_wca_id.present? %>
+    <% mail_to_delegate = mail_to(@user.delegate_to_handle_wca_id_claim.email, @user.delegate_to_handle_wca_id_claim.name, target: "_blank") %>
+    <% wca_id_partial = render("shared/wca_id", wca_id: @user.unconfirmed_wca_id) %>
+    <% message = @user.confirmed_at ? '.pending_claim_confirmation_html' : '.pending_claim_mail_confirmation_html' %>
+    <%= alert :warning, t(message, delegate: mail_to_delegate, wca_id: wca_id_partial) %>
+  <% end %>
   <% if @user.unconfirmed_email %>
     <%= alert :warning, t('.pending_mail_confirmation', email: @user.unconfirmed_email) %>
   <% end %>
   <% if @user.pending_avatar? %>
-    <div class="alert alert-warning">
+    <%= alert :warning do %>
       <%= t '.pending_avatar_confirmation' %>
       <%= link_to users_pending_avatar_thumbnail_edit_path(@user) do %>
         <%= render "shared/user_avatar", user: @user, show_pending: true, title: t('.edit_thumbnail'), break_cache: true %>
@@ -37,26 +25,26 @@
       <% if current_user.can_admin_results? %>
         <%= link_to t('.manage_pending'), admin_avatars_path %>
       <% end %>
-    </div>
+    <% end %>
   <% end %>
   <% if @user.dummy_account? %>
-    <div class="alert alert-warning">
+    <%= alert :warning do %>
       This account is a dummy account. It serves as a placeholder because the competitor
       uploaded a profile picture before the website supported WCA accounts. This
       acount will be automatically deleted when another user is assigned WCA
       id <%= @user.wca_id %>.
       See <%= link_to "this commit", "https://github.com/cubing/worldcubeassociation.org/commit/32624f95b2c9e68967f8680ffa3ed7aefccd5319", target: "_blank" %> for more details.
-    </div>
+    <% end %>
   <% end %>
   <% if @user.cannot_register_for_competition_reasons.length > 0 %>
-    <div class="alert alert-warning">
+    <%= alert :warning do %>
       <%= t '.please_fix_profile' %>
       <ul>
         <% @user.cannot_register_for_competition_reasons.each do |reason| %>
           <li><%= reason %></li>
         <% end %>
       </ul>
-    </div>
+    <% end %>
   <% end %>
   <% if current_user.cannot_edit_data_reason_html(@user) %>
     <%= alert :warning, current_user.cannot_edit_data_reason_html(@user) %>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -5,9 +5,7 @@
   <%= render 'shared/error_messages', object: @user %>
 
   <% if !@user.confirmed_at %>
-    <div class="alert alert-warning">
-      This account's email address (<%= @user.email %>) is not confirmed.
-    </div>
+    <%= alert :warning, t('.unconfirmed_email', email: @user.email) %>
     <% if @user.unconfirmed_wca_id.present? %>
       <div class="alert alert-warning">
         <%= t '.pending_claim_mail_confirmation_html',
@@ -28,9 +26,7 @@
   <% end %>
 
   <% if @user.unconfirmed_email %>
-    <div class="alert alert-warning">
-      <%= t '.pending_mail_confirmation', email: @user.unconfirmed_email %>
-    </div>
+    <%= alert :warning, t('.pending_mail_confirmation', email: @user.unconfirmed_email) %>
   <% end %>
   <% if @user.pending_avatar? %>
     <div class="alert alert-warning">
@@ -63,9 +59,7 @@
     </div>
   <% end %>
   <% if current_user.cannot_edit_data_reason_html(@user) %>
-    <div class="alert alert-warning">
-      <%= current_user.cannot_edit_data_reason_html(@user) %>
-    </div>
+    <%= alert :warning, current_user.cannot_edit_data_reason_html(@user) %>
   <% end %>
 
   <% editable_fields = current_user.editable_fields_of_user(@user) %>

--- a/WcaOnRails/app/views/votes/vote.html.erb
+++ b/WcaOnRails/app/views/votes/vote.html.erb
@@ -3,24 +3,20 @@
 <div class="container">
 
   <% if @poll.over? %>
-    <div class="alert alert-danger">Poll is closed. Check out the <%= link_to "results", polls_results_path(@poll) %>.</div>
+    <%= alert :danger, "Poll is closed. Check out the #{link_to "results", polls_results_path(@poll)}." %>
   <% elsif @poll.confirmed || current_user.can_create_poll? %>
 
     <% if @poll.confirmed %>
-      <div class="alert alert-info">
-        Voting closes in <%= distance_of_time_in_words_to_now(@poll.deadline) %>, on <%= wca_local_time(@poll.deadline) %>.
-      </div>
+      <%= alert :info, "Voting closes in #{distance_of_time_in_words_to_now(@poll.deadline)}, on #{wca_local_time(@poll.deadline)}." %>
     <% else %>
-      <div class="alert alert-danger">
-        This is just a preview! You can confirm this poll <%= link_to "here", edit_poll_path %>.
-      </div>
+      <%= alert :danger, "This is just a preview! You can confirm this poll #{link_to "here", edit_poll_path}." %>
     <% end %>
 
     <h3><%=md @poll.question %></h3>
     <%=md @poll.comment %>
 
     <% if !@vote.new_record? %>
-      <div class="alert alert-warning"><p>You have already voted for this poll!</p><p>You can edit your vote below</p></div>
+      <%= alert :warning, "<p>You have already voted for this poll!</p><p>You can edit your vote below</p>" %>
     <% end %>
 
     <%= simple_form_for @vote do |f| %>
@@ -54,6 +50,6 @@
     <% end %>
 
   <% else %>
-    <div class="alert alert-danger">Voting is not open</div>
+    <%= alert "Voting is not open." %>
   <% end %>
 </div>

--- a/WcaOnRails/app/views/votes/vote.html.erb
+++ b/WcaOnRails/app/views/votes/vote.html.erb
@@ -3,20 +3,28 @@
 <div class="container">
 
   <% if @poll.over? %>
-    <%= alert :danger, "Poll is closed. Check out the #{link_to "results", polls_results_path(@poll)}." %>
+    <%= alert :danger do %>
+      Poll is closed. Check out the <%= link_to "results", polls_results_path(@poll) %>.
+    <% end %>
   <% elsif @poll.confirmed || current_user.can_create_poll? %>
 
     <% if @poll.confirmed %>
-      <%= alert :info, "Voting closes in #{distance_of_time_in_words_to_now(@poll.deadline)}, on #{wca_local_time(@poll.deadline)}." %>
+      <%= alert :info do %>
+        Voting closes in <%= distance_of_time_in_words_to_now(@poll.deadline) %>, on <%= wca_local_time(@poll.deadline) %>.
+      <% end %>
     <% else %>
-      <%= alert :danger, "This is just a preview! You can confirm this poll #{link_to "here", edit_poll_path}." %>
+      <%= alert :danger do %>
+        This is just a preview! You can confirm this poll <%= link_to "here", edit_poll_path %>.
+      <% end %>
     <% end %>
 
     <h3><%=md @poll.question %></h3>
     <%=md @poll.comment %>
 
     <% if !@vote.new_record? %>
-      <%= alert :warning, "<p>You have already voted for this poll!</p><p>You can edit your vote below</p>" %>
+      <%= alert :warning do %>
+        <p>You have already voted for this poll!</p><p>You can edit your vote below</p>
+      <% end %>
     <% end %>
 
     <%= simple_form_for @vote do |f| %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -243,6 +243,7 @@ en:
       unconfirmed_wca_id: "Unconfirmed WCA ID"
       profile: "Profile"
       approve: "Approve"
+      unconfirmed_email: "This account's email address (%{email}) is not confirmed."
       pending_mail_confirmation: "This account is pending confirmation of new email address %{email}."
       pending_avatar_confirmation: "This account is pending confirmation of a new avatar."
       pending_claim_confirmation_html: "This account is waiting for %{delegate} to confirm their claimed WCA ID %{wca_id}."
@@ -308,7 +309,7 @@ en:
         delete_registration: "Delete registration."
         will_open_html: "Registration will open in <strong>%{days}</strong> on %{time}."
         will_close_html: "Registration closes in <strong>%{days}</strong> on %{time}."
-        closed_html: "Registration closed <strong>%{days}</strong> ago on %{time} %>."
+        closed_html: "Registration closed <strong>%{days}</strong> ago on %{time}."
         please_sign_in_past_html: "%{sign_in} to check the status of your registration. If you do not yet have a WCA account, you can create one %{here}, but it is too late to register for this competition."
         please_sign_in_not_yet_open_html: "%{sign_in} to check the status of your registration. If you do not yet have a WCA account, you can create one %{here}, but its registration is not yet open."
         please_sign_in_html: "%{sign_in} to register for %{comp}. If you do not yet have a WCA account, you can create one %{here}"
@@ -351,5 +352,6 @@ en:
       submit_confirm: "Are you sure you're ready to confirm? After confirming, you won't be able to modify any information. Check your email after this to verify that the Board was notified."
       submit_delete: "Are you sure you want to delete this competition? There is no going back."
       coordinates: "Coordinates"
+      results_preview_alert: "You are viewing results that have not been posted yet."
   notifications:
     connect_wca_id: "Connect your WCA ID to your account!"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -320,6 +320,7 @@ en:
         contact_organizer: "Contact the organizer if you wish to make a change."
         waiting_list: "You are currently number %{i} of %{n} on the waiting list."
         accepted: "Your registration has been accepted!"
+        preferred_events_prompt: "To speed up registration in the future, you can set your preferred events %{link}."
       menu:
         results: "Results"
         podiums: "Podiums"


### PR DESCRIPTION
This adds the `alert` helper method and makes use of it.
Use it as follows:
- One-line alerts
```ruby
<%= alert :success, "You've succeeded!" %>
```

- Longer alerts
```ruby
<%= alert :success do %>
  A list of errors:
  <% errors.each do |error| %>
    Here I am: <%= error %>
  <% end %>
<% end %>
```

- Alerts with `Note:`
```ruby
<%= alert :success, "You've succeeded!", note: true %>
```