### PR TITLE
Nag delegates about results after a week

### DIFF
--- a/WcaOnRails/app/jobs/submit_results_nag_job.rb
+++ b/WcaOnRails/app/jobs/submit_results_nag_job.rb
@@ -1,0 +1,14 @@
+class SubmitResultsNagJob < ActiveJob::Base
+  queue_as :default
+
+  def nag_needed(competition)
+    (competition.results_nag_sent_at || competition.end_date) <= 1.week.ago
+  end
+
+  def perform()
+    Competition.where(results_posted_at: nil).all.select { |c| nag_needed(c) }.each do |competition|
+      competition.update_attribute(:results_nag_sent_at, Time.now)
+      CompetitionsMailer.submit_results_nag(competition).deliver_later
+    end
+  end
+end

--- a/WcaOnRails/app/jobs/submit_results_nag_job.rb
+++ b/WcaOnRails/app/jobs/submit_results_nag_job.rb
@@ -5,10 +5,10 @@ class SubmitResultsNagJob < ActiveJob::Base
     (competition.results_nag_sent_at || competition.end_date) <= 1.week.ago
   end
 
-  def perform()
-    Competition.where(results_posted_at: nil).all.select { |c| nag_needed(c) }.each do |competition|
+  def perform
+    Competition.where(results_posted_at: nil).select { |c| nag_needed(c) }.each do |competition|
       competition.update_attribute(:results_nag_sent_at, Time.now)
-      CompetitionsMailer.submit_results_nag(competition).deliver_later
+      CompetitionsMailer.submit_results_nag(competition).deliver_now
     end
   end
 end

--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -6,7 +6,7 @@ class CompetitionsMailer < ApplicationMailer
       to: "board@worldcubeassociation.org",
       cc: competition.delegates.pluck(:email),
       reply_to: confirmer.email,
-      subject: "#{confirmer.name} just confirmed #{competition.name}"
+      subject: "#{confirmer.name} just confirmed #{competition.name}",
     )
   end
 
@@ -16,6 +16,16 @@ class CompetitionsMailer < ApplicationMailer
     mail(
       to: user.email,
       subject: "The results of #{competition.name} are posted"
+    )
+  end
+
+  def submit_results_nag(competition)
+    @competition = competition
+    mail(
+      to: competition.delegates.pluck(:email),
+      cc: "results@worldcubeassociation.org",
+      reply_to: "results@worldcubeassociation.org",
+      subject: "#{competition.name} Results",
     )
   end
 end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -45,6 +45,7 @@ class Competition < ActiveRecord::Base
     registration_open
     registration_close
     results_posted_at
+    results_nag_sent_at
   ).freeze
   ENDS_WITH_YEAR_RE = /\A(.*) (\d{4})\z/
   PATTERN_LINK_RE = /\[\{([^}]+)}\{((https?:|mailto:)[^}]+)}\]/

--- a/WcaOnRails/app/models/light_result.rb
+++ b/WcaOnRails/app/models/light_result.rb
@@ -1,5 +1,4 @@
 require 'solve_time'
-require_relative './format'
 
 # This is an alternative to `Result` used for performance reasons.
 # See also the comment in `app/models/competition.rb`.

--- a/WcaOnRails/app/views/competitions_mailer/submit_results_nag.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/submit_results_nag.html.erb
@@ -1,0 +1,16 @@
+<p>
+  Dear <%= "Delegate".pluralize(@competition.delegates.count) %> of <%= @competition.name %>,
+</p>
+
+<p>
+  This is an automated reminder. Over a week has passed since <%= @competition.name %> took
+  place and the results of the competition are still not available as required by regulation
+  <a href="https://www.worldcubeassociation.org/regulations/#1c3">1c3)</a>.
+  There might be valid reasons for this, but nonetheless you are requested to reply to this mail
+  to inform the results team about the state of the competition results as soon as possible
+  (if not already done).
+</p>
+
+<p>
+  Regards, The WCA Results Team.
+</p>

--- a/WcaOnRails/db/migrate/20160528071910_add_results_nag_sent_at_to_competitions.rb
+++ b/WcaOnRails/db/migrate/20160528071910_add_results_nag_sent_at_to_competitions.rb
@@ -1,0 +1,5 @@
+class AddResultsNagSentAtToCompetitions < ActiveRecord::Migration
+  def change
+    add_column :Competitions, :results_nag_sent_at, :datetime
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -50,6 +50,7 @@ CREATE TABLE `Competitions` (
   `use_wca_registration` tinyint(1) NOT NULL DEFAULT '0',
   `guests_enabled` tinyint(1) NOT NULL DEFAULT '1',
   `results_posted_at` datetime DEFAULT NULL,
+  `results_nag_sent_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `year_month_day` (`year`,`month`,`day`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
@@ -989,3 +990,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160518045741');
 INSERT INTO schema_migrations (version) VALUES ('20160520230353');
 
 INSERT INTO schema_migrations (version) VALUES ('20160517140653');
+
+INSERT INTO schema_migrations (version) VALUES ('20160528071910');

--- a/WcaOnRails/lib/tasks/work.rake
+++ b/WcaOnRails/lib/tasks/work.rake
@@ -1,0 +1,6 @@
+namespace :work do
+  desc 'Schedule work to be done'
+  task :schedule => :environment do
+    SubmitResultsNagJob.perform_later
+  end
+end

--- a/WcaOnRails/spec/jobs/submit_results_nag_job_spec.rb
+++ b/WcaOnRails/spec/jobs/submit_results_nag_job_spec.rb
@@ -2,18 +2,21 @@ require 'rails_helper'
 
 RSpec.describe SubmitResultsNagJob, type: :job do
   it "schedules results nag email" do
-    recent_competition_missing_results = FactoryGirl.create :competition, starts: 3.days.ago
+    _recent_competition_missing_results = FactoryGirl.create :competition, starts: 3.days.ago
     old_competition_missing_results = FactoryGirl.create :competition, starts: 3.weeks.ago
-    older_competition_missing_results_but_already_nagged = FactoryGirl.create :competition, starts: 3.weeks.ago, results_nag_sent_at: 1.day.ago
+    _older_competition_missing_results_but_already_nagged = FactoryGirl.create :competition, starts: 3.weeks.ago, results_nag_sent_at: 1.day.ago
     older_competition_missing_results_nagged_a_long_time_ago = FactoryGirl.create :competition, starts: 3.weeks.ago, results_nag_sent_at: 8.days.ago
 
     expect(CompetitionsMailer).to receive(:submit_results_nag).with(old_competition_missing_results).and_call_original
     expect(CompetitionsMailer).to receive(:submit_results_nag).with(older_competition_missing_results_nagged_a_long_time_ago).and_call_original
-    SubmitResultsNagJob.perform_now
-    assert_enqueued_jobs 2
+
+    expect do
+      SubmitResultsNagJob.perform_now
+    end.to change { ActionMailer::Base.deliveries.length }.by(2)
 
     # Calling SubmitResultsNagJob again shouldn't cause any new emails to be sent.
-    SubmitResultsNagJob.perform_now
-    assert_enqueued_jobs 2
+    expect do
+      SubmitResultsNagJob.perform_now
+    end.to change { ActionMailer::Base.deliveries.length }.by(0)
   end
 end

--- a/WcaOnRails/spec/jobs/submit_results_nag_job_spec.rb
+++ b/WcaOnRails/spec/jobs/submit_results_nag_job_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe SubmitResultsNagJob, type: :job do
+  it "schedules results nag email" do
+    recent_competition_missing_results = FactoryGirl.create :competition, starts: 3.days.ago
+    old_competition_missing_results = FactoryGirl.create :competition, starts: 3.weeks.ago
+    older_competition_missing_results_but_already_nagged = FactoryGirl.create :competition, starts: 3.weeks.ago, results_nag_sent_at: 1.day.ago
+    older_competition_missing_results_nagged_a_long_time_ago = FactoryGirl.create :competition, starts: 3.weeks.ago, results_nag_sent_at: 8.days.ago
+
+    expect(CompetitionsMailer).to receive(:submit_results_nag).with(old_competition_missing_results).and_call_original
+    expect(CompetitionsMailer).to receive(:submit_results_nag).with(older_competition_missing_results_nagged_a_long_time_ago).and_call_original
+    SubmitResultsNagJob.perform_now
+    assert_enqueued_jobs 2
+
+    # Calling SubmitResultsNagJob again shouldn't cause any new emails to be sent.
+    SubmitResultsNagJob.perform_now
+    assert_enqueued_jobs 2
+  end
+end

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
 
     it "renders the headers" do
       expect(mail.subject).to eq "Comp of the Future 2016 Results"
-      expect(mail.to).to match_array competition.delegates.map(&:email)
+      expect(mail.to).to match_array competition.delegates.pluck(:email)
       expect(mail.cc).to eq ["results@worldcubeassociation.org"]
       expect(mail.reply_to).to eq ["results@worldcubeassociation.org"]
       expect(mail.from).to eq ["notifications@worldcubeassociation.org"]

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -33,4 +33,23 @@ RSpec.describe CompetitionsMailer, type: :mailer do
       expect(mail.body.encoded).to match(/Your results at .+ have just been posted./)
     end
   end
+
+  describe "submit_results_nag" do
+    let(:competition) do
+      FactoryGirl.create(:competition, name: "Comp of the Future 2016")
+    end
+    let(:mail) { CompetitionsMailer.submit_results_nag(competition) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq "Comp of the Future 2016 Results"
+      expect(mail.to).to match_array competition.delegates.map(&:email)
+      expect(mail.cc).to eq ["results@worldcubeassociation.org"]
+      expect(mail.reply_to).to eq ["results@worldcubeassociation.org"]
+      expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match(/Over a week has passed since #{competition.name}/)
+    end
+  end
 end

--- a/WcaOnRails/spec/mailers/previews/competitions_mailer_preview.rb
+++ b/WcaOnRails/spec/mailers/previews/competitions_mailer_preview.rb
@@ -1,18 +1,18 @@
 # Preview all emails at http://localhost:3000/rails/mailers/competitions_mailer
 class CompetitionsMailerPreview < ActionMailer::Preview
   def notify_board_of_confirmed_competition
-    c = CompetitionDelegate.first.competition
+    c = CompetitionDelegate.last.competition
     CompetitionsMailer.notify_board_of_confirmed_competition(c.delegates[0], c)
   end
 
   def notify_users_of_results_presence
-    competition = Competition.joins(:results).where.not(results_posted_at: nil).first
-    user = competition.competitor_users.first
+    competition = Competition.joins(:results).where.not(results_posted_at: nil).last
+    user = competition.competitor_users.last
     CompetitionsMailer.notify_users_of_results_presence(user, competition)
   end
 
   def submit_results_nag
-    competition = Competition.first
+    competition = Competition.last
     CompetitionsMailer.submit_results_nag(competition)
   end
 end

--- a/WcaOnRails/spec/mailers/previews/competitions_mailer_preview.rb
+++ b/WcaOnRails/spec/mailers/previews/competitions_mailer_preview.rb
@@ -1,16 +1,18 @@
 # Preview all emails at http://localhost:3000/rails/mailers/competitions_mailer
 class CompetitionsMailerPreview < ActionMailer::Preview
-
-  # Preview this email at http://localhost:3000/rails/mailers/competitions_mailer/notify_board_of_confirmed_competition
   def notify_board_of_confirmed_competition
     c = CompetitionDelegate.first.competition
     CompetitionsMailer.notify_board_of_confirmed_competition(c.delegates[0], c)
   end
 
-  # Preview this email at http://localhost:3000/rails/mailers/competitions_mailer/notify_users_of_results_presence
   def notify_users_of_results_presence
     competition = Competition.joins(:results).where.not(results_posted_at: nil).first
     user = competition.competitor_users.first
     CompetitionsMailer.notify_users_of_results_presence(user, competition)
+  end
+
+  def submit_results_nag
+    competition = Competition.first
+    CompetitionsMailer.submit_results_nag(competition)
   end
 end

--- a/chef/site-cookbooks/wca/recipes/cronjobs.rb
+++ b/chef/site-cookbooks/wca/recipes/cronjobs.rb
@@ -22,6 +22,19 @@ unless node.chef_environment.start_with?("development")
   end
 end
 
+unless node.chef_environment.start_with?("development")
+  cron "hourly schedule rails work" do
+    minute '0'
+    hour '*'
+    weekday '*'
+
+    path path
+    mailto admin_email
+    user username
+    command "(cd #{repo_root}; bin/rake work:schedule)"
+  end
+end
+
 html_format_envvars = {
   "CONTENT_TYPE" => "text/html",
   "CONTENT_TRANSFER_ENCODING" => "utf8",


### PR DESCRIPTION
This builds on top of our delayed_job infrastructure. I added a new rake script: `work:schedule` that is called hourly by cron.

Currently, `work:schedule` only calls `SubmitResultsNagJob.perform_later`, which does a query to find competitions that are over and missing results. If enough time has passed (1 week), then it will send a nag email (`CompetitionsMailer.submit_results_nag`) to the delegates of the competition, and cc results@.

An example such email (@SAuroux, could you take a look? This was basically copied from https://github.com/cubing/worldcubeassociation.org/issues/571#issuecomment-216946902):

![image](https://cloud.githubusercontent.com/assets/277474/15642938/52f2c056-25ff-11e6-8d4f-a3356b045eb7.png)

NOTE: To ensure idempotence of SubmitResultsNagJob, I added a `results_nag_sent_at` field to the `Competitions` table.