### PR TITLE
Edit registrations improvements

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -122,7 +122,7 @@ class RegistrationsController < ApplicationController
     when "accept-selected"
       registrations.each do |registration|
         if !registration.accepted?
-          registration.accepted!
+          registration.update!(accepted_at: Time.now)
           RegistrationsMailer.notify_registrant_of_accepted_registration(registration).deliver_now
         end
       end
@@ -130,7 +130,7 @@ class RegistrationsController < ApplicationController
     when "reject-selected"
       registrations.each do |registration|
         if !registration.pending?
-          registration.pending!
+          registration.update!(accepted_at: nil)
           RegistrationsMailer.notify_registrant_of_pending_registration(registration).deliver_now
         end
       end
@@ -231,7 +231,11 @@ class RegistrationsController < ApplicationController
       registration_events_attributes: [:id, :event_id, :_destroy],
     ]
     if current_user.can_manage_competition?(competition_from_params)
-      permitted_params << :status
+      permitted_params << :accepted_at
+      status = params[:registration][:status]
+      if status
+        params[:registration][:accepted_at] = status == "a" ? Time.now : nil
+      end
     end
     params.require(:registration).permit(*permitted_params)
   end

--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -234,7 +234,7 @@ class RegistrationsController < ApplicationController
       permitted_params << :accepted_at
       status = params[:registration][:status]
       if status
-        params[:registration][:accepted_at] = status == "a" ? Time.now : nil
+        params[:registration][:accepted_at] = (status == "a" ? Time.now : nil)
       end
     end
     params.require(:registration).permit(*permitted_params)

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -1,7 +1,8 @@
 class Registration < ActiveRecord::Base
   self.table_name = "Preregs"
 
-  enum status: { accepted: "a", pending: "p" }
+  scope :pending, -> { where(accepted_at: nil) }
+  scope :accepted, -> { where.not(accepted_at: nil) }
 
   belongs_to :competition, foreign_key: "competitionId"
   belongs_to :user
@@ -20,6 +21,14 @@ class Registration < ActiveRecord::Base
     elsif !competition.use_wca_registration?
       errors.add(:competition, "Competition registration is closed")
     end
+  end
+
+  def pending?
+    accepted_at.nil?
+  end
+
+  def accepted?
+    !pending?
   end
 
   def events

--- a/WcaOnRails/app/views/registrations/edit.html.erb
+++ b/WcaOnRails/app/views/registrations/edit.html.erb
@@ -34,7 +34,7 @@
 
     <%= f.input :comments %>
 
-    <%= f.input :status, as: :radio_buttons, collection: [:a, :p], checked: @registration.read_attribute(:status), include_blank: false %>
+    <%= f.input :status, as: :radio_buttons, collection: [:a, :p], checked: @registration.accepted? ? :a : :p, include_blank: false %>
 
     <div class="form-group">
       <div class="col-sm-offset-2 col-sm-10">

--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -19,7 +19,6 @@
             <th class="wca-id" data-sortable="true">WCA ID</th>
             <th class="name" data-sortable="true">Name</th>
             <th class="countryId" data-sortable="true">Citizen of</th>
-            <th class="registration-date" data-sortable="true" data-field="registration-date">Registered</th>
             <th class="birthday" data-sortable="true">Birthday</th>
             <% @competition.events.each do |event| %>
               <th>
@@ -31,7 +30,7 @@
                 </span>
               </th>
             <% end %>
-
+            <th class="registration-date" data-sortable="true" data-field="registration-date">Registered</th>
             <th class="guests">Guests</th>
             <th class="comments">Comments</th>
             <th></th>
@@ -58,11 +57,6 @@
 
               <td class="name"><%= registration.name %></td>
               <td class="countryId"><%= registration.countryId %></td>
-              <td>
-                <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.created_at %>">
-                  <%= registration.created_at.to_date %>
-                </span>
-              </td>
               <td class="birthday"><%= registration.birthday %></td>
               <% @competition.events.each do |event| %>
                 <td>
@@ -76,6 +70,11 @@
                   <% end %>
                 </td>
               <% end %>
+              <td>
+                <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.created_at %>">
+                  <%= registration.created_at.to_date %>
+                </span>
+              </td>
               <td class="guests">
                 <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.guests %> <%= registration.guests_old %>">
                   <%= registration.guests %>

--- a/WcaOnRails/app/views/registrations/export.csv.erb
+++ b/WcaOnRails/app/views/registrations/export.csv.erb
@@ -3,7 +3,7 @@
 <%= CSV.generate_line(headers).html_safe -%>
 <% @registrations.each do |registration| %>
 <%= CSV.generate_line([
-  Registration.statuses[registration.status],
+  registration.pending? ? "p" : "a",
   registration.name,
   registration.countryId,
   registration.personId,

--- a/WcaOnRails/db/migrate/20160514124545_add_approved_at_to_registrations.rb
+++ b/WcaOnRails/db/migrate/20160514124545_add_approved_at_to_registrations.rb
@@ -1,0 +1,5 @@
+class AddApprovedAtToRegistrations < ActiveRecord::Migration
+  def change
+    add_column :Preregs, :accepted_at, :datetime
+  end
+end

--- a/WcaOnRails/db/migrate/20160514141051_fill_accepted_at_registrations_column.rb
+++ b/WcaOnRails/db/migrate/20160514141051_fill_accepted_at_registrations_column.rb
@@ -1,0 +1,11 @@
+class FillAcceptedAtRegistrationsColumn < ActiveRecord::Migration
+  def change
+    # Move the data
+    Registration.where(status: "a").includes(:competition).each do |registration|
+      registration.update!(accepted_at: registration.competition.registration_open)
+    end
+
+    # Remove the column
+    remove_column :Preregs, :status
+  end
+end

--- a/WcaOnRails/db/seeds/development/competitions.seeds.rb
+++ b/WcaOnRails/db/seeds/development/competitions.seeds.rb
@@ -153,7 +153,7 @@ after "development:users" do
     # Create registrations for some competitions taking place far in the future
     next if i < 480
     users.each_with_index do |user, i|
-      status = i % 4 == 0 ? "a" : "p"
+      accepted_at = i % 4 == 0 ? Time.now : nil
       registration_event_ids = eventIds.sample(rand(1..eventIds.count))
       if i % 2 == 0
         Registration.new(
@@ -169,11 +169,11 @@ after "development:users" do
           guests: rand(10),
           comments: Faker::Lorem.paragraph,
           ip: "1.1.1.1",
-          status: status,
+          accepted_at: accepted_at,
           registration_events_attributes: registration_event_ids.map { |event_id| {event_id: event_id} },
         ).save!(validate: false)
       else
-        FactoryGirl.create(:registration, user: user, competition: competition, status: status, event_ids: registration_event_ids)
+        FactoryGirl.create(:registration, user: user, competition: competition, accepted_at: accepted_at, event_ids: registration_event_ids)
       end
     end
   end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -284,7 +284,6 @@ CREATE TABLE `Preregs` (
   `guests_old` text COLLATE utf8_unicode_ci,
   `comments` text COLLATE utf8_unicode_ci NOT NULL,
   `ip` varchar(16) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `status` char(1) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'p',
   `user_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -907,3 +906,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160505231300');
 INSERT INTO schema_migrations (version) VALUES ('20160513162613');
 
 INSERT INTO schema_migrations (version) VALUES ('20160514124545');
+
+INSERT INTO schema_migrations (version) VALUES ('20160514141051');

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -289,6 +289,7 @@ CREATE TABLE `Preregs` (
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `guests` int(11) NOT NULL DEFAULT '0',
+  `accepted_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_Preregs_on_competitionId_and_user_id` (`competitionId`,`user_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=80561 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
@@ -904,3 +905,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160504230105');
 INSERT INTO schema_migrations (version) VALUES ('20160505231300');
 
 INSERT INTO schema_migrations (version) VALUES ('20160513162613');
+
+INSERT INTO schema_migrations (version) VALUES ('20160514124545');

--- a/WcaOnRails/spec/factories/registrations.rb
+++ b/WcaOnRails/spec/factories/registrations.rb
@@ -17,11 +17,11 @@ FactoryGirl.define do
     end
 
     trait :accepted do
-      status "a"
+      accepted_at Time.now
     end
 
     trait :pending do
-      status "p"
+      accepted_at nil
     end
 
     factory :userless_registration do

--- a/WcaOnRails/spec/views/registrations/export.csv.erb_spec.rb
+++ b/WcaOnRails/spec/views/registrations/export.csv.erb_spec.rb
@@ -4,7 +4,7 @@ describe "registrations/export.csv.erb" do
   it "renders valid csv" do
     competition = FactoryGirl.create :competition
     competition.registrations.build(
-      status: "a",
+      accepted_at: Time.now,
       name: "Bob",
       countryId: "USA",
       birthYear: 1990,


### PR DESCRIPTION
This a PR follows #613. Apart from reordering the columns it also adds `accepted_at` column to the registrations table as a replacement of `status`.