### PR TITLE
Turns out users_to_sentence wasn't escaping users names!

### DIFF
--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -140,8 +140,8 @@ module ApplicationHelper
   end
 
   def users_to_sentence(users, include_email: false)
-    users.sort_by(&:name).map do |user|
+    "".html_safe + users.sort_by(&:name).map do |user|
       include_email ? mail_to(user.email, user.name) : user.name
-    end.to_sentence.html_safe
+    end.to_sentence
   end
 end

--- a/WcaOnRails/spec/helpers/application_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/application_helper_spec.rb
@@ -7,4 +7,22 @@ describe ApplicationHelper do
       expect(string).to eq '<div class="alert alert-warning"><strong>Note:</strong> good job</div>'
     end
   end
+
+  describe "#users_to_sentence" do
+    it "escapes name" do
+      users = []
+      users << FactoryGirl.create(:user, name: "Jonatan")
+      users << FactoryGirl.create(:user, name: "Pedro")
+      users << FactoryGirl.create(:user, name: "Jeremy O'Fleischman")
+      string = helper.users_to_sentence(users)
+      expect(string).to eq 'Jeremy O&#39;Fleischman, Jonatan, and Pedro'
+    end
+
+    it "includes email" do
+      users = []
+      users << FactoryGirl.create(:user, name: "Jonatan O'Klosko", email: "jonatan@worldcubeassociation.org")
+      string = helper.users_to_sentence(users, include_email: true)
+      expect(string).to eq '<a href="mailto:jonatan@worldcubeassociation.org">Jonatan O&#39;Klosko</a>'
+    end
+  end
 end


### PR DESCRIPTION
Fixed that injection vulnerability and added a test.

This fixes #639 (which actually wasn't a testing issue!) Yay tests!

@jonatanklosko, could you take a look at this?