### PR TITLE
Remove "Delegate report for" from email notification.

### DIFF
--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -26,7 +26,7 @@ class CompetitionsMailer < ApplicationMailer
     mail(
       to: "delegates@worldcubeassociation.org",
       cc: competition.delegates.pluck(:email),
-      subject: "[wca-report] [#{competition.continent.name}] Delegate report for #{competition.name}",
+      subject: "[wca-report] [#{competition.continent.name}] #{competition.name}",
     )
   end
 

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
     let(:mail) { CompetitionsMailer.notify_of_delegate_report_submission(competition) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq "[wca-report] [Oceania] Delegate report for Comp of the Future 2016"
+      expect(mail.subject).to eq "[wca-report] [Oceania] Comp of the Future 2016"
       expect(mail.to).to eq ["delegates@worldcubeassociation.org"]
       expect(mail.cc).to match_array competition.delegates.pluck(:email)
       expect(mail.from).to eq ["notifications@worldcubeassociation.org"]


### PR DESCRIPTION
Tim Reynolds suggested that it was redundant, given that we already have the [wca-report]. Also, the title was too long to be shown correctly/relevant in phone mail apps.