### PR TITLE
Use gsub(/ /, '$20') instead of URI.encode.

### DIFF
--- a/WcaOnRails/app/models/delegate_report.rb
+++ b/WcaOnRails/app/models/delegate_report.rb
@@ -8,7 +8,7 @@ class DelegateReport < ActiveRecord::Base
 
   before_create :set_discussion_url
   def set_discussion_url
-    self.discussion_url = "https://groups.google.com/forum/#!topicsearchin/wca-delegates/" + URI.encode(competition.name)
+    self.discussion_url = "https://groups.google.com/forum/#!topicsearchin/wca-delegates/" + competition.name.gsub(/ /,'$20')
   end
 
   before_create :equipment_default


### PR DESCRIPTION
Fixes #726