### PR TITLE
Organizers will be listed in the signature of registration emails - fixes #337

### DIFF
--- a/WcaOnRails/app/mailers/registrations_mailer.rb
+++ b/WcaOnRails/app/mailers/registrations_mailer.rb
@@ -34,7 +34,7 @@ class RegistrationsMailer < ApplicationMailer
     @registration = registration
     mail(
       to: registration.email,
-      reply_to: registration.competition.managers.map(&:email),
+      reply_to: registration.competition.organizers_or_delegates.map(&:email),
       subject: "You have registered for #{registration.competition.name}",
     )
   end
@@ -43,7 +43,7 @@ class RegistrationsMailer < ApplicationMailer
     @registration = registration
     mail(
       to: registration.email,
-      reply_to: registration.competition.managers.map(&:email),
+      reply_to: registration.competition.organizers_or_delegates.map(&:email),
       subject: "Your registration for #{registration.competition.name} has been accepted",
     )
   end
@@ -52,7 +52,7 @@ class RegistrationsMailer < ApplicationMailer
     @registration = registration
     mail(
       to: registration.email,
-      reply_to: registration.competition.managers.map(&:email),
+      reply_to: registration.competition.organizers_or_delegates.map(&:email),
       subject: "You have been moved to the waiting list for #{registration.competition.name}",
     )
   end
@@ -61,7 +61,7 @@ class RegistrationsMailer < ApplicationMailer
     @registration = registration
     mail(
       to: registration.email,
-      reply_to: registration.competition.managers.map(&:email),
+      reply_to: registration.competition.organizers_or_delegates.map(&:email),
       subject: "Your registration for #{registration.competition.name} has been deleted",
     )
   end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -593,6 +593,10 @@ class Competition < ActiveRecord::Base
     Country.find_by_id(countryId)
   end
 
+  def organizers_or_delegates
+    self.organizers.empty? ? self.delegates : self.organizers
+  end
+
   def self.search(query, params: {})
     competitions = Competition.where(showAtAll: true)
 

--- a/WcaOnRails/app/views/registrations_mailer/_organizers_or_delegates_signature.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/_organizers_or_delegates_signature.html.erb
@@ -1,0 +1,3 @@
+<p>
+  Regards, <%= users_to_sentence @competition.organizers_or_delegates %>.
+</p>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_accepted_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_accepted_registration.html.erb
@@ -1,14 +1,12 @@
-<% competition = @registration.competition %>
+<% @competition = @registration.competition %>
 
 <p>
-  Your registration for <%= link_to competition.name, competition_url(competition) %> has been accepted.
-  As always, you can check the status of your registration <%= link_to "here", competition_register_url(competition) %>.
+  Your registration for <%= link_to @competition.name, competition_url(@competition) %> has been accepted.
+  As always, you can check the status of your registration <%= link_to "here", competition_register_url(@competition) %>.
 </p>
 
 <p>
-  We look forward to seeing you on <%= competition.start_date.to_formatted_s(:long) %>!
+  We look forward to seeing you on <%= @competition.start_date.to_formatted_s(:long) %>!
 </p>
 
-<p>
-  Regards, <%= users_to_sentence competition.managers %>.
-</p>
+<%= render partial: 'organizers_or_delegates_signature' %>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_deleted_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_deleted_registration.html.erb
@@ -1,7 +1,7 @@
-<% competition = @registration.competition %>
+<% @competition = @registration.competition %>
 
 <p>
-  Your registration for <%= link_to competition.name, competition_url(competition) %> has been deleted. Possible causes are:
+  Your registration for <%= link_to @competition.name, competition_url(@competition) %> has been deleted. Possible causes are:
 </p>
 
 <ul>
@@ -20,6 +20,4 @@
   If you think this is an error, please reply to this email.
 </p>
 
-<p>
-  Regards, <%= users_to_sentence competition.managers %>.
-</p>
+<%= render partial: 'organizers_or_delegates_signature' %>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_new_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_new_registration.html.erb
@@ -1,19 +1,17 @@
-<% competition = @registration.competition %>
+<% @competition = @registration.competition %>
 
 <p>
-  You just registered for <%= link_to competition.name, competition_url(competition) %>.
+  You just registered for <%= link_to @competition.name, competition_url(@competition) %>.
 </p>
 
 <p>
-  Your registration is on the waiting list, which currently has <%= competition.registrations.pending.count %> <%= "person".pluralize(competition.registrations.pending.count) %> on it.
+  Your registration is on the waiting list, which currently has <%= @competition.registrations.pending.count %> <%= "person".pluralize(@competition.registrations.pending.count) %> on it.
 </p>
 
 <p>
   You will be emailed when your registration is approved.
   You can also check the status of your registration
-  <%= link_to "here", competition_register_url(competition) %>.
+  <%= link_to "here", competition_register_url(@competition) %>.
 </p>
 
-<p>
-  Regards, <%= users_to_sentence competition.managers %>.
-</p>
+<%= render partial: 'organizers_or_delegates_signature' %>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_pending_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_pending_registration.html.erb
@@ -1,7 +1,7 @@
-<% competition = @registration.competition %>
+<% @competition = @registration.competition %>
 
 <p>
-  Your registration for <%= link_to competition.name, competition_url(competition) %> has been moved to the waiting list. Possible causes are:
+  Your registration for <%= link_to @competition.name, competition_url(@competition) %> has been moved to the waiting list. Possible causes are:
 </p>
 
 <ul>
@@ -17,6 +17,4 @@
   If you think this is an error, please reply to this email.
 </p>
 
-<p>
-  Regards, <%= users_to_sentence competition.managers %>.
-</p>
+<%= render partial: 'organizers_or_delegates_signature' %>


### PR DESCRIPTION
If the  organizers are not listed then the delegates will be used.