### PR TITLE
Show registration status on My Competitions page

### DIFF
--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -15,28 +15,42 @@
         <th>Date</th>
         <th></th>
         <th></th>
+        <th></th>
         <th class="big-column"></th>
       </tr>
     </thead>
     <tbody>
       <% competitions.each do |competition| %>
+        <% message = "" %>
+        <% if registration = competition.registrations.find_by_user_id(current_user.id) %>
+          <% if registration.accepted? %>
+            <% message = "You are registered. " %>
+          <% else %>
+            <% message = "You are currently on the waiting list. " %>
+          <% end %>
+        <% end %>
         <% if competition.isConfirmed %>
           <% if competition.showAtAll %>
-            <% message = "This competition is confirmed and visible." %>
+            <% message += "This competition is confirmed and visible." %>
           <% else %>
-            <% message = "This competition is confirmed but not visible." %>
+            <% message += "This competition is confirmed but not visible." %>
           <% end %>
         <% else %>
           <% if competition.showAtAll %>
-            <% message = "This competition is not confirmed but is visible." %>
+            <% message += "This competition is not confirmed but is visible." %>
           <% else %>
-            <% message = "This competition is not confirmed and not visible." %>
+            <% message += "This competition is not confirmed and not visible." %>
           <% end %>
         <% end %>
           <tr class="<%= competition.isConfirmed ? "confirmed" : "not-confirmed" %> <%= competition.showAtAll ? "visible" : "not-visible" %> <%= !past ? "not-past" : "past" %>" data-toggle="tooltip" data-placement="top" data-container="body" title="<%= !past ? message : "" %>">
             <td><%= link_to competition.name, competition_path(competition) %></td>
             <td><%= competition.cityName %>, <%= competition.country ? competition.country.name : "" %></td>
             <td><%= wca_date_range(competition.start_date, competition.end_date) %></td>
+            <td>
+              <% if registration %>
+                <%= icon(registration.accepted? ? "calendar-check-o" : "hourglass-half") %>
+              <% end %>
+            </td>
             <td>
               <% if !past && current_user.can_manage_competition?(competition) %>
                 <%= link_to "Edit", edit_competition_path(competition) %>

--- a/WcaOnRails/spec/views/competitions/my_competitions.html.erb_spec.rb
+++ b/WcaOnRails/spec/views/competitions/my_competitions.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "competitions/my_competitions" do
+  let(:competition) { FactoryGirl.create(:competition, :registration_open, name: "Melbourne Open 2016") }
+  let(:registration) { FactoryGirl.create(:registration, competition: competition) }
+
+  before do
+    allow(view).to receive(:current_user) { registration.user }
+    assign(:not_past_competitions, [competition])
+    assign(:past_competitions, [])
+  end
+
+  it "shows upcoming competitions" do
+    render
+    expect(rendered).to match '<td><a href="/competitions/MelbourneOpen2016">Melbourne Open 2016</a></td>'
+  end
+
+  it "shows you are on the waiting list" do
+    render
+    expect(rendered).to match 'You are currently on the waiting list'
+    expect(rendered).to match '<i class="fa fa-hourglass-half"></i>'
+  end
+end


### PR DESCRIPTION
The list and registered icons from Font Awesome Icons have been used
to show the registration status along with some extra text in the tooltip.
Two tests were created to test the my_competitions view.