### PR TITLE
Display country name instead of id

### DIFF
--- a/WcaOnRails/app/models/light_result.rb
+++ b/WcaOnRails/app/models/light_result.rb
@@ -58,6 +58,10 @@ class LightResult
     Format.find_by_id(formatId)
   end
 
+  def country
+    Country.find(countryId)
+  end
+
   def wca_id
     @personId
   end

--- a/WcaOnRails/app/views/competitions/_results_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_results_table.html.erb
@@ -81,7 +81,7 @@
         <td class="average"><%= result.average_solve.clock_format %></td>
         <td class="regionalAverageRecord"><%= result.regionalAverageRecord %></td>
 
-        <td class="country"><%= result.countryId %></td>
+        <td class="country"><%= result.country.name %></td>
 
         <% trimmed_indices = result.trimmed_indices %>
         <% best_index = result.best_index %>

--- a/WcaOnRails/app/views/competitions/show_results_by_person.html.erb
+++ b/WcaOnRails/app/views/competitions/show_results_by_person.html.erb
@@ -5,7 +5,7 @@
     <% @competition.person_names_with_results.each do |personName, results| %>
       <h3>
         <% first_result = results.first %>
-        <%= anchorable "#{personName} - #{first_result.countryId}", first_result.wca_id %>
+        <%= anchorable "#{personName} - #{first_result.country.name}", first_result.wca_id %>
         <%= link_to "WCA profile", first_result.results_path %>
       </h3>
       <%= render "results_table", results: results, hide_name: true, hide_country: true %>

--- a/webroot/results/includes/_framework.php
+++ b/webroot/results/includes/_framework.php
@@ -135,8 +135,11 @@ function competitionDate ( $competition ) {
 
 function chosenRegionName ( $visibleWorld = false ) {
   global $chosenRegionId;
-  if ( !$chosenRegionId && $visibleWorld ) return 'World';
-  return preg_replace( '/^_/', '', $chosenRegionId );
+  if ( !$chosenRegionId && $visibleWorld )
+    return 'World';
+  if( preg_match( '/^_/', $chosenRegionId ) )
+    return substr($chosenRegionId, 1);
+  return dbQuery( "SELECT name FROM Countries WHERE id='$chosenRegionId'" )[0]['name'];
 }
 
 function chosenEventName () {
@@ -178,7 +181,7 @@ function yearCondition () {
 
 function regionCondition ( $countrySource ) {
   global $chosenRegionId;
-  
+
   if( preg_match( '/^(world)?$/i', $chosenRegionId ))
     return '';
 


### PR DESCRIPTION
Fixes the Rails part of #666.
@timhabermaas I guess we need to clear cached pages, how should this be done correctly?

About the PHP part. Should this be fixed by changing [this method](https://github.com/cubing/worldcubeassociation.org/blob/5fe5e5c1557c4d5e7d2b49d4caeb585f60e4c2ed/webroot/results/includes/_framework.php#L136-L140), to the following?
```php
function chosenRegionName ( $visibleWorld = false ) {
  global $chosenRegionId;
  if ( !$chosenRegionId && $visibleWorld )
    return 'World';
  if( preg_match( '/^_/', $chosenRegionId ) )
    return substr($chosenRegionId, 1);
  return dbQuery( "SELECT name FROM Countries WHERE id='$chosenRegionId'" )[0]['name'];
}
```