### PR TITLE
Make Regulations and Guidelines omnisearchable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,13 @@ cache:
 rvm:
   - 2.3.1
 env:
-  - DATABASE_URL=mysql2://root@127.0.0.1:3306/wca_test
+  global:
+    - DATABASE_URL=mysql2://root@127.0.0.1:3306/wca_test
+    - PATH=$HOME/.local/bin:$PATH
 before_install:
+  - pip install --user wrc
+  - git clone --depth=1 https://github.com/cubing/wca-regulations.git
+  - wrc wca-regulations -o WcaOnRails/app/views/regulations --target=json
   # Travis has an old install of PhantomJS without .bind() support, here we upgrade to
   # version 2.0.0
   # From https://mediocre.com/forum/topics/phantomjs-2-and-travis-ci-we-beat-our-heads-against-a-wall-so-you-dont-have-to

--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -117,6 +117,10 @@ wca.renderMarkdownRequest = function(markdownContent) {
   });
 };
 
+wca.stripHtmlTags = function(text) {
+  return $("<div/>").html(text).text();
+};
+
 wca.datetimepicker = function(){
   // Copied (and modified by jfly) from
   // https://github.com/zpaulovics/datetimepicker-rails

--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -76,11 +76,15 @@ class Api::V0::ApiController < ApplicationController
     search(User)
   end
 
+  def regulations_search
+    search(Regulation)
+  end
+
   def omni_search
     # We intentionally exclude Post, as our autocomplete ui isn't very useful with
     # them yet.
     params[:persons_table] = true
-    search(Competition, User)
+    search(Competition, User, Regulation)
   end
 
   def show_user(user)

--- a/WcaOnRails/app/controllers/search_results_controller.rb
+++ b/WcaOnRails/app/controllers/search_results_controller.rb
@@ -8,6 +8,7 @@ class SearchResultsController < ApplicationController
       @competitions = Competition.search(@omni_query).page(params[:competitions_page]).per(SEARCH_RESULT_LIMIT)
       @persons = User.search(@omni_query, params: { persons_table: true }).page(params[:people_page]).per(SEARCH_RESULT_LIMIT)
       @posts = Post.search(@omni_query).page(params[:posts_page]).per(SEARCH_RESULT_LIMIT)
+      @regulations = Kaminari.paginate_array(Regulation.search(@omni_query)).page(params[:regulations_page]).per(SEARCH_RESULT_LIMIT)
     end
   end
 end

--- a/WcaOnRails/app/models/regulation.rb
+++ b/WcaOnRails/app/models/regulation.rb
@@ -1,0 +1,21 @@
+class Regulation < SimpleDelegator
+  begin
+    REGULATIONS = JSON.parse(File.read(Rails.root.to_s + "/app/views/regulations/wca-regulations.json")).freeze
+  rescue
+    REGULATIONS = [].freeze
+  end
+
+  def limit(number)
+    first(number)
+  end
+
+  def self.search(query, *)
+    matched_regulations = REGULATIONS.dup
+    query.downcase.split.each do |part|
+      matched_regulations.select! do |reg|
+        %w(text id).any? { |field| reg[field].downcase.include?(part) }
+      end
+    end
+    Regulation.new(matched_regulations)
+  end
+end

--- a/WcaOnRails/app/models/regulation.rb
+++ b/WcaOnRails/app/models/regulation.rb
@@ -1,9 +1,7 @@
+# frozen_string_literal: true
+
 class Regulation < SimpleDelegator
-  begin
-    REGULATIONS = JSON.parse(File.read(Rails.root.to_s + "/app/views/regulations/wca-regulations.json")).freeze
-  rescue
-    REGULATIONS = [].freeze
-  end
+  REGULATIONS = JSON.parse(File.read(Rails.root.to_s + "/app/views/regulations/wca-regulations.json")).freeze
 
   def limit(number)
     first(number)
@@ -13,7 +11,7 @@ class Regulation < SimpleDelegator
     matched_regulations = REGULATIONS.dup
     query.downcase.split.each do |part|
       matched_regulations.select! do |reg|
-        %w(text id).any? { |field| reg[field].downcase.include?(part) }
+        %w(content_html id).any? { |field| reg[field].downcase.include?(part) }
       end
     end
     Regulation.new(matched_regulations)

--- a/WcaOnRails/app/views/search_results/index.html.erb
+++ b/WcaOnRails/app/views/search_results/index.html.erb
@@ -77,7 +77,7 @@
       <%= paginate @posts, param_name: :posts_page, params: { anchor: "posts" } %>
     <% end %>
 
-    <% if !@regulations.empty? %>
+    <% if @regulations.present? %>
       <h2><%= anchorable "Regulations and Guidelines" %></h2>
       <% @regulations.each do |reg| %>
         <div>
@@ -85,7 +85,7 @@
             <h4><%= wca_highlight(reg["id"], query_parts) %></h4>
           <% end %>
           <blockquote>
-            <%= wca_highlight(reg["text"], query_parts) %>
+            <%= wca_highlight(reg["content_html"], query_parts) %>
           </blockquote>
         </div>
       <% end %>
@@ -102,7 +102,7 @@
       <h2>No posts found for <%= wca_highlight(@omni_query, @omni_query) %></h2>
     <% end %>
     <% if @regulations.empty? %>
-      <h2>No Regulation or Guideline found for <%= wca_highlight(@omni_query, @omni_query) %></h2>
+      <h2>No Regulations or Guidelines found for <%= wca_highlight(@omni_query, @omni_query) %></h2>
     <% end %>
   <% end %>
 </div>

--- a/WcaOnRails/app/views/search_results/index.html.erb
+++ b/WcaOnRails/app/views/search_results/index.html.erb
@@ -77,6 +77,21 @@
       <%= paginate @posts, param_name: :posts_page, params: { anchor: "posts" } %>
     <% end %>
 
+    <% if !@regulations.empty? %>
+      <h2><%= anchorable "Regulations and Guidelines" %></h2>
+      <% @regulations.each do |reg| %>
+        <div>
+          <%= link_to reg["url"] do %>
+            <h4><%= wca_highlight(reg["id"], query_parts) %></h4>
+          <% end %>
+          <blockquote>
+            <%= wca_highlight(reg["text"], query_parts) %>
+          </blockquote>
+        </div>
+      <% end %>
+      <%= paginate @regulations, param_name: :regulations_page, params: { anchor: "regulations-and-guidelines" } %>
+    <% end %>
+
     <% if @competitions.empty? %>
       <h2>No competitions found for <%= wca_highlight(@omni_query, @omni_query) %></h2>
     <% end %>
@@ -85,6 +100,9 @@
     <% end %>
     <% if @posts.empty? %>
       <h2>No posts found for <%= wca_highlight(@omni_query, @omni_query) %></h2>
+    <% end %>
+    <% if @regulations.empty? %>
+      <h2>No Regulation or Guideline found for <%= wca_highlight(@omni_query, @omni_query) %></h2>
     <% end %>
   <% end %>
 </div>

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -121,6 +121,7 @@ Rails.application.routes.draw do
       get '/search/posts' => 'api#posts_search'
       get '/search/competitions' => 'api#competitions_search'
       get '/search/users' => 'api#users_search'
+      get '/search/regulations' => 'api#regulations_search'
       get '/users/:id' => 'api#show_user_by_id', constraints: { id: /\d+/ }
       get '/users/:wca_id' => 'api#show_user_by_wca_id'
       get '/competitions' => 'api#competitions'

--- a/WcaOnRails/vendor/assets/javascripts/jquery.wca-autocomplete.js
+++ b/WcaOnRails/vendor/assets/javascripts/jquery.wca-autocomplete.js
@@ -15,10 +15,12 @@
       var posts_search = $(that).hasClass("wca-autocomplete-posts_search");
 
       var delimiter = ',';
-      var searchFields = [];
-      searchFields = searchFields.concat([ 'wca_id', 'name' ]); // user search fields
-      searchFields = searchFields.concat([ 'id', 'name', 'cellName', 'cityName', 'countryId' ]); // competition search fields
-      searchFields = searchFields.concat([ 'title', 'body' ]); // post search fields
+      var searchFields = [
+        'wca_id', 'name', // user search fields
+        'id', 'cellName', 'cityName', 'countryId', // competition search fields ('name' already added)
+        'title', 'body', // post search fields
+        'text', // regulation search fields ('id' already added)
+      ];
 
       var url;
       var defaultSearchData = {};
@@ -70,6 +72,14 @@
           post: function(post) {
             var $div = $('<div class="wca-autocomplete-post"><span class="title"></span></div>');
             $div.find(".title").text(post.title);
+            return $div[0].outerHTML;
+          },
+
+          regulation: function(regulation) {
+            var $div = $('<div class="wca-autocomplete-regulation"><span class="id"></span>: <span class="text"></span></div>');
+            $div.find(".id").text(regulation.id);
+            // NOTE: the regulation 'text' field may contain links (references to other regulations/guidelines)
+            $div.find(".text").html(regulation.text);
             return $div[0].outerHTML;
           },
 

--- a/WcaOnRails/vendor/assets/javascripts/jquery.wca-autocomplete.js
+++ b/WcaOnRails/vendor/assets/javascripts/jquery.wca-autocomplete.js
@@ -15,12 +15,12 @@
       var posts_search = $(that).hasClass("wca-autocomplete-posts_search");
 
       var delimiter = ',';
-      var searchFields = [
+      var searchFields = _.uniq([
         'wca_id', 'name', // user search fields
-        'id', 'cellName', 'cityName', 'countryId', // competition search fields ('name' already added)
+        'id', 'cellName', 'cityName', 'countryId', 'name', // competition search fields
         'title', 'body', // post search fields
-        'text', // regulation search fields ('id' already added)
-      ];
+        'id', 'content_html', // regulation search fields
+      ]);
 
       var url;
       var defaultSearchData = {};
@@ -76,10 +76,9 @@
           },
 
           regulation: function(regulation) {
-            var $div = $('<div class="wca-autocomplete-regulation"><span class="id"></span>: <span class="text"></span></div>');
+            var $div = $('<div class="wca-autocomplete-regulation"><span class="id"></span>: <span class="content_html"></span></div>');
             $div.find(".id").text(regulation.id);
-            // NOTE: the regulation 'text' field may contain links (references to other regulations/guidelines)
-            $div.find(".text").html(regulation.text);
+            $div.find(".content_html").text(wca.stripHtmlTags(regulation.content_html))
             return $div[0].outerHTML;
           },
 


### PR DESCRIPTION
This is kind of a wip/technical feedback request.

The @cubing/wrc-team needed a tool to perform some basic checks on the Regulations and its translations (easy to use through Travis), and at some point in the (hopefully) near futur, Jeremy would like to clean up a bit the whole Regulations building process. So I created a [tool](https://github.com/cubing/wca-regulations-compiler) to do that. And the cool thing is that, additionally to the html/pdf backends, I could easily add a backend to feed omnisearch.
The easier I could think of was json, so I went with that (for reference each json entry looks like [this](https://github.com/viroulep/wca-regulations-compiler/blob/json/wrc/codegen/cgjson.py#L27-L29)), but feel free to suggest something better that you may have in mind.

The feature assumes there is a `wca-regulations.json` somewhere, load it (hopefully only once), and make it searchable through the API/omnisearch.

In the end I think the file should be built with the regulations and have its place in the `app/views/regulations` folder, but for now and for the purpose of the demonstration I just added it to the `search_results` folder.

The result looks like this in the autocomplete field:
![regsearch](https://cloud.githubusercontent.com/assets/1007485/16063599/abbb5426-329a-11e6-8e19-936d4e445bc5.png)

And like this in the results page:
![regresults](https://cloud.githubusercontent.com/assets/1007485/16063622/ca1ccf08-329a-11e6-8aba-00ef98bdc2b6.png)


I would welcome reviews on the feature (assuming the file is in some nice place), and also your opinion on if it's the most convenient way to make the Regulations searchable (and if not, what would it be).


