### PR TITLE
Inverted two strings for the "ask for guests" during registration

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -135,8 +135,8 @@ en:
           p: "Waiting list"
       competition:
         guests_enabled:
-          "true": "Do NOT ask about guests"
-          "false": "Ask about guests"
+          "true": "Ask about guests"
+          "false": "Do NOT ask about guests"
   errors:
     messages:
       error: "error"


### PR DESCRIPTION
I believe that the two strings (true and false for guests_enabled) need to be inverted:

if I select "do NOT ask about guests"
![image](https://cloud.githubusercontent.com/assets/4145338/15654372/ec112a72-2693-11e6-866c-8e0c092a2d49.png)

and then I try to register, it asks me for the guests:
![image](https://cloud.githubusercontent.com/assets/4145338/15654385/0ed75428-2694-11e6-886c-5cdf2d85ac0a.png)

while, if i select "Ask about guests":
![image](https://cloud.githubusercontent.com/assets/4145338/15654400/25504ca0-2694-11e6-92ee-2fb76a7c471e.png)

It doesn't ask me the number of guests:
![image](https://cloud.githubusercontent.com/assets/4145338/15654405/374a8c18-2694-11e6-89c9-73bf48860567.png)
