### PR TITLE
Enforce extra validations when a competition is visible - Fixes #604

### DIFF
--- a/WcaOnRails/spec/controllers/api_competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_competitions_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe Api::V0::CompetitionsController do
   let(:competition) { FactoryGirl.create(:competition,
+                                         :with_delegate,
                                          id: "TestComp2014",
                                          start_date: "2014-02-03",
                                          end_date: "2014-02-05",

--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Api::V0::ApiController do
   describe 'GET #competitions_search' do
-    let!(:comp) { FactoryGirl.create(:competition, name: "Jfly's Competition 2015") }
+    let!(:comp) { FactoryGirl.create(:competition, :confirmed, :visible, name: "Jfly's Competition 2015") }
 
     it 'requires query parameter' do
       get :competitions_search
@@ -131,7 +131,7 @@ describe Api::V0::ApiController do
   end
 
   describe 'GET #omni_search' do
-    let!(:comp) { FactoryGirl.create(:competition, name: "jeremy Jfly's Competition 2015") }
+    let!(:comp) { FactoryGirl.create(:competition, :confirmed, :visible, name: "jeremy Jfly's Competition 2015") }
     let!(:post) { FactoryGirl.create(:post, title: "jeremy post title", body: "post body") }
     let!(:user) { FactoryGirl.create(:user_with_wca_id, name: "Jeremy") }
 
@@ -183,10 +183,10 @@ describe Api::V0::ApiController do
 
   describe 'GET #competitions' do
     it 'sorts newest to oldest' do
-      yesteryear_comp = FactoryGirl.create(:competition, starts: 1.year.ago)
-      yesterday_comp = FactoryGirl.create(:competition, starts: 1.day.ago)
-      today_comp = FactoryGirl.create(:competition, starts: 0.days.ago)
-      tomorrow_comp = FactoryGirl.create(:competition, starts: 1.day.from_now)
+      yesteryear_comp = FactoryGirl.create(:competition, :confirmed, :visible, starts: 1.year.ago)
+      yesterday_comp = FactoryGirl.create(:competition, :confirmed, :visible, starts: 1.day.ago)
+      today_comp = FactoryGirl.create(:competition, :confirmed, :visible, starts: 0.days.ago)
+      tomorrow_comp = FactoryGirl.create(:competition, :confirmed, :visible, starts: 1.day.from_now)
 
       get :competitions
       expect(response.status).to eq 200
@@ -200,8 +200,8 @@ describe Api::V0::ApiController do
     end
 
     it 'can sort by start_date,end_date' do
-      one_day_comp = FactoryGirl.create(:competition, starts: Date.new(2016, 2, 1), ends: Date.new(2016, 2, 1))
-      two_day_comp = FactoryGirl.create(:competition, starts: Date.new(2016, 2, 1), ends: Date.new(2016, 2, 2))
+      one_day_comp = FactoryGirl.create(:competition, :confirmed, :visible, starts: Date.new(2016, 2, 1), ends: Date.new(2016, 2, 1))
+      two_day_comp = FactoryGirl.create(:competition, :confirmed, :visible, starts: Date.new(2016, 2, 1), ends: Date.new(2016, 2, 2))
 
       get :competitions, sort: "start_date,end_date"
       json = JSON.parse(response.body)
@@ -213,8 +213,8 @@ describe Api::V0::ApiController do
     end
 
     it 'can query by country_iso2' do
-      vietnam_comp = FactoryGirl.create(:competition, countryId: "Vietnam")
-      usa_comp = FactoryGirl.create(:competition, countryId: "USA")
+      vietnam_comp = FactoryGirl.create(:competition, :confirmed, :visible, countryId: "Vietnam")
+      usa_comp = FactoryGirl.create(:competition, :confirmed, :visible, countryId: "USA")
 
       get :competitions, country_iso2: "US"
       json = JSON.parse(response.body)
@@ -228,8 +228,8 @@ describe Api::V0::ApiController do
     end
 
     it 'can do a plaintext query' do
-      terrible_comp = FactoryGirl.create(:competition, name: "A terrible competition 2016", countryId: "USA")
-      awesome_comp = FactoryGirl.create(:competition, name: "An awesome competition 2016", countryId: "France")
+      terrible_comp = FactoryGirl.create(:competition, :confirmed, :visible, name: "A terrible competition 2016", countryId: "USA")
+      awesome_comp = FactoryGirl.create(:competition, :confirmed, :visible, name: "An awesome competition 2016", countryId: "France")
 
       get :competitions, q: "AWES"
       json = JSON.parse(response.body)
@@ -272,9 +272,9 @@ describe Api::V0::ApiController do
     end
 
     it 'can query by date' do
-      last_feb_comp = FactoryGirl.create(:competition, starts: Date.new(2015, 2, 1))
-      feb_comp = FactoryGirl.create(:competition, starts: Date.new(2016, 2, 1))
-      march_comp = FactoryGirl.create(:competition, starts: Date.new(2016, 3, 1))
+      last_feb_comp = FactoryGirl.create(:competition, :confirmed, :visible, starts: Date.new(2015, 2, 1))
+      feb_comp = FactoryGirl.create(:competition, :confirmed, :visible, starts: Date.new(2016, 2, 1))
+      march_comp = FactoryGirl.create(:competition, :confirmed, :visible, starts: Date.new(2016, 3, 1))
 
       get :competitions, start: "2015-02-01"
       json = JSON.parse(response.body)
@@ -295,7 +295,7 @@ describe Api::V0::ApiController do
 
     it 'paginates' do
       30.times do
-        FactoryGirl.create :competition
+        FactoryGirl.create :competition, :confirmed, :visible
       end
 
       get :competitions

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -5,10 +5,10 @@ describe CompetitionsController do
 
   describe 'GET #index' do
     describe "selecting events" do
-      let!(:competition1) { FactoryGirl.create(:competition, starts: 1.week.from_now, eventSpecs: "222 333 444 555 666") }
-      let!(:competition2) { FactoryGirl.create(:competition, starts: 2.week.from_now, eventSpecs: "333 444 555 pyram clock") }
-      let!(:competition3) { FactoryGirl.create(:competition, starts: 3.week.from_now, eventSpecs: "222 333 skewb 666 pyram sq1") }
-      let!(:competition4) { FactoryGirl.create(:competition, starts: 4.week.from_now, eventSpecs: "333 pyram 666 777 clock") }
+      let!(:competition1) { FactoryGirl.create(:competition, :confirmed, :visible, starts: 1.week.from_now, eventSpecs: "222 333 444 555 666") }
+      let!(:competition2) { FactoryGirl.create(:competition, :confirmed, :visible, starts: 2.week.from_now, eventSpecs: "333 444 555 pyram clock") }
+      let!(:competition3) { FactoryGirl.create(:competition, :confirmed, :visible, starts: 3.week.from_now, eventSpecs: "222 333 skewb 666 pyram sq1") }
+      let!(:competition4) { FactoryGirl.create(:competition, :confirmed, :visible, starts: 4.week.from_now, eventSpecs: "333 pyram 666 777 clock") }
 
       context "when no event is selected" do
         it "competitions are sorted by start date" do
@@ -37,12 +37,12 @@ describe CompetitionsController do
     end
 
     describe "selecting present/past competitions" do
-      let!(:past_comp1) { FactoryGirl.create(:competition, starts: 1.year.ago) }
-      let!(:past_comp2) { FactoryGirl.create(:competition, starts: 3.years.ago) }
-      let!(:in_progress_comp1) { FactoryGirl.create(:competition, starts: Date.today, ends: 1.day.from_now) }
-      let!(:in_progress_comp2) { FactoryGirl.create(:competition, starts: Date.today, ends: Date.today) }
-      let!(:upcoming_comp1) { FactoryGirl.create(:competition, starts: 2.weeks.from_now) }
-      let!(:upcoming_comp2) { FactoryGirl.create(:competition, starts: 3.weeks.from_now) }
+      let!(:past_comp1) { FactoryGirl.create(:competition, :confirmed, :visible, starts: 1.year.ago) }
+      let!(:past_comp2) { FactoryGirl.create(:competition, :confirmed, :visible, starts: 3.years.ago) }
+      let!(:in_progress_comp1) { FactoryGirl.create(:competition, :confirmed, :visible, starts: Date.today, ends: 1.day.from_now) }
+      let!(:in_progress_comp2) { FactoryGirl.create(:competition, :confirmed, :visible, starts: Date.today, ends: Date.today) }
+      let!(:upcoming_comp1) { FactoryGirl.create(:competition, :confirmed, :visible, starts: 2.weeks.from_now) }
+      let!(:upcoming_comp2) { FactoryGirl.create(:competition, :confirmed, :visible, starts: 3.weeks.from_now) }
 
       context "when present is selected" do
         before do
@@ -82,6 +82,7 @@ describe CompetitionsController do
       sign_out
 
       it 'redirects to the old php page' do
+        competition.update_column(:showAtAll, true)
         get :show, id: competition.id
         expect(response.status).to eq 200
         expect(assigns(:competition)).to eq competition
@@ -180,7 +181,7 @@ describe CompetitionsController do
       end
 
       it 'shows an error message under name when creating a competition with a duplicate id' do
-        competition = FactoryGirl.create :competition
+        competition = FactoryGirl.create :competition, :with_delegate
         post :create, competition: { name: competition.name, competition_id_to_clone: "" }
         expect(response).to render_template(:new)
         new_comp = assigns(:competition)

--- a/WcaOnRails/spec/controllers/notifications_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/notifications_controller_spec.rb
@@ -11,9 +11,8 @@ RSpec.describe NotificationsController, type: :controller do
 
     context "when signed in as delegate" do
       let(:delegate) { FactoryGirl.create :delegate }
-      let!(:unconfirmed_competition) { FactoryGirl.create :competition, delegates: [delegate], isConfirmed: false, showAtAll: false }
-      let!(:confirmed_competition) { FactoryGirl.create :competition, delegates: [delegate], isConfirmed: true, showAtAll: false }
-      let!(:visible_competition) { FactoryGirl.create :competition, delegates: [delegate], isConfirmed: true, showAtAll: true }
+      let!(:unconfirmed_competition) { FactoryGirl.create :competition, delegates: [delegate] }
+      let!(:confirmed_competition) { FactoryGirl.create :competition, delegates: [delegate], isConfirmed: true }
       before :each do
         sign_in delegate
       end
@@ -70,10 +69,10 @@ RSpec.describe NotificationsController, type: :controller do
 
     context "when signed in as a board member" do
       let(:board_member) { FactoryGirl.create :board_member }
-      let!(:unconfirmed_competition) { FactoryGirl.create :competition, isConfirmed: false, showAtAll: false }
-      let!(:confirmed_competition) { FactoryGirl.create(:competition, :confirmed, showAtAll: false) }
-      let!(:visible_confirmed_competition) { FactoryGirl.create(:competition, :confirmed, showAtAll: true) }
-      let!(:visible_unconfirmed_competition) { FactoryGirl.create :competition, isConfirmed: false, showAtAll: true }
+      let!(:unconfirmed_competition) { FactoryGirl.create :competition }
+      let!(:confirmed_competition) { FactoryGirl.create(:competition, :confirmed) }
+      let!(:visible_confirmed_competition) { FactoryGirl.create(:competition, :confirmed, :visible) }
+      let!(:visible_unconfirmed_competition) { FactoryGirl.create :competition, :visible }
       before :each do
         sign_in board_member
       end

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe RegistrationsController do
     end
 
     it 'cannot change registration of a different competition' do
-      other_competition = FactoryGirl.create(:competition, :registration_open)
+      other_competition = FactoryGirl.create(:competition, :confirmed, :visible, :registration_open)
       other_registration = FactoryGirl.create(:registration, competition: other_competition)
 
       patch :update, id: other_registration.id, registration: { status: :accepted }
@@ -166,7 +166,7 @@ RSpec.describe RegistrationsController do
   context "signed in as competitor" do
     let!(:user) { FactoryGirl.create(:user, :wca_id) }
     let!(:delegate) { FactoryGirl.create(:delegate) }
-    let!(:competition) { FactoryGirl.create(:competition, :registration_open, delegates: [delegate]) }
+    let!(:competition) { FactoryGirl.create(:competition, :registration_open, delegates: [delegate], showAtAll: true) }
 
     before :each do
       sign_in user
@@ -274,7 +274,7 @@ RSpec.describe RegistrationsController do
   end
 
   context "register" do
-    let(:competition) { FactoryGirl.create :competition, :registration_open }
+    let(:competition) { FactoryGirl.create :competition, :confirmed, :visible, :registration_open }
 
     it "redirects to competition root if competition is not using WCA registration" do
       competition.use_wca_registration = false
@@ -328,7 +328,7 @@ RSpec.describe RegistrationsController do
   end
 
   context "psych sheet when not signed in" do
-    let!(:competition) { FactoryGirl.create(:competition, :registration_open, eventSpecs: "333 444 333bf") }
+    let!(:competition) { FactoryGirl.create(:competition, :confirmed, :visible, :registration_open, eventSpecs: "333 444 333bf") }
 
     it "redirects psych sheet to 333" do
       get :psych_sheet, competition_id: competition.id

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -18,7 +18,7 @@ FactoryGirl.define do
     venue "My backyard"
     venueAddress "My backyard street"
     website "https://www.worldcubeassociation.org"
-    showAtAll true
+    showAtAll false
 
     guests_enabled true
 
@@ -43,6 +43,11 @@ FactoryGirl.define do
     trait :confirmed do
       with_delegate
       isConfirmed true
+    end
+
+    trait :visible do
+      with_delegate
+      showAtAll true
     end
   end
 end

--- a/WcaOnRails/spec/features/competition_results_spec.rb
+++ b/WcaOnRails/spec/features/competition_results_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "competition results" do
-  let(:competition) { FactoryGirl.create :competition, eventSpecs: "333", results_posted_at: 1.day.ago }
+  let(:competition) { FactoryGirl.create :competition, :confirmed, :visible, eventSpecs: "333", results_posted_at: 1.day.ago }
   let(:person_1) { FactoryGirl.create :person, name: "Fast Cuber" }
   let(:person_2) { FactoryGirl.create :person, name: "Slow Cuber" }
 

--- a/WcaOnRails/spec/features/create_competition_spec.rb
+++ b/WcaOnRails/spec/features/create_competition_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.feature "Create competition", js: true do
   let(:delegate) { FactoryGirl.create(:delegate) }
-  let(:competition_to_clone) { FactoryGirl.create :competition }
+  let(:cloned_delegate) { FactoryGirl.create(:delegate) }
+  let(:competition_to_clone) { FactoryGirl.create :competition, delegates: [cloned_delegate], showAtAll: true }
 
   before :each do
     sign_in delegate
@@ -49,7 +50,7 @@ RSpec.feature "Create competition", js: true do
     expect(Competition.all.length).to eq 2
     new_competition = Competition.find("NewComp2015")
     expect(new_competition.name).to eq "New Comp 2015"
-    expect(new_competition.delegates).to eq [delegate]
+    expect(new_competition.delegates).to eq [delegate, cloned_delegate]
     expect(new_competition.venue).to eq competition_to_clone.venue
   end
 end

--- a/WcaOnRails/spec/features/register_for_competition_spec.rb
+++ b/WcaOnRails/spec/features/register_for_competition_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Registering for a competition" do
   let(:user) { FactoryGirl.create :user }
   let(:delegate) { FactoryGirl.create :delegate }
-  let(:competition) { FactoryGirl.create :competition, :registration_open, delegates: [delegate] }
+  let(:competition) { FactoryGirl.create :competition, :registration_open, delegates: [delegate], showAtAll: true }
 
   context "signed in as user" do
     before :each do


### PR DESCRIPTION
The default factory for a competition used to set showAtAll true without a delegate.
The extra validations make this default competition invalid. To change this the default
is now showAtAll false which matches what happens in the front end. A lot of tests needed
to be updated that created competitions because of this change.

Let me know if you think this is the right approach to adding validations when making a competition visible.