### PR TITLE
Small fix for the make.py script

### DIFF
--- a/regulations/make.py
+++ b/regulations/make.py
@@ -166,6 +166,7 @@ parser.add_argument(
 parser.add_argument(
   '--check', '-!',
   action='append',
+  default=[],
   help="Check consistency between translations and original versions, and some other tests. Specify comma-separated list of languages, or 'all' to check all translations."
 )
 


### PR DESCRIPTION
Right after giving the LGTM for @Claster's #589 I used the deploy script to rebuild everything for #624, and it broke :p (bad bad me for not checking thoroughly).

There was no default value for "--check":
```
$ ./scripts/deploy.sh rebuild_regs
++ for command in '"$@"'
++ rebuild_regs
++ regulations/make.py --num-workers 1 --wca
Cleaning build folder: ./build/regulations/
Using 1 workers.
Traceback (most recent call last):
  File "regulations/make.py", line 293, in <module>
    main()
  File "regulations/make.py", line 52, in main
    build(args)
  File "regulations/make.py", line 197, in build
    map(f, languages)
  File "regulations/make.py", line 251, in buildLanguagePooled
    buildLanguage(args, language)
  File "regulations/make.py", line 231, in buildLanguage
    if 'all' in args.check or language in args.check:
TypeError: argument of type 'NoneType' is not iterable
```

Tiny fix for that.