### PR TITLE
Results notifications

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -225,7 +225,7 @@ class CompetitionsController < ApplicationController
       end
     end
     comp.update!(results_posted_at: Time.now)
-    comp.competitor_users.each { |user| user.notify_of_results_presence(comp) }
+    comp.competitor_users.each { |user| user.notify_of_results_posted(comp) }
     create_post_and_redirect(title: title, body: body, author: current_user, world_readable: true)
   end
 

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -225,6 +225,9 @@ class CompetitionsController < ApplicationController
       end
     end
     comp.update!(results_posted_at: Time.now)
+    comp.competitor_users.each do |user|
+      CompetitionsMailer.notify_users_of_results_presence(user, comp).deliver_now
+    end
     create_post_and_redirect(title: title, body: body, author: current_user, world_readable: true)
   end
 

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -225,9 +225,7 @@ class CompetitionsController < ApplicationController
       end
     end
     comp.update!(results_posted_at: Time.now)
-    comp.competitor_users.each do |user|
-      CompetitionsMailer.notify_users_of_results_presence(user, comp).deliver_now
-    end
+    comp.competitor_users.each { |user| user.notify_of_results_presence(comp) }
     create_post_and_redirect(title: title, body: body, author: current_user, world_readable: true)
   end
 

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -136,6 +136,6 @@ module ApplicationHelper
   def users_to_sentence(users, include_email: false)
     users.sort_by(&:name).map do |user|
       include_email ? mail_to(user.email, user.name) : user.name
-    end.to_sentence(last_word_connector: " and ").html_safe
+    end.to_sentence.html_safe
   end
 end

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -132,4 +132,10 @@ module ApplicationHelper
     content.prepend content_tag(:strong, "Note: ") if note
     content_tag :div, content, class: "alert alert-#{type}"
   end
+
+  def users_to_sentence(users, include_email: false)
+    users.sort_by(&:name).map do |user|
+      include_email ? mail_to(user.email, user.name) : user.name
+    end.to_sentence(last_word_connector: " and ").html_safe
+  end
 end

--- a/WcaOnRails/app/helpers/static_pages_helper.rb
+++ b/WcaOnRails/app/helpers/static_pages_helper.rb
@@ -2,6 +2,6 @@ module StaticPagesHelper
   def format_team_members(team_friendly_id)
     Team.find_by_friendly_id!(team_friendly_id).current_members.includes(:user).order(team_leader: :desc).order("users.name asc").map do |u|
       u.user.name + (u.team_leader ? " (leader)" : "")
-    end.to_sentence(last_word_connector: " and ")
+    end.to_sentence
   end
 end

--- a/WcaOnRails/app/mailers/application_mailer.rb
+++ b/WcaOnRails/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
   default from: WcaOnRails::Application.config.default_from_address
   layout 'mailer'
+  helper :application
 end

--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -9,4 +9,13 @@ class CompetitionsMailer < ApplicationMailer
       subject: "#{confirmer.name} just confirmed #{competition.name}"
     )
   end
+
+  def notify_users_of_results_presence(user, competition)
+    @competition = competition
+    @user = user
+    mail(
+      to: user.email,
+      subject: "The results of #{competition.name} are posted"
+    )
+  end
 end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -7,6 +7,8 @@ class Competition < ActiveRecord::Base
 
   has_many :registrations, foreign_key: "competitionId"
   has_many :results, foreign_key: "competitionId"
+  has_many :competitors, -> { distinct }, through: :results, source: :person
+  has_many :competitor_users, -> { distinct }, through: :competitors, source: :user
   has_many :competition_delegates, dependent: :delete_all
   has_many :delegates, through: :competition_delegates
   has_many :competition_organizers, dependent: :delete_all

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -462,6 +462,7 @@ class User < ActiveRecord::Base
       fields << :email
       fields << :preferred_events
       fields << { user_preferred_events_attributes: [:id, :event_id, :_destroy] }
+      fields << :results_notifications_enabled
     end
     if admin? || board_member?
       fields << :delegate_status
@@ -487,6 +488,12 @@ class User < ActiveRecord::Base
       fields << :remove_avatar
     end
     fields
+  end
+
+  def notify_of_results_presence(competition)
+    if results_notifications_enabled?
+      CompetitionsMailer.notify_users_of_results_presence(self, competition).deliver_now
+    end
   end
 
   def self.find_first_by_auth_conditions(warden_conditions)

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -490,7 +490,7 @@ class User < ActiveRecord::Base
     fields
   end
 
-  def notify_of_results_presence(competition)
+  def notify_of_results_posted(competition)
     if results_notifications_enabled?
       CompetitionsMailer.notify_users_of_results_presence(self, competition).deliver_now
     end

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -24,20 +24,14 @@
       <% if competition.organizers.length > 0 %>
         <dt><%= "Organizer".pluralize(competition.organizers.length) %></dt>
         <dd>
-          <%=md competition.organizers.order(:name).map { |u|
-            # If the contact field is present, don't show organizers' emails.
-            if competition.contact.present?
-              u.name
-            else
-              "[#{u.name}](mailto:#{u.email})"
-            end
-          }.to_sentence %>
+          <%# If the contact field is present, don't show organizers' emails. %>
+          <%= users_to_sentence competition.organizers, include_email: competition.contact.blank? %>
         </dd>
       <% end %>
 
       <dt><%= "WCA Delegate".pluralize(competition.delegates.length) %></dt>
       <dd>
-        <%=md competition.delegates.order(:name).map { |u| "[#{u.name}](mailto:#{u.email})" }.to_sentence %>
+        <%= users_to_sentence competition.delegates, include_email: true %>
       </dd>
 
       <% if competition.contact.present? %>

--- a/WcaOnRails/app/views/competitions/_nearby_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_nearby_competitions_table.html.erb
@@ -9,7 +9,7 @@
   <% nearby_competitions.each do |c| %>
     <tr class="<%= @competition.dangerously_close_to?(c) ? "danger" : "warning" %>">
       <td class="text-nowrap"><%= link_to c.name, admin_edit_competition_path(c.id) %></td>
-      <td><%= c.delegates.map(&:name).to_sentence %></td>
+      <td><%= users_to_sentence c.delegates %></td>
       <td data-toggle="tooltip" data-placement="top" data-container="body" title="<%= c.name %> starts on <%= c.start_date %>">
       <% days_until = (c.start_date - @competition.start_date).to_i %>
       <%=t('datetime.distance_in_words.x_days', count: days_until.abs) %> <%= days_until < 0 ? t('.before') : t('.after') %>

--- a/WcaOnRails/app/views/competitions_mailer/notify_users_of_results_presence.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_users_of_results_presence.html.erb
@@ -1,5 +1,5 @@
 <p>
-  The results of <%= link_to @competition.name, competition_url(@competition) %> you've competed recently are now available.
+  Your results at <%= link_to @competition.name, competition_url(@competition) %> have just been posted.
 </p>
 
 <p>
@@ -7,5 +7,6 @@
 </p>
 
 <p>
-  Regards, <%= users_to_sentence @competition.managers %>.
+  Regards,
+  The WCA Results Team on behalf of <%= users_to_sentence @competition.managers %>.
 </p>

--- a/WcaOnRails/app/views/competitions_mailer/notify_users_of_results_presence.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_users_of_results_presence.html.erb
@@ -1,0 +1,11 @@
+<p>
+  The results of <%= link_to @competition.name, competition_url(@competition) %> you've competed recently are now available.
+</p>
+
+<p>
+  Check out all your results <%= link_to "here", competition_results_by_person_url(@competition, anchor: @user.wca_id) %>.
+</p>
+
+<p>
+  Regards, <%= @competition.managers.map(&:name).sort.to_sentence(last_word_connector: " and ") %>.
+</p>

--- a/WcaOnRails/app/views/competitions_mailer/notify_users_of_results_presence.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_users_of_results_presence.html.erb
@@ -7,5 +7,5 @@
 </p>
 
 <p>
-  Regards, <%= @competition.managers.map(&:name).sort.to_sentence(last_word_connector: " and ") %>.
+  Regards, <%= users_to_sentence @competition.managers %>.
 </p>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_accepted_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_accepted_registration.html.erb
@@ -10,5 +10,5 @@
 </p>
 
 <p>
-  Regards, <%= competition.managers.map(&:name).sort.to_sentence %>.
+  Regards, <%= users_to_sentence competition.managers %>.
 </p>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_deleted_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_deleted_registration.html.erb
@@ -21,5 +21,5 @@
 </p>
 
 <p>
-  Regards, <%= competition.managers.map(&:name).sort.to_sentence %>.
+  Regards, <%= users_to_sentence competition.managers %>.
 </p>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_new_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_new_registration.html.erb
@@ -15,5 +15,5 @@
 </p>
 
 <p>
-  Regards, <%= competition.managers.map(&:name).sort.to_sentence %>.
+  Regards, <%= users_to_sentence competition.managers %>.
 </p>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_pending_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_pending_registration.html.erb
@@ -18,5 +18,5 @@
 </p>
 
 <p>
-  Regards, <%= competition.managers.map(&:name).sort.to_sentence %>.
+  Regards, <%= users_to_sentence competition.managers %>.
 </p>

--- a/WcaOnRails/app/views/teams/index.html.erb
+++ b/WcaOnRails/app/views/teams/index.html.erb
@@ -21,9 +21,9 @@
             <td><%= team.friendly_id %></td>
             <td><%= team.name %></td>
             <td><%= team.description %></td>
-            <td><%= team.current_members.map { |member| member.user.name }.to_sentence %></td>
+            <td><%= users_to_sentence team.current_members.map(&:user) %></td>
             <td>
-              <%= team.current_members.where(team_leader: true).map { |leader| leader.user.name }.sort.to_sentence %>
+              <%= users_to_sentence team.current_members.where(team_leader: true).map(&:user) %>
             </td>
             <td><%= link_to icon("pencil-square-o", "Manage"), edit_team_path(team), class: "btn btn-success" %></td>
           </tr>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -167,7 +167,12 @@
 
           <%= render "shared/associated_events_picker", form_builder: f, label: t('.preferred_events'), disabled: !editable_fields.include?(:preferred_events),
                                                         events_association_name: :user_preferred_events, selected_events: @user.preferred_events %>
-            <span class="help-block"><%= t '.preferred_events_desc' %></span>
+          <span class="help-block"><%= t '.preferred_events_desc' %></span>
+
+          <%= label_tag :notifications, t('layouts.navigation.notifications') %>
+          <div id="notifications">
+            <%= f.input :results_notifications_enabled %>
+          </div>
 
           <%= f.submit t('.save'), class: "btn btn-primary" %>
         <% end %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
         remember_me: "Remember me"
         pending_avatar: "Upload new avatar"
         remove_avatar: "Remove avatar"
+        results_notifications_enabled: "Email me when my results are posted."
       competition:
         competition_id_to_clone: "Competition id to clone"
 

--- a/WcaOnRails/db/migrate/20160513162613_add_results_notifications_enabled_to_users.rb
+++ b/WcaOnRails/db/migrate/20160513162613_add_results_notifications_enabled_to_users.rb
@@ -1,0 +1,5 @@
+class AddResultsNotificationsEnabledToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :results_notifications_enabled, :boolean, default: true
+  end
+end

--- a/WcaOnRails/db/migrate/20160513162613_add_results_notifications_enabled_to_users.rb
+++ b/WcaOnRails/db/migrate/20160513162613_add_results_notifications_enabled_to_users.rb
@@ -1,5 +1,5 @@
 class AddResultsNotificationsEnabledToUsers < ActiveRecord::Migration
   def change
-    add_column :users, :results_notifications_enabled, :boolean, default: true
+    add_column :users, :results_notifications_enabled, :boolean, default: false
   end
 end

--- a/WcaOnRails/db/seeds/development/competitions.seeds.rb
+++ b/WcaOnRails/db/seeds/development/competitions.seeds.rb
@@ -67,6 +67,8 @@ after "development:users" do
         end
       end
     end
+
+    competition.update!(results_posted_at: Time.now)
   end
 
   # Create a bunch of competitions just to fill up the competitions list

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -728,7 +728,7 @@ CREATE TABLE `users` (
   `dob` date DEFAULT NULL,
   `gender` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `country_iso2` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `results_notifications_enabled` tinyint(1) DEFAULT '1',
+  `results_notifications_enabled` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
   UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`),

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -728,6 +728,7 @@ CREATE TABLE `users` (
   `dob` date DEFAULT NULL,
   `gender` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `country_iso2` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `results_notifications_enabled` tinyint(1) DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
   UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`),
@@ -901,3 +902,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160504170758');
 INSERT INTO schema_migrations (version) VALUES ('20160504230105');
 
 INSERT INTO schema_migrations (version) VALUES ('20160505231300');
+
+INSERT INTO schema_migrations (version) VALUES ('20160513162613');

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -575,6 +575,7 @@ describe CompetitionsController do
           FactoryGirl.create_list(:result, 2, person: user.person, competitionId: competition.id)
         end
 
+        expect(CompetitionsMailer).to receive(:notify_users_of_results_presence).and_call_original.exactly(4).times
         expect do
           get :post_results, id: competition
         end.to change { ActionMailer::Base.deliveries.count }.by(4)

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -569,6 +569,16 @@ describe CompetitionsController do
         competition.reload
         expect(competition.results_posted_at.to_f).to be < Time.now.to_f
       end
+
+      it "sends the notification emails to users that competed" do
+        FactoryGirl.create_list(:user_with_wca_id, 4).each do |user|
+          FactoryGirl.create_list(:result, 2, person: user.person, competitionId: competition.id)
+        end
+
+        expect do
+          get :post_results, id: competition
+        end.to change { ActionMailer::Base.deliveries.count }.by(4)
+      end
     end
   end
 end

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -571,7 +571,7 @@ describe CompetitionsController do
       end
 
       it "sends the notification emails to users that competed" do
-        FactoryGirl.create_list(:user_with_wca_id, 4).each do |user|
+        FactoryGirl.create_list(:user_with_wca_id, 4, results_notifications_enabled: true).each do |user|
           FactoryGirl.create_list(:result, 2, person: user.person, competitionId: competition.id)
         end
 

--- a/WcaOnRails/spec/helpers/static_pages_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/static_pages_helper_spec.rb
@@ -11,7 +11,7 @@ describe StaticPagesHelper do
       FactoryGirl.create(:team_member, team_id: team.id, user_id: other_member.id, start_date: Date.today-1)
       FactoryGirl.create(:team_member, team_id: team.id, user_id: another_member.id, start_date: Date.today-1)
       string = helper.format_team_members(team.friendly_id)
-      expect(string).to eq "Jeremy (leader), Aaron and Pedro"
+      expect(string).to eq "Jeremy (leader), Aaron, and Pedro"
     end
 
     it "does not include the demoted members" do

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -17,4 +17,20 @@ RSpec.describe CompetitionsMailer, type: :mailer do
       expect(mail.body.encoded).to match(admin_edit_competition_url(competition))
     end
   end
+
+  describe "notify_users_of_results_presence" do
+    let(:competition) { FactoryGirl.create :competition }
+    let(:competitor_user) { FactoryGirl.create :user, :wca_id }
+    let(:mail) { CompetitionsMailer.notify_users_of_results_presence(competitor_user, competition) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq "The results of #{competition.name} are posted"
+      expect(mail.to).to eq [competitor_user.email]
+      expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match /The results of .+ you've competed recently are now available/
+    end
+  end
 end

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match(/The results of .+ you've competed recently are now available/)
+      expect(mail.body.encoded).to match(/Your results at .+ have just been posted./)
     end
   end
 end

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match /The results of .+ you've competed recently are now available/
+      expect(mail.body.encoded).to match(/The results of .+ you've competed recently are now available/)
     end
   end
 end

--- a/WcaOnRails/spec/mailers/previews/competitions_mailer_preview.rb
+++ b/WcaOnRails/spec/mailers/previews/competitions_mailer_preview.rb
@@ -7,4 +7,10 @@ class CompetitionsMailerPreview < ActionMailer::Preview
     CompetitionsMailer.notify_board_of_confirmed_competition(c.delegates[0], c)
   end
 
+  # Preview this email at http://localhost:3000/rails/mailers/competitions_mailer/notify_users_of_results_presence
+  def notify_users_of_results_presence
+    competition = Competition.joins(:results).where.not(results_posted_at: nil).first
+    user = competition.competitor_users.first
+    CompetitionsMailer.notify_users_of_results_presence(user, competition)
+  end
 end

--- a/WcaOnRails/spec/mailers/registrations_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/registrations_mailer_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe RegistrationsMailer, type: :mailer do
       expect(mail.body.encoded).to match("Your registration for .{1,200}#{registration.competition.name}.{1,200} has been moved to the waiting list")
       expect(mail.body.encoded).to match("If you think this is an error, please reply to this email.")
       names = competition.managers.map(&:name).map { |n| ERB::Util.html_escape(n) }.sort
-      expect(mail.body.encoded).to match("Regards, #{names.to_sentence(last_word_connector: " and ")}\\.")
+      expect(mail.body.encoded).to match("Regards, #{names.to_sentence}\\.")
     end
   end
 
@@ -127,7 +127,7 @@ RSpec.describe RegistrationsMailer, type: :mailer do
     it "renders the body" do
       expect(mail.body.encoded).to match("Your registration for .{1,200}#{registration.competition.name}.{1,200} has been deleted")
       names = competition.managers.map(&:name).map { |n| ERB::Util.html_escape(n) }.sort
-      expect(mail.body.encoded).to match("Regards, #{names.to_sentence(last_word_connector: " and ")}\\.")
+      expect(mail.body.encoded).to match("Regards, #{names.to_sentence}\\.")
     end
   end
 end

--- a/WcaOnRails/spec/mailers/registrations_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/registrations_mailer_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe RegistrationsMailer, type: :mailer do
       expect(mail.body.encoded).to match("Your registration for .{1,200}#{registration.competition.name}.{1,200} has been moved to the waiting list")
       expect(mail.body.encoded).to match("If you think this is an error, please reply to this email.")
       names = competition.managers.map(&:name).map { |n| ERB::Util.html_escape(n) }.sort
-      expect(mail.body.encoded).to match("Regards, #{names.to_sentence}\\.")
+      expect(mail.body.encoded).to match("Regards, #{names.to_sentence(last_word_connector: " and ")}\\.")
     end
   end
 
@@ -127,7 +127,7 @@ RSpec.describe RegistrationsMailer, type: :mailer do
     it "renders the body" do
       expect(mail.body.encoded).to match("Your registration for .{1,200}#{registration.competition.name}.{1,200} has been deleted")
       names = competition.managers.map(&:name).map { |n| ERB::Util.html_escape(n) }.sort
-      expect(mail.body.encoded).to match("Regards, #{names.to_sentence}\\.")
+      expect(mail.body.encoded).to match("Regards, #{names.to_sentence(last_word_connector: " and ")}\\.")
     end
   end
 end

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -516,7 +516,7 @@ RSpec.describe User, type: :model do
 
     it "sends the notification if the user has it enabled" do
       expect(CompetitionsMailer).to receive(:notify_users_of_results_presence).and_call_original
-      FactoryGirl.build(:user_with_wca_id).notify_of_results_presence(competition)
+      FactoryGirl.build(:user_with_wca_id, results_notifications_enabled: true).notify_of_results_presence(competition)
     end
 
     it "doesn't send the notification if the user has it disabled" do

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -510,4 +510,18 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "#notify_of_results_presence" do
+    let(:competition) { FactoryGirl.build(:competition) }
+
+    it "sends the notification if the user has it enabled" do
+      expect(CompetitionsMailer).to receive(:notify_users_of_results_presence).and_call_original
+      FactoryGirl.build(:user_with_wca_id).notify_of_results_presence(competition)
+    end
+
+    it "doesn't send the notification if the user has it disabled" do
+      expect(CompetitionsMailer).to_not receive(:notify_users_of_results_presence).and_call_original
+      FactoryGirl.build(:user_with_wca_id, results_notifications_enabled: false).notify_of_results_presence(competition)
+    end
+  end
 end

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -511,17 +511,19 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe "#notify_of_results_presence" do
+  describe "#notify_of_results_posted" do
     let(:competition) { FactoryGirl.build(:competition) }
 
     it "sends the notification if the user has it enabled" do
-      expect(CompetitionsMailer).to receive(:notify_users_of_results_presence).and_call_original
-      FactoryGirl.build(:user_with_wca_id, results_notifications_enabled: true).notify_of_results_presence(competition)
+      user = FactoryGirl.build(:user_with_wca_id, results_notifications_enabled: true)
+      expect(CompetitionsMailer).to receive(:notify_users_of_results_presence).with(user, competition).and_call_original
+      user.notify_of_results_posted(competition)
     end
 
     it "doesn't send the notification if the user has it disabled" do
-      expect(CompetitionsMailer).to_not receive(:notify_users_of_results_presence).and_call_original
-      FactoryGirl.build(:user_with_wca_id, results_notifications_enabled: false).notify_of_results_presence(competition)
+      user = FactoryGirl.build(:user_with_wca_id, results_notifications_enabled: false)
+      expect(CompetitionsMailer).to_not receive(:notify_users_of_results_presence).with(user, competition).and_call_original
+      user.notify_of_results_posted(competition)
     end
   end
 end


### PR DESCRIPTION
This sets up the basic notifications about results presence (see: #311). As indicated in the issue there would be awesome to include some funny statistics in this email. Anyway I think this is well enough to make make use of it right now and extend the email content later =)