### PR TITLE
Fixed bug where nag job didn't take into account unscheduled competitions.

### DIFF
--- a/WcaOnRails/app/jobs/submit_results_nag_job.rb
+++ b/WcaOnRails/app/jobs/submit_results_nag_job.rb
@@ -6,7 +6,7 @@ class SubmitResultsNagJob < ActiveJob::Base
   end
 
   def perform
-    Competition.where(results_posted_at: nil).select { |c| nag_needed(c) }.each do |competition|
+    Competition.where(showAtAll: true, results_posted_at: nil).select { |c| nag_needed(c) }.each do |competition|
       competition.update_attribute(:results_nag_sent_at, Time.now)
       CompetitionsMailer.submit_results_nag(competition).deliver_now
     end

--- a/WcaOnRails/spec/jobs/submit_results_nag_job_spec.rb
+++ b/WcaOnRails/spec/jobs/submit_results_nag_job_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 RSpec.describe SubmitResultsNagJob, type: :job do
   it "schedules results nag email" do
-    _recent_competition_missing_results = FactoryGirl.create :competition, starts: 3.days.ago
-    old_competition_missing_results = FactoryGirl.create :competition, starts: 3.weeks.ago
-    _older_competition_missing_results_but_already_nagged = FactoryGirl.create :competition, starts: 3.weeks.ago, results_nag_sent_at: 1.day.ago
-    older_competition_missing_results_nagged_a_long_time_ago = FactoryGirl.create :competition, starts: 3.weeks.ago, results_nag_sent_at: 8.days.ago
+    _unscheduled_competition = FactoryGirl.create :competition, starts: nil
+    _recent_competition_missing_results = FactoryGirl.create :competition, :visible, starts: 3.days.ago
+    old_competition_missing_results = FactoryGirl.create :competition, :visible, starts: 3.weeks.ago
+    _older_competition_missing_results_but_already_nagged = FactoryGirl.create :competition, :visible, starts: 3.weeks.ago, results_nag_sent_at: 1.day.ago
+    older_competition_missing_results_nagged_a_long_time_ago = FactoryGirl.create :competition, :visible, starts: 3.weeks.ago, results_nag_sent_at: 8.days.ago
 
     expect(CompetitionsMailer).to receive(:submit_results_nag).with(old_competition_missing_results).and_call_original
     expect(CompetitionsMailer).to receive(:submit_results_nag).with(older_competition_missing_results_nagged_a_long_time_ago).and_call_original


### PR DESCRIPTION
Whoops! Didn't think about this in #682. I'm going to merge this up immediately.