### PR TITLE
Very long venue names don't appear on a new line anymore when listing competitions

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -232,19 +232,19 @@ $venue-map-wrapper-height: 400px;
       top: -1px;
       margin-right: 5px;
     }
-    
+
     .location {
       display: inline;
     }
 
     .venue-link {
       display: inline;
-      
+
       p {
         display: inline;
       }
     }
-    
+
     @media (min-width: $screen-sm) {
       .competition-link {
         display: inline-block;

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -232,7 +232,19 @@ $venue-map-wrapper-height: 400px;
       top: -1px;
       margin-right: 5px;
     }
+    
+    .location {
+      display: inline;
+    }
 
+    .venue-link {
+      display: inline;
+      
+      p {
+        display: inline;
+      }
+    }
+    
     @media (min-width: $screen-sm) {
       .competition-link {
         display: inline-block;
@@ -244,13 +256,9 @@ $venue-map-wrapper-height: 400px;
         text-overflow: ellipsis;
         vertical-align: bottom;
       }
-      .location {
-        display: inline;
-        margin-left: 20px;
-      }
 
-      .venue-link {
-        display: inline;
+      .location {
+        margin-left: 20px;
       }
     }
 
@@ -277,7 +285,6 @@ $venue-map-wrapper-height: 400px;
       }
 
       .venue-link {
-        display: inline-block;
         margin-left: 20px;
       }
     }


### PR DESCRIPTION
fixes #503.

Screenshot: 
![selection_080](https://cloud.githubusercontent.com/assets/881394/15800834/a1f1ccf4-2a39-11e6-800b-8dbea8413d98.png)
