### PR TITLE
Reorder column on the registrations edit page

### DIFF
--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -19,7 +19,6 @@
             <th class="wca-id" data-sortable="true">WCA ID</th>
             <th class="name" data-sortable="true">Name</th>
             <th class="countryId" data-sortable="true">Citizen of</th>
-            <th class="registration-date" data-sortable="true" data-field="registration-date">Registered</th>
             <th class="birthday" data-sortable="true">Birthday</th>
             <% @competition.events.each do |event| %>
               <th>
@@ -31,7 +30,7 @@
                 </span>
               </th>
             <% end %>
-
+            <th class="registration-date" data-sortable="true" data-field="registration-date">Registered</th>
             <th class="guests">Guests</th>
             <th class="comments">Comments</th>
             <th></th>
@@ -58,11 +57,6 @@
 
               <td class="name"><%= registration.name %></td>
               <td class="countryId"><%= registration.countryId %></td>
-              <td>
-                <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.created_at %>">
-                  <%= registration.created_at.to_date %>
-                </span>
-              </td>
               <td class="birthday"><%= registration.birthday %></td>
               <% @competition.events.each do |event| %>
                 <td>
@@ -76,6 +70,11 @@
                   <% end %>
                 </td>
               <% end %>
+              <td>
+                <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.created_at %>">
+                  <%= registration.created_at.to_date %>
+                </span>
+              </td>
               <td class="guests">
                 <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.guests %> <%= registration.guests_old %>">
                   <%= registration.guests %>

--- a/WcaOnRails/db/seeds/development/users.seeds.rb
+++ b/WcaOnRails/db/seeds/development/users.seeds.rb
@@ -1,16 +1,4 @@
 after :teams do
-  def self.random_user
-    {
-      name: Faker::Name.name,
-      country_iso2: "US",
-      gender: "m",
-      dob: Date.new(1980, 1, 1),
-      email: Faker::Internet.email,
-      password: "wca",
-      password_confirmation: "wca",
-    }
-  end
-
   # Create board members
   8.times do
     FactoryGirl.create(:board_member)


### PR DESCRIPTION
Olivér asked for this to make all the events visible without scrolling. I hope that's fine enough.

He also wrote a loose suggestion to show 'accepted at' in the second table instead of 'registration date'. I was trying to follow that, but when I was almost done with migrations, fixing tests and so on, I realised that it's too hard and messy to achieve this because we update the tables via Ajax (approving/rejecting/deleting). Since we do something like *copy-paste the rows* using bootstrap-table, their structure should be parallel.

I also added an admin in the seeds, it's not related but I was creating one after every database reset and that was annoying, so I just change the seeds.