### PR TITLE
Improve instructions in the "approve a WCA ID claim" email - fixes #464

### DIFF
--- a/WcaOnRails/app/views/wca_id_claim_mailer/notify_delegate_of_wca_id_claim.html.erb
+++ b/WcaOnRails/app/views/wca_id_claim_mailer/notify_delegate_of_wca_id_claim.html.erb
@@ -5,5 +5,8 @@
 
 <p>
   @<%= @user_claiming_wca_id.delegate_to_handle_wca_id_claim.name %>: You can approve or reject this claim <%= link_to "here", edit_user_url(@user_claiming_wca_id.id, anchor: "wca_id") %>.
+  Note that any delegate can handle a WCA ID claim. If you feel another delegate should be handling this claim please forward this email to them.
+</p>
+<p>
   For a complete list of unconfirmed WCA ID claims see your <%= link_to "notifications", notifications_url %>.
 </p>


### PR DESCRIPTION
The email now mentions that any delegate can handle a WCA ID claim and
that they can forward the email to another delegate to handle.

![wca-id-claim-email](https://cloud.githubusercontent.com/assets/4403168/15744933/61aeebe0-2912-11e6-9562-c78326926b67.png)