### PR TITLE
Markdown editor!

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -56,6 +56,7 @@ gem 'daemons'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-autosize'
+  gem 'rails-assets-simplemde'
 end
 
 group :development, :test do

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -287,6 +287,7 @@ GEM
       railties (= 4.2.1)
       sprockets-rails
     rails-assets-autosize (3.0.15)
+    rails-assets-simplemde (1.10.1)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.7)
@@ -460,6 +461,7 @@ DEPENDENCIES
   rack-cors
   rails (= 4.2.1)
   rails-assets-autosize!
+  rails-assets-simplemde!
   rake
   recaptcha
   redcarpet (~> 3.3)

--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -29,6 +29,7 @@
 //= require markerclusterer
 //= require bootstrap-table
 //= require autosize
+//= require simplemde
 //= require_self
 //= require_tree .
 
@@ -177,6 +178,13 @@ $(function() {
   $('[data-toggle="tooltip"]').tooltip();
   $('[data-toggle="popover"]').popover();
   $('input.wca-autocomplete').wcaAutocomplete();
+  $('.markdown-editor').each(function() {
+    new SimpleMDE({
+      element: this,
+      spellChecker: false,
+      promptURLs: true,
+    });
+  });
 
   var $tablesToFloatHeaders = $('table.floatThead');
   $tablesToFloatHeaders.floatThead({

--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -183,6 +183,9 @@ $(function() {
       element: this,
       spellChecker: false,
       promptURLs: true,
+
+      // Status bar isn't quite working. See https://github.com/NextStepWebs/simplemde-markdown-editor/issues/334
+      status: false,
     });
   });
 

--- a/WcaOnRails/app/assets/stylesheets/application.css.scss
+++ b/WcaOnRails/app/assets/stylesheets/application.css.scss
@@ -27,6 +27,7 @@
 @import "font-awesome";
 @import "flags/basic";
 @import "flags/flags16";
+@import "simplemde";
 
 @import "wca";
 @import "navbar-static-top";
@@ -41,6 +42,7 @@
 @import "registrations";
 @import "wca-autocomplete";
 @import "collapsible-panels";
+@import "markdown-editor";
 @import "avatars";
 @import "polls";
 @import "teams";

--- a/WcaOnRails/app/assets/stylesheets/links.scss
+++ b/WcaOnRails/app/assets/stylesheets/links.scss
@@ -2,7 +2,7 @@
  * Solution inspired by:
  *  https://github.com/twbs/bootstrap/issues/14854#issuecomment-60221141
  */
-a[target=_blank]:not(.hide-new-window-icon),
+a[target=_blank]:not(.hide-new-window-icon):not(.fa),
 form[target=_blank] button[type=submit] {
   &::after {
     font-family: 'Glyphicons Halflings';

--- a/WcaOnRails/app/assets/stylesheets/markdown-editor.scss
+++ b/WcaOnRails/app/assets/stylesheets/markdown-editor.scss
@@ -1,0 +1,6 @@
+// Styles for simplemde-markdown-editor
+.CodeMirror-fullscreen,
+.editor-toolbar.fullscreen,
+.editor-preview-active-side {
+  z-index: 1001; // on top of navbar
+}

--- a/WcaOnRails/app/assets/stylesheets/posts.scss
+++ b/WcaOnRails/app/assets/stylesheets/posts.scss
@@ -6,3 +6,9 @@ div.pagination {
 textarea[name="post[body]"] {
   height: 400px;
 }
+
+.panel-wca-post .panel-title .pull-right {
+  a {
+    text-decoration: none;
+  }
+}

--- a/WcaOnRails/app/models/post.rb
+++ b/WcaOnRails/app/models/post.rb
@@ -34,7 +34,7 @@ class Post < ActiveRecord::Base
   end
 
   def deletable
-    !is_crash_course_post?
+    persisted? && !is_crash_course_post?
   end
 
   def edit_path

--- a/WcaOnRails/app/views/competitions/edit.html.erb
+++ b/WcaOnRails/app/views/competitions/edit.html.erb
@@ -223,7 +223,7 @@
         <%= render "nearby_competitions" %>
       </div>
 
-      <%= f.input :information, hint: t('.supports_md_html') %>
+      <%= f.input :information, input_html: { class: "markdown-editor" } %>
       <%= f.input :delegate_ids, as: :user_ids, only_delegates: true %>
       <%= f.input :organizer_ids, as: :user_ids %>
       <%= f.input :contact, hint: t('.contact_html', md: t('.supports_md_html')) %>

--- a/WcaOnRails/app/views/posts/_post.html.erb
+++ b/WcaOnRails/app/views/posts/_post.html.erb
@@ -1,4 +1,4 @@
-<div class="panel <%= post.sticky? ? "panel-info" : "panel-default" %>">
+<div class="panel <%= post.sticky? ? "panel-info" : "panel-default" %> panel-wca-post">
   <div class="panel-heading">
     <h3 class="panel-title">
       <% if render_permalink %>

--- a/WcaOnRails/app/views/posts/_post_form.html.erb
+++ b/WcaOnRails/app/views/posts/_post_form.html.erb
@@ -1,0 +1,15 @@
+<% url = @post.new_record? ? posts_path : @post.update_path %>
+<%= simple_form_for @post, url: url, html: { class: 'form-horizontal' } do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+
+  <%= f.input :title, disabled: !editable_post_fields.include?(:title), autofocus: true %>
+  <%= f.input :body if editable_post_fields.include? :body %>
+  <%= f.input :sticky if editable_post_fields.include? :sticky %>
+  <%= f.button :submit %>
+
+  <% if @post.deletable %>
+    <%= link_to post_path(@post.slug), method: "delete", data: { confirm: I18n.t(:confirm_delete_post) }, class: "btn btn-danger" do %>
+      <span class="glyphicon glyphicon-trash"></span> Delete post
+    <% end %>
+  <% end %>
+<% end %>

--- a/WcaOnRails/app/views/posts/_post_form.html.erb
+++ b/WcaOnRails/app/views/posts/_post_form.html.erb
@@ -3,7 +3,7 @@
   <%= render 'shared/error_messages', object: f.object %>
 
   <%= f.input :title, disabled: !editable_post_fields.include?(:title), autofocus: true %>
-  <%= f.input :body if editable_post_fields.include? :body %>
+  <%= f.input :body, input_html: { class: 'markdown-editor' } if editable_post_fields.include? :body %>
   <%= f.input :sticky if editable_post_fields.include? :sticky %>
   <%= f.button :submit %>
 

--- a/WcaOnRails/app/views/posts/edit.html.erb
+++ b/WcaOnRails/app/views/posts/edit.html.erb
@@ -3,18 +3,5 @@
 <div class="container">
   <h1><%= yield(:title) %></h1>
 
-  <%= simple_form_for @post, url: @post.update_path, html: { class: 'form-horizontal' } do |f| %>
-    <%= render 'shared/error_messages', object: f.object %>
-
-    <%= f.input :title, disabled: !editable_post_fields.include?(:title) %>
-    <%= f.input :body if editable_post_fields.include? :body %>
-    <%= f.input :sticky if editable_post_fields.include? :sticky %>
-    <%= f.button :submit %>
-
-    <% if @post.deletable %>
-      <%= link_to post_path(@post.slug), method: "delete", data: { confirm: I18n.t(:confirm_delete_post) }, class: "btn btn-danger" do %>
-        <span class="glyphicon glyphicon-trash"></span> Delete post
-      <% end %>
-    <% end %>
-  <% end %>
+  <%= render "post_form" %>
 </div>

--- a/WcaOnRails/app/views/posts/new.html.erb
+++ b/WcaOnRails/app/views/posts/new.html.erb
@@ -3,12 +3,5 @@
 <div class="container">
   <h1><%= yield(:title) %></h1>
 
-  <%= simple_form_for @post, html: { class: 'form-horizontal' } do |f| %>
-    <%= render 'shared/error_messages', object: f.object %>
-
-    <%= f.input :title, autofocus: true %>
-    <%= f.input :body %>
-    <%= f.input :sticky %>
-    <%= f.button :submit %>
-  <% end %>
+  <%= render "post_form" %>
 </div>


### PR DESCRIPTION
(This is part of the building blocks towards doing delegate reports on the WCA website. https://github.com/cubing/worldcubeassociation.org/issues/222) @viroulep, could you take a look at the editor I chose? I tried very hard to pick one that would be usable by people unfamiliar with markdown.

I looked at all of the fancy text editors listed on https://github.com/cubing/ccm/issues/133, and decided that https://github.com/NextStepWebs/simplemde-markdown-editor looked the best for people unfamiliar with markdown.

- Added a markdown editor to the create and edit posts pages (after consolidating the 2 pages into a single partial).
- Added a markdown editor to the information field on the edit competitions page.
  - Note: there are a number of other fields on edit competition page that support markdown, but I chose not to give them the fancy editor. We need to talk about what exactly we want those fields to be (most of them are inputs that expect exactly 1 line, and could probably be better expressed as 2 separate textboxes: text and url). I've created #663 to track this.
- Fixed a silly comestic bug with underlines on links: ![image](https://cloud.githubusercontent.com/assets/277474/15492115/c1c31454-212c-11e6-8c96-c921d0df03d7.png)

You can try out the new editor on staging [here](https://staging.worldcubeassociation.org/posts/nanchang-winter-2015-on-december-27-2015-in-nanchang-jiangxi-china/edit) and [here](https://staging.worldcubeassociation.org/competitions/BerlinWinter2013/edit/admin).