### PR TITLE
Fix images styling on the delegate report page

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/application.css.scss
+++ b/WcaOnRails/app/assets/stylesheets/application.css.scss
@@ -49,3 +49,4 @@
 @import "teams";
 @import "persons";
 @import "search_results";
+@import "delegate_reports";

--- a/WcaOnRails/app/assets/stylesheets/delegate_reports.scss
+++ b/WcaOnRails/app/assets/stylesheets/delegate_reports.scss
@@ -1,0 +1,7 @@
+.delegate-report {
+  img {
+    display: block;
+    max-width: 100%;
+    max-height: 300px;
+  }
+}

--- a/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
@@ -1,70 +1,72 @@
 <% competition = delegate_report.competition %>
 
-<div>
-  <strong>Date</strong>
-  <%= wca_date_range(competition.start_date, competition.end_date) %>
-  <% if delegate_report.schedule_url.present? %>
-    (<%= link_to "Schedule", delegate_report.schedule_url %>)
-  <% else %>
-    (Schedule missing)
+<div class="delegate-report">
+  <div>
+    <strong>Date</strong>
+    <%= wca_date_range(competition.start_date, competition.end_date) %>
+    <% if delegate_report.schedule_url.present? %>
+      (<%= link_to "Schedule", delegate_report.schedule_url %>)
+    <% else %>
+      (Schedule missing)
+    <% end %>
+  </div>
+
+  <div>
+    <strong>Location</strong>
+    <%= competition.cityName %>, <%= competition.country_name %>
+    <%= link_to_google_maps_place competition.venueAddress, competition.latitude_degrees, competition.longitude_degrees %>
+  </div>
+
+  <div>
+    <strong>Competitors</strong>
+
+    <% if competition.results_posted? %>
+      <%= competition.competitors.count %>
+    <% else %>
+      Unknown, results are not posted yet.
+    <% end %>
+  </div>
+
+  <div>
+    <strong>Equipment</strong>
+    <%=md delegate_report.equipment %>
+  </div>
+
+  <div>
+    <strong>Delegates</strong>
+    <%= competition.delegates.pluck(:name).to_sentence %>
+  </div>
+  <% if competition.organizers.length > 0 %>
+    <div>
+      <strong>Organisers</strong>
+      <%= competition.organizers.pluck(:name).to_sentence %>
+    </div>
+  <% end %>
+
+  <div>
+    <strong>Venue</strong>
+    <%=md delegate_report.venue %>
+  </div>
+
+  <div>
+    <strong>Organisation</strong>
+    <%=md delegate_report.organisation %>
+  </div>
+
+  <div>
+    <strong>Incidents</strong>
+    <%=md delegate_report.incidents %>
+  </div>
+
+  <div>
+    <strong>Remarks:</strong>
+    <%=md delegate_report.remarks %>
+  </div>
+
+  <% if delegate_report.posted_by_user %>
+    <br>
+    <div>
+      Report submitted by <%= delegate_report.posted_by_user.name %>
+    </div>
   <% end %>
 </div>
-
-<div>
-  <strong>Location</strong>
-  <%= competition.cityName %>, <%= competition.country_name %>
-  <%= link_to_google_maps_place competition.venueAddress, competition.latitude_degrees, competition.longitude_degrees %>
-</div>
-
-<div>
-  <strong>Competitors</strong>
-
-  <% if competition.results_posted? %>
-    <%= competition.competitors.count %>
-  <% else %>
-    Unknown, results are not posted yet.
-  <% end %>
-</div>
-
-<div>
-  <strong>Equipment</strong>
-  <%=md delegate_report.equipment %>
-</div>
-
-<div>
-  <strong>Delegates</strong>
-  <%= competition.delegates.pluck(:name).to_sentence %>
-</div>
-<% if competition.organizers.length > 0 %>
-  <div>
-    <strong>Organisers</strong>
-    <%= competition.organizers.pluck(:name).to_sentence %>
-  </div>
-<% end %>
-
-<div>
-  <strong>Venue</strong>
-  <%=md delegate_report.venue %>
-</div>
-
-<div>
-  <strong>Organisation</strong>
-  <%=md delegate_report.organisation %>
-</div>
-
-<div>
-  <strong>Incidents</strong>
-  <%=md delegate_report.incidents %>
-</div>
-
-<div>
-  <strong>Remarks:</strong>
-  <%=md delegate_report.remarks %>
-</div>
-
-<% if delegate_report.posted_by_user %>
-  <br>
-  <div>
-    Report submitted by <%= delegate_report.posted_by_user.name %>
-  </div>
-<% end %>

--- a/WcaOnRails/app/views/delegate_reports/edit.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/edit.html.erb
@@ -3,7 +3,8 @@
 
 <%= render layout: 'nav' do %>
   <h2>Editing Delegate Report for <%= @competition.name%></h2>
-  <%= simple_form_for(@delegate_report, url: delegate_report_path(@competition.id)) do |f| %>
+  <%= simple_form_for @delegate_report, url: delegate_report_path(@competition.id),
+                                        html: { class: "delegate-report" } do |f| %>
     <%= render 'shared/error_messages', object: @delegate_report %>
 
     <%= f.hidden_field :updated_at %>


### PR DESCRIPTION
Fixes #712.
Images are no wider than the whole page and no higher than 300px (the proportions are preserved of course). The result is pretty good I think =)