### PR TITLE
Added support for delayed_job

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -51,6 +51,8 @@ gem 'datetimepicker-rails', github: 'zpaulovics/datetimepicker-rails', branch: '
 gem 'blocks'
 gem 'rack-cors', require: 'rack/cors'
 gem 'api-pagination'
+gem 'delayed_job_active_record'
+gem 'daemons'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-autosize'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -139,8 +139,14 @@ GEM
     columnize (0.9.0)
     css_parser (1.3.7)
       addressable
+    daemons (1.2.3)
     database_cleaner (1.5.1)
     debug_inspector (0.0.2)
+    delayed_job (4.1.2)
+      activesupport (>= 3.0, < 5.1)
+    delayed_job_active_record (4.1.1)
+      activerecord (>= 3.0, < 5.1)
+      delayed_job (>= 3.0, < 5)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     devise (3.5.4)
@@ -421,8 +427,10 @@ DEPENDENCIES
   carrierwave
   carrierwave-crop!
   cocoon
+  daemons
   database_cleaner
   datetimepicker-rails!
+  delayed_job_active_record
   devise
   devise-bootstrap-views
   doorkeeper

--- a/WcaOnRails/app/mailers/job_failure_mailer.rb
+++ b/WcaOnRails/app/mailers/job_failure_mailer.rb
@@ -5,7 +5,7 @@ class JobFailureMailer < ApplicationMailer
     mail(
       to: "admin@worldcubeassociation.org",
       reply_to: "admin@worldcubeassociation.org",
-      subject: "Job #{@job.id} failed"
+      subject: "Job #{@job.id} failed",
     )
   end
 end

--- a/WcaOnRails/app/mailers/job_failure_mailer.rb
+++ b/WcaOnRails/app/mailers/job_failure_mailer.rb
@@ -1,0 +1,11 @@
+class JobFailureMailer < ApplicationMailer
+  def notify_admin_of_job_failure(job, exception)
+    @exception = exception
+    @job = job
+    mail(
+      to: "admin@worldcubeassociation.org",
+      reply_to: "admin@worldcubeassociation.org",
+      subject: "Job #{@job.id} failed"
+    )
+  end
+end

--- a/WcaOnRails/app/models/completed_job.rb
+++ b/WcaOnRails/app/models/completed_job.rb
@@ -1,0 +1,2 @@
+class CompletedJob < ActiveRecord::Base
+end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -492,7 +492,7 @@ class User < ActiveRecord::Base
 
   def notify_of_results_posted(competition)
     if results_notifications_enabled?
-      CompetitionsMailer.notify_users_of_results_presence(self, competition).deliver_now
+      CompetitionsMailer.notify_users_of_results_presence(self, competition).deliver_later
     end
   end
 

--- a/WcaOnRails/app/views/job_failure_mailer/notify_admin_of_job_failure.html.erb
+++ b/WcaOnRails/app/views/job_failure_mailer/notify_admin_of_job_failure.html.erb
@@ -3,4 +3,8 @@
   <%= @exception.inspect %>
 </p>
 
+<h2>Handler</h2>
+<pre><%= @job.handler %></pre>
+
+<h2>Backtrace</h2>
 <pre><%= @exception.backtrace.join("\n") %></pre>

--- a/WcaOnRails/app/views/job_failure_mailer/notify_admin_of_job_failure.html.erb
+++ b/WcaOnRails/app/views/job_failure_mailer/notify_admin_of_job_failure.html.erb
@@ -1,0 +1,6 @@
+<p>
+  Job <%= @job.id %> failed.
+  <%= @exception.inspect %>
+</p>
+
+<pre><%= @exception.backtrace.join("\n") %></pre>

--- a/WcaOnRails/bin/delayed_job
+++ b/WcaOnRails/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/WcaOnRails/config/application.rb
+++ b/WcaOnRails/config/application.rb
@@ -30,6 +30,8 @@ module WcaOnRails
     config.active_record.raise_in_transactional_callbacks = true
     config.active_record.schema_format = :sql
 
+    config.active_job.queue_adapter = :delayed_job
+
     config.generators do |g|
       g.test_framework :rspec,
         fixtures: true,

--- a/WcaOnRails/config/initializers/delayed_job_config.rb
+++ b/WcaOnRails/config/initializers/delayed_job_config.rb
@@ -1,0 +1,3 @@
+Delayed::Worker.destroy_failed_jobs = false
+Delayed::Worker.max_run_time = 5.minutes
+Delayed::Worker.delay_jobs = !Rails.env.test?

--- a/WcaOnRails/config/initializers/delayed_job_config.rb
+++ b/WcaOnRails/config/initializers/delayed_job_config.rb
@@ -1,3 +1,6 @@
+require 'delayed/plugins/save_completed_jobs'
+
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.max_run_time = 5.minutes
 Delayed::Worker.delay_jobs = !Rails.env.test?
+Delayed::Worker.plugins << Delayed::Plugins::SaveCompletedJobs

--- a/WcaOnRails/db/migrate/20160518020433_create_delayed_jobs.rb
+++ b/WcaOnRails/db/migrate/20160518020433_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/WcaOnRails/db/migrate/20160518045741_create_completed_jobs.rb
+++ b/WcaOnRails/db/migrate/20160518045741_create_completed_jobs.rb
@@ -3,16 +3,15 @@ class CreateCompletedJobs < ActiveRecord::Migration
     # Idea for storing completed jobs inspired by
     #  http://stackoverflow.com/a/28217770/1739415
     create_table :completed_jobs do |table|
-
       table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
       table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
       table.text :handler,                 null: false # YAML-encoded string of the object that will do work
       # table.text :last_error                           # reason for last failure (See Note below)
-      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
-      # table.datetime :locked_at                        # Set when a client is working on this object
-      # table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
-      # table.string :locked_by                          # Who is working on this object (if locked)
-      table.string :queue                              # The name of the queue this job is in
+      table.datetime :run_at # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      # table.datetime :locked_at # Set when a client is working on this object
+      # table.datetime :failed_at # Set when all retries have failed (actually, by default, the record is deleted instead)
+      # table.string :locked_by # Who is working on this object (if locked)
+      table.string :queue # The name of the queue this job is in
       table.timestamps null: false
 
       table.datetime :completed_at # You won't find this in delayed_job's job table

--- a/WcaOnRails/db/migrate/20160518045741_create_completed_jobs.rb
+++ b/WcaOnRails/db/migrate/20160518045741_create_completed_jobs.rb
@@ -1,0 +1,21 @@
+class CreateCompletedJobs < ActiveRecord::Migration
+  def change
+    # Idea for storing completed jobs inspired by
+    #  http://stackoverflow.com/a/28217770/1739415
+    create_table :completed_jobs do |table|
+
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      # table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      # table.datetime :locked_at                        # Set when a client is working on this object
+      # table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      # table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: false
+
+      table.datetime :completed_at # You won't find this in delayed_job's job table
+    end
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -467,6 +467,30 @@ CREATE TABLE `competition_organizers` (
   KEY `index_competition_organizers_on_competition_id` (`competition_id`),
   KEY `index_competition_organizers_on_organizer_id` (`organizer_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2290 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+--
+-- Table structure for table `delayed_jobs`
+--
+
+DROP TABLE IF EXISTS `delayed_jobs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `delayed_jobs` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `priority` int(11) NOT NULL DEFAULT '0',
+  `attempts` int(11) NOT NULL DEFAULT '0',
+  `handler` text COLLATE utf8_unicode_ci NOT NULL,
+  `last_error` text COLLATE utf8_unicode_ci,
+  `run_at` datetime DEFAULT NULL,
+  `locked_at` datetime DEFAULT NULL,
+  `failed_at` datetime DEFAULT NULL,
+  `locked_by` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `queue` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `delayed_jobs_priority` (`priority`,`run_at`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -908,3 +932,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160513162613');
 INSERT INTO schema_migrations (version) VALUES ('20160514124545');
 
 INSERT INTO schema_migrations (version) VALUES ('20160514141051');
+
+INSERT INTO schema_migrations (version) VALUES ('20160518020433');

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -469,6 +469,27 @@ CREATE TABLE `competition_organizers` (
 ) ENGINE=InnoDB AUTO_INCREMENT=2290 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 --
+-- Table structure for table `completed_jobs`
+--
+
+DROP TABLE IF EXISTS `completed_jobs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `completed_jobs` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `priority` int(11) NOT NULL DEFAULT '0',
+  `attempts` int(11) NOT NULL DEFAULT '0',
+  `handler` text COLLATE utf8_unicode_ci NOT NULL,
+  `run_at` datetime DEFAULT NULL,
+  `queue` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  `completed_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `delayed_jobs`
 --
 
@@ -934,3 +955,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160514124545');
 INSERT INTO schema_migrations (version) VALUES ('20160514141051');
 
 INSERT INTO schema_migrations (version) VALUES ('20160518020433');
+
+INSERT INTO schema_migrations (version) VALUES ('20160518045741');

--- a/WcaOnRails/lib/delayed/plugins/save_completed_jobs.rb
+++ b/WcaOnRails/lib/delayed/plugins/save_completed_jobs.rb
@@ -1,0 +1,23 @@
+module Delayed
+  module Plugins
+    class SaveCompletedJobs < Delayed::Plugin
+      callbacks do |lifecycle|
+        lifecycle.around(:invoke_job) do |job, *args, &block|
+          block.call(job, *args)
+          Delayed::Plugins::SaveCompletedJobs.save_completed_job(job)
+        end
+      end
+
+      def self.save_completed_job(job)
+        CompletedJob.create({
+          priority: job.priority,
+          attempts: job.attempts,
+          handler: job.handler,
+          run_at: job.run_at,
+          queue: job.queue,
+          completed_at: DateTime.now,
+        })
+      end
+    end
+  end
+end

--- a/WcaOnRails/lib/delayed/plugins/save_completed_jobs.rb
+++ b/WcaOnRails/lib/delayed/plugins/save_completed_jobs.rb
@@ -6,7 +6,7 @@ module Delayed
           begin
             block.call(job, *args)
             Delayed::Plugins::SaveCompletedJobs.save_completed_job(job)
-          rescue Exception => error
+          rescue Exception => error # rubocop:disable Lint/RescueException
             JobFailureMailer.notify_admin_of_job_failure(job, error).deliver_now
             raise error
           end
@@ -14,14 +14,14 @@ module Delayed
       end
 
       def self.save_completed_job(job)
-        CompletedJob.create({
+        CompletedJob.create(
           priority: job.priority,
           attempts: job.attempts,
           handler: job.handler,
           run_at: job.run_at,
           queue: job.queue,
           completed_at: DateTime.now,
-        })
+        )
       end
     end
   end

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -577,9 +577,8 @@ describe CompetitionsController do
         end
 
         expect(CompetitionsMailer).to receive(:notify_users_of_results_presence).and_call_original.exactly(4).times
-        expect do
-          get :post_results, id: competition
-        end.to change { ActionMailer::Base.deliveries.count }.by(4)
+        get :post_results, id: competition
+        assert_enqueued_jobs 4
       end
     end
   end

--- a/WcaOnRails/spec/lib/delayed/plugins/save_completed_jobs_spec.rb
+++ b/WcaOnRails/spec/lib/delayed/plugins/save_completed_jobs_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+class SuccessfulJob < ActiveJob::Base
+  def perform
+    puts "Succeeding!"
+  end
+end
+
+class FailingJob < ActiveJob::Base
+  def perform
+    raise "Failure!"
+  end
+end
+
+describe Delayed::Plugins::SaveCompletedJobs, type: :feature do
+  describe "call" do
+    around(:each) do |example|
+      old_delay_jobs = Delayed::Worker.delay_jobs
+      old_queue_adapter = ActiveJob::Base.queue_adapter
+      Delayed::Worker.delay_jobs = true
+      ActiveJob::Base.queue_adapter = :delayed_job
+      example.run
+      Delayed::Worker.delay_jobs = old_delay_jobs
+      ActiveJob::Base.queue_adapter = old_queue_adapter
+    end
+
+    it "stores completed jobs in completed_jobs table" do
+      expect(Delayed::Job.count).to eq 0
+      expect(CompletedJob.count).to eq 0
+
+      SuccessfulJob.perform_later
+
+      expect(Delayed::Job.count).to eq 1
+      expect(CompletedJob.count).to eq 0
+
+      dw = Delayed::Worker.new
+      dj = Delayed::Job.last
+      dw.run dj
+
+      expect(Delayed::Job.count).to eq 0
+      expect(CompletedJob.count).to eq 1
+    end
+
+    it "doesn't delete failed jobs" do
+      expect(Delayed::Job.count).to eq 0
+      expect(CompletedJob.count).to eq 0
+
+      FailingJob.perform_later
+
+      expect(Delayed::Job.count).to eq 1
+      job = Delayed::Job.first
+      expect(job.failed_at).to eq nil
+      expect(CompletedJob.count).to eq 0
+
+      # Create a worker and run this job until it's marked as failed.
+      dw = Delayed::Worker.new
+      Delayed::Worker.max_attempts.times do
+        dw.run Delayed::Job.last
+      end
+
+      expect(Delayed::Job.count).to eq 1
+      job.reload
+      expect(job.failed_at).not_to eq nil
+      expect(CompletedJob.count).to eq 0
+    end
+  end
+end

--- a/WcaOnRails/spec/lib/delayed/plugins/save_completed_jobs_spec.rb
+++ b/WcaOnRails/spec/lib/delayed/plugins/save_completed_jobs_spec.rb
@@ -8,7 +8,7 @@ end
 
 class FailingJob < ActiveJob::Base
   def perform
-    raise "Failure!"
+    fail "Failure!"
   end
 end
 

--- a/WcaOnRails/spec/mailers/job_failure_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/job_failure_mailer_spec.rb
@@ -4,11 +4,7 @@ RSpec.describe JobFailureMailer, type: :mailer do
   describe "notify_admin_of_job_failure" do
     let(:job) { Delayed::Job.new(id: 42, handler: "I tried to take care of this") }
     let(:exception) do
-      begin
-        raise "error!"
-      rescue Exception => e
-        return e
-      end
+      RuntimeError.new("error!").tap { |e| e.set_backtrace(["stack level 1", "stack level 2"]) }
     end
     let(:mail) { JobFailureMailer.notify_admin_of_job_failure(job, exception) }
 
@@ -24,6 +20,7 @@ RSpec.describe JobFailureMailer, type: :mailer do
       expect(mail.body.encoded).to match("Handler")
       expect(mail.body.encoded).to match("I tried to take care of this")
       expect(mail.body.encoded).to match("Backtrace")
+      expect(mail.body.encoded).to match("<pre>stack level 1\r\nstack level 2</pre>")
     end
   end
 end

--- a/WcaOnRails/spec/mailers/job_failure_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/job_failure_mailer_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe JobFailureMailer, type: :mailer do
+  describe "notify_admin_of_job_failure" do
+    let(:job) { Delayed::Job.new(id: 42) }
+    let(:exception) do
+      begin
+        raise "error!"
+      rescue Exception => e
+        return e
+      end
+    end
+    let(:mail) { JobFailureMailer.notify_admin_of_job_failure(job, exception) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Job 42 failed")
+      expect(mail.to).to eq(["admin@worldcubeassociation.org"])
+      expect(mail.reply_to).to eq(["admin@worldcubeassociation.org"])
+      expect(mail.from).to eq(["notifications@worldcubeassociation.org"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Job 42 failed")
+    end
+  end
+end

--- a/WcaOnRails/spec/mailers/job_failure_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/job_failure_mailer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe JobFailureMailer, type: :mailer do
   describe "notify_admin_of_job_failure" do
-    let(:job) { Delayed::Job.new(id: 42) }
+    let(:job) { Delayed::Job.new(id: 42, handler: "I tried to take care of this") }
     let(:exception) do
       begin
         raise "error!"
@@ -21,6 +21,9 @@ RSpec.describe JobFailureMailer, type: :mailer do
 
     it "renders the body" do
       expect(mail.body.encoded).to match("Job 42 failed")
+      expect(mail.body.encoded).to match("Handler")
+      expect(mail.body.encoded).to match("I tried to take care of this")
+      expect(mail.body.encoded).to match("Backtrace")
     end
   end
 end

--- a/WcaOnRails/spec/mailers/previews/job_failure_mailer_preview.rb
+++ b/WcaOnRails/spec/mailers/previews/job_failure_mailer_preview.rb
@@ -1,0 +1,13 @@
+# Preview all emails at http://localhost:3000/rails/mailers/job_failure_mailer
+class JobFailureMailerPreview < ActionMailer::Preview
+  def notify_admin_of_job_failure
+    job = Delayed::Job.new(id: 4242)
+    exception = nil
+    begin
+      raise "This is an error!"
+    rescue Exception => e
+      exception = e
+    end
+    JobFailureMailer.notify_admin_of_job_failure(job, exception)
+  end
+end

--- a/WcaOnRails/spec/mailers/previews/job_failure_mailer_preview.rb
+++ b/WcaOnRails/spec/mailers/previews/job_failure_mailer_preview.rb
@@ -4,8 +4,8 @@ class JobFailureMailerPreview < ActionMailer::Preview
     job = Delayed::Job.new(id: 4242)
     exception = nil
     begin
-      raise "This is an error!"
-    rescue Exception => e
+      fail "This is an error!"
+    rescue StandardError => e
       exception = e
     end
     JobFailureMailer.notify_admin_of_job_failure(job, exception)

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -512,10 +512,10 @@ RSpec.describe User, type: :model do
   end
 
   describe "#notify_of_results_posted" do
-    let(:competition) { FactoryGirl.build(:competition) }
+    let(:competition) { FactoryGirl.create(:competition) }
 
     it "sends the notification if the user has it enabled" do
-      user = FactoryGirl.build(:user_with_wca_id, results_notifications_enabled: true)
+      user = FactoryGirl.create(:user_with_wca_id, results_notifications_enabled: true)
       expect(CompetitionsMailer).to receive(:notify_users_of_results_presence).with(user, competition).and_call_original
       user.notify_of_results_posted(competition)
     end

--- a/WcaOnRails/spec/rails_helper.rb
+++ b/WcaOnRails/spec/rails_helper.rb
@@ -55,4 +55,6 @@ RSpec.configure do |config|
 
   # Make sign_in helper available in feature specs
   config.include SessionHelper, type: :feature
+
+  config.include ActiveJob::TestHelper
 end

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -34,8 +34,10 @@ rebuild_rails() {
 
     # Note that we are intentionally not automating database migrations.
 
+    # Kill all delayed_job workers.
+    pkill -f "wca_worker/delayed_job"
     # Restart delayed_job worker.
-    bin/delayed_job restart
+    bin/delayed_job -p wca_worker --pool=mailers:1 --pool=*:1 start
 
     # Attempt to restart unicorn gracefully as per
     #  http://unicorn.bogomips.org/SIGNALS.html

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -34,6 +34,9 @@ rebuild_rails() {
 
     # Note that we are intentionally not automating database migrations.
 
+    # Restart delayed_job worker.
+    bin/delayed_job restart
+
     # Attempt to restart unicorn gracefully as per
     #  http://unicorn.bogomips.org/SIGNALS.html
     pid=$(<"pids/unicorn.pid")


### PR DESCRIPTION
This is a large part of #633.

In addition to setting up delayed_job, I ported our new notify competitors of results feature (#75) to use `deliver_later` instead of `deliver_now`. This caused some test fallout that was a little tricky to track down.
Should we be using `deliver_later` everywhere now instead of `deliver_now`? There's also devise.... https://github.com/plataformatec/devise#activejob-integration

When jobs succeed, we copy them over to the `completed_jobs` table, because delayed_job removes completed jobs from the delayed_jobs table.

When a job fails, we immediately email `admin@`. The email looks like this:

![image](https://cloud.githubusercontent.com/assets/277474/15353132/4ae8662a-1c9c-11e6-9d9f-b8a9111a4389.png)
