### PR TITLE
Fix searching by name on the persons index

### DIFF
--- a/WcaOnRails/app/controllers/persons_controller.rb
+++ b/WcaOnRails/app/controllers/persons_controller.rb
@@ -10,7 +10,9 @@ class PersonsController < ApplicationController
           persons = persons.where("countryId = :region OR continentId = :region", region: params[:region])
         end
         if params[:search].present?
-          persons = persons.where("rails_persons.name LIKE :input OR wca_id LIKE :input", input: "%#{params[:search]}%")
+          params[:search].split.each do |part|
+            persons = persons.where("rails_persons.name LIKE :part OR wca_id LIKE :part", part: "%#{part}%")
+          end
         end
         persons = persons.order(:name, :countryId)
 

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -517,8 +517,6 @@ class User < ActiveRecord::Base
   end
 
   def self.search(query, params: {})
-    sql_query = "%#{query}%"
-
     users = Person
     unless ActiveRecord::Type::Boolean.new.type_cast_from_database(params[:persons_table])
       users = User.where.not(confirmed_at: nil).not_dummy_account
@@ -532,7 +530,11 @@ class User < ActiveRecord::Base
       end
     end
 
-    users.where("name LIKE :sql_query OR wca_id LIKE :sql_query", sql_query: sql_query).order(:name)
+    query.split.each do |part|
+      users = users.where("name LIKE :part OR wca_id LIKE :part", part: "%#{part}%")
+    end
+
+    users.order(:name)
   end
 
   attr_accessor :doorkeeper_token

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -392,7 +392,7 @@ en:
     connect_wca_id: "Connect your WCA ID to your account!"
   persons:
     index:
-      name_or_wca_id: "Name or WCA ID"
+      name_or_wca_id: "Name parts or WCA ID"
       name: "Name"
       country: "Country"
       podiums: "Podiums"

--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -139,7 +139,7 @@ describe Api::V0::ApiController do
   describe 'GET #omni_search' do
     let!(:comp) { FactoryGirl.create(:competition, :confirmed, :visible, name: "jeremy Jfly's Competition 2015") }
     let!(:post) { FactoryGirl.create(:post, title: "jeremy post title", body: "post body") }
-    let!(:user) { FactoryGirl.create(:user_with_wca_id, name: "Jeremy") }
+    let!(:user) { FactoryGirl.create(:user_with_wca_id, name: "Jeremy Fleischman") }
 
     it 'requires query parameter' do
       get :omni_search
@@ -157,6 +157,14 @@ describe Api::V0::ApiController do
       expect(json["result"].count { |r| r["class"] == "post" }).to eq 0
       expect(json["result"].count { |r| r["class"] == "user" }).to eq 0
       expect(json["result"].count { |r| r["class"] == "person" }).to eq 1
+    end
+
+    it "works well when parts of the name are given" do
+      get :omni_search, q: "Flei Jer"
+      expect(response.status).to eq 200
+      json = JSON.parse(response.body)
+      expect(json["result"].length).to eq 1
+      expect(json["result"][0]["name"]).to include "Jeremy Fleischman"
     end
   end
 

--- a/WcaOnRails/spec/controllers/persons_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/persons_controller_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe PersonsController, type: :controller do
         expect(json['total']).to eq 2
         expect(json['rows'].count).to eq 2
       end
+
+      it "works well when parts of the name are given" do
+        xhr :get, :index, search: "Law Jenn"
+        json = JSON.parse(response.body)
+        expect(json['total']).to eq 1
+        expect(json['rows'].count).to eq 1
+        expect(json['rows'][0]['name']).to include "Jennifer Lawrence"
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #690.
About [this](https://github.com/cubing/worldcubeassociation.org/issues/690#issuecomment-222774731) comment: the api searching isn't related to this on the persons index page because bootstrap-table requires normalized format, anyway I can apply the same solution [here](https://github.com/cubing/worldcubeassociation.org/blob/master/WcaOnRails/app/models/user.rb#L535) if you consider it to be right.