### PR TITLE
Eager load registration_events and user when rendering registration page

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -66,7 +66,7 @@ class RegistrationsController < ApplicationController
 
   def index
     @competition = competition_from_params
-    @registrations = @competition.registrations.accepted
+    @registrations = @competition.registrations.accepted.includes(:user, :registration_events)
   end
 
   def edit

--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -9,7 +9,7 @@
       <% else %>
         <h2>Approved registrations</h2>
       <% end %>
-      <% registrations = @competition.registrations.send(status) %>
+      <% registrations = @competition.registrations.public_send(status).includes(:user, :registration_events) %>
       <%= wca_table table_class: "registrations-table #{status}",
                     data: { toggle: "table", sort_name: "registration-date", select_item_name: "selected_registrations[]", click_to_select: "true" } do %>
         <thead>


### PR DESCRIPTION
For every row on the `registrations#index` page we made two SQL requests. This PR fixes that.