### PR TITLE
Enforce stricter competition names - fixes #444

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -117,7 +117,7 @@ en:
         pending_avatar: "After uploading a new avatar, you will have to wait for the Board to approve it."
       competition:
         competition_id_to_clone: "Optional. Can save you some typing if you're running a similar competition to a past competition."
-        name: "The full name of the competition including the year at the end (e.g., European Rubik's Cube Championship 2006). Be sure to capitalize."
+        name: "The full name of the competition including the year at the end (e.g., Danish Open 2016). Be sure to capitalize. The name must contain only alphnumeric characters, dashes(-), ampersands(&), periods(.), colons(:), apostrophes('), and spaces( )."
         cellName: "A short name for displaying. If the name of the competition is already short, you can re-use the name (e.g., Europe 2006)."
         cityName: "Name of the city and state (if applicable) where the competition takes place. Do not include country (e.g., Paris OR San Francisco, California)."
         information: "Some information text about the competition (e.g., Euro 2006 is open to citizens of the European countries and Israel)."

--- a/WcaOnRails/db/migrate/20160531124049_update_competition_names.rb
+++ b/WcaOnRails/db/migrate/20160531124049_update_competition_names.rb
@@ -1,0 +1,31 @@
+class UpdateCompetitionNames < ActiveRecord::Migration
+  def up
+    execute "update Competitions set name = 'Clock N'' Other Stuff 2016', cellName = 'Clock N'' Other Stuff 2016' where id = 'ClockNOtherStuff2016';"
+    execute "update Competitions set name = 'Macau Rubik''s Open 2009', cellName = 'Macau Rubik''s Open 2009' where id = 'MacauOpen2009';"
+    execute "update Competitions set name = 'Moldavian Nationals - Winter 2016', cellName = 'Moldavian Nationals - Winter 2016' where id = 'MoldavianNationalsWinter2016';"
+    execute "update Competitions set name = 'Thakur Rubik''s Cube Championship 2014', cellName = 'Thakur Rubik''s Cube Championship 2014' where id = 'ThakurChampionship2014';"
+    execute "update Competitions set name = 'C3 Cube Open 2014', cellName = 'C3 Cube Open 2014' where id = 'C3Open2014';"
+    execute "update Competitions set name = 'Hari ng Norte King of the North 2015' where id = 'HariNgNorte2015';"
+    execute "update Competitions set name = 'HOOAH SMA 2015', cellName = 'HOOAH SMA 2015' where id = 'HOOAHSMA2015';"
+    execute "update Competitions set name = 'Reno Lake Tahoe Winter 2010 Cube Competition' where id = 'RenoWinter2010';"
+    execute "update Competitions set name = 'Rubik''s Cubed Baires 2.0 2011' where id = 'RubiksBaires2011';"
+    execute "update Competitions set name = 'Campeonato de Cubos Mágicos de São Carlos SP 2013' where id = 'SaoCarlos2013';"
+    execute "update Competitions set name = 'SESC Santos 2010', cellName = 'SESC Santos 2010' where id = 'SESCSantos2010';"
+    execute "update Competitions set name = 'SESC Santos 2011', cellName = 'SESC Santos 2011' where id = 'SESCSantos2011';"
+  end
+
+  def down
+    execute "update Competitions set name = 'Clock N’ Other Stuff 2016', cellName = 'Clock N’ Other Stuff 2016' where id = 'ClockNOtherStuff2016';"
+    execute "update Competitions set name = 'Macau Rubik´s Open 2009', cellName = 'Macau Rubik´s Open 2009' where id = 'MacauOpen2009';"
+    execute "update Competitions set name = 'Moldavian Nationals – Winter 2016', cellName = 'Moldavian Nationals – Winter 2016' where id = 'MoldavianNationalsWinter2016';"
+    execute "update Competitions set name = 'Thakur Rubik’s Cube Championship 2014', cellName = 'Thakur Rubik’s Cube Championship 2014' where id = 'ThakurChampionship2014';"
+    execute "update Competitions set name = 'C^3 Cube Open 2014', cellName = 'C^3 Cube Open 2014' where id = 'C3Open2014';"
+    execute "update Competitions set name = 'Hari ng Norte (King of the North) 2015' where id = 'HariNgNorte2015';"
+    execute "update Competitions set name = 'HOOAH! SMA 2015', cellName = 'HOOAH! SMA 2015' where id = 'HOOAHSMA2015';"
+    execute "update Competitions set name = 'Reno/Lake Tahoe Winter 2010 Cube Competition' where id = 'RenoWinter2010';"
+    execute "update Competitions set name = '(Rubik´s)^3 Baires 2.0 2011' where id = 'RubiksBaires2011';"
+    execute "update Competitions set name = 'Campeonato de Cubos Mágicos de São Carlos/SP 2013' where id = 'SaoCarlos2013';"
+    execute "update Competitions set name = 'SESC/Santos 2010', cellName = 'SESC/Santos 2010' where id = 'SESCSantos2010';"
+    execute "update Competitions set name = 'SESC/Santos 2011', cellName = 'SESC/Santos 2011' where id = 'SESCSantos2011';"
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -992,3 +992,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160520230353');
 INSERT INTO schema_migrations (version) VALUES ('20160517140653');
 
 INSERT INTO schema_migrations (version) VALUES ('20160528071910');
+
+INSERT INTO schema_migrations (version) VALUES ('20160531124049');

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -2,11 +2,24 @@ require 'rails_helper'
 
 RSpec.describe Competition do
   it "defines a valid competition" do
-    competition = FactoryGirl.build :competition, name: "Foo !Test- 2015"
+    competition = FactoryGirl.build :competition, name: "Foo: Test - 2015"
     expect(competition).to be_valid
     expect(competition.id).to eq "FooTest2015"
-    expect(competition.name).to eq "Foo !Test- 2015"
-    expect(competition.cellName).to eq "Foo !Test- 2015"
+    expect(competition.name).to eq "Foo: Test - 2015"
+    expect(competition.cellName).to eq "Foo: Test - 2015"
+  end
+
+  it "rejects invalid names" do
+    [
+      "foo (Test) - 2015",
+      "Poly^3 2016",
+      "HOOAH! SMA 2015",
+      "Campeonato de Cubos Mágicos de São Carlos/SP 2013",
+      "Moldavian Nationals – Winter 2016",
+      "PingSkills Cubing Classic, 2016",
+    ].each do |name|
+      expect(FactoryGirl.build(:competition, name: name)).to be_invalid
+    end
   end
 
   it "handles missing start/end_date" do
@@ -37,10 +50,10 @@ RSpec.describe Competition do
   end
 
   it "truncates name as necessary to produce id and cellName" do
-    competition = FactoryGirl.build :competition, name: "Alexander and the Terrible, Horrible, No Good 2015"
+    competition = FactoryGirl.build :competition, name: "Alexander and the Terrible Horrible No Good 2015"
     expect(competition).to be_valid
     expect(competition.id).to eq "AlexanderandtheTerribleHorri2015"
-    expect(competition.name).to eq "Alexander and the Terrible, Horrible, No Good 2015"
+    expect(competition.name).to eq "Alexander and the Terrible Horrible No Good 2015"
     expect(competition.cellName).to eq "Alexander and the Terrib... 2015"
   end
 
@@ -54,7 +67,7 @@ RSpec.describe Competition do
   it "requires that name end in a year" do
     competition = FactoryGirl.build :competition, name: "Name without year"
     expect(competition).to be_invalid
-    expect(competition.errors.messages[:name]).to eq ["must end with a year"]
+    expect(competition.errors.messages[:name]).to eq ["must end with a year and must contain only alphnumeric characters, dashes(-), ampersands(&), periods(.), colons(:), apostrophes('), and spaces( )"]
   end
 
   it "requires that cellName end in a year" do


### PR DESCRIPTION
Only allow alphanumeric characters, dash, ampersand, period,
colon, apostrophe, and space for name and cellName.

Update old invalid competition names so they are valid.