### PR TITLE
Use joins for psych sheet events to improve performance - Fixes #731

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -38,30 +38,7 @@ class RegistrationsController < ApplicationController
     @competition = competition_from_params
     @event = Event.find(params[:event_id])
     @preferred_format = @event.preferred_formats.first
-
-    @registrations = @competition.registrations.
-                                  accepted.
-                                  joins(:registration_events).
-                                  where("registration_events.event_id=?", @event.id).
-                                  sort_by do |r|
-                                    has_competed = !!r.world_rank(@event, @preferred_format.sort_by)
-                                    [ has_competed ? 0 : 1, r.world_rank(@event, @preferred_format.sort_by) || Float::INFINITY, r.world_rank(@event, @preferred_format.sort_by_second) || Float::INFINITY, r.name ]
-                                  end
-
-    @registrations.each_with_index do |registration, i|
-      prev_registration = i > 0 ? @registrations[i - 1] : nil
-      registration.tied_previous = false
-      if prev_registration
-        registration.tied_previous = registration.world_rank(@event, @preferred_format.sort_by) == prev_registration.world_rank(@event, @preferred_format.sort_by)
-      end
-      if registration.tied_previous
-        registration.pos = prev_registration.pos
-      else
-        registration.pos = i + 1
-      end
-      has_competed = !!registration.world_rank(@event, @preferred_format.sort_by)
-      registration.pos = nil unless has_competed
-    end
+    @registrations = @competition.psych_sheet_event(@event)
   end
 
   def index

--- a/WcaOnRails/app/views/registrations/psych_sheet_event.html.erb
+++ b/WcaOnRails/app/views/registrations/psych_sheet_event.html.erb
@@ -30,19 +30,19 @@
           <td class="pos <%= registration.tied_previous ? "tied-previous" : "" %>">
             <%= registration.pos %>
           </td>
-          <td class="name"><%= registration.name %></td>
+          <td class="name"><%= registration.select_name %></td>
           <td class="wca-id">
-            <% if registration.wca_id.present? %>
-              <%= render "shared/wca_id", wca_id: registration.wca_id %>
+            <% if registration.select_wca_id %>
+              <%= render "shared/wca_id", wca_id: registration.select_wca_id %>
             <% end %>
           </td>
-          <td class="country"><%= registration.countryId %></td>
+          <td class="country"><%= registration.select_country %></td>
 
-          <td class="average"><%= registration.best_solve(@event, :average).clock_format %></td>
-          <td class="world-rank-average"><%= registration.world_rank(@event, :average) %></td>
+          <td class="average"><%= SolveTime.new(@event.id, :average, registration.average_best).clock_format %></td>
+          <td class="world-rank-average"><%= registration.average_rank %></td>
 
-          <td class="single"><%= registration.best_solve(@event, :single).clock_format %></td>
-          <td class="world-rank-single"><%= registration.world_rank(@event, :single) %></td>
+          <td class="single"><%= SolveTime.new(@event.id, :single, registration.single_best).clock_format %></td>
+          <td class="world-rank-single"><%= registration.single_rank %></td>
 
           <!-- Extra column for .table-greedy-last-column -->
           <td></td>

--- a/WcaOnRails/spec/controllers/persons_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/persons_controller_spec.rb
@@ -13,11 +13,6 @@ RSpec.describe PersonsController, type: :controller do
       let!(:competition) { FactoryGirl.create(:competition) }
       let!(:result) { FactoryGirl.create(:result, pos: 1, roundId: "f", competitionId: competition.id, person: person1) }
 
-      before do
-        # Filled Countries table is necessary here.
-        load "#{Rails.root}/db/seeds/countries.seeds.rb"
-      end
-
       it "responds with correct JSON when region and search are specified" do
         xhr :get, :index, search: "Jennifer", region: "USA"
         json = JSON.parse(response.body)

--- a/WcaOnRails/spec/support/database_cleaner.rb
+++ b/WcaOnRails/spec/support/database_cleaner.rb
@@ -1,6 +1,11 @@
 RSpec.configure do |config|
+  reference_tables_to_keep = %w(Countries Continents Events Rounds Formats teams)
   config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.clean_with(:truncation, except: reference_tables_to_keep)
+    reference_tables_to_keep.each do |table|
+      ActiveRecord::Base.connection.execute("TRUNCATE #{table};")
+      load "#{Rails.root}/db/seeds/#{table.underscore}.seeds.rb"
+    end
   end
 
   config.before(:each) do
@@ -8,15 +13,11 @@ RSpec.configure do |config|
   end
 
   config.before(:each, js: true) do
-    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.strategy = :truncation, {except: reference_tables_to_keep}
   end
 
   config.before(:each) do
     DatabaseCleaner.start
-    FactoryGirl.create(:team, friendly_id: 'software', name: 'Software Team', description: 'Does software')
-    FactoryGirl.create(:team, friendly_id: 'results', name: 'Results Team', description: 'Posts results')
-    FactoryGirl.create(:team, friendly_id: 'wrc', name: 'WRC Team', description: 'Regulations')
-    FactoryGirl.create(:team, friendly_id: 'wdc', name: 'WDC Team', description: 'Disciplinary Committee')
   end
 
   config.after(:each) do

--- a/WcaOnRails/spec/views/registrations/psych_sheet_event.html.erb_spec.rb
+++ b/WcaOnRails/spec/views/registrations/psych_sheet_event.html.erb_spec.rb
@@ -4,10 +4,12 @@ RSpec.describe "registrations/psych_sheet_event" do
   it "works" do
     competition = FactoryGirl.create(:competition, :registration_open)
     event = Event.find("333")
+    user1 = FactoryGirl.create(:user, :wca_id, name: "Andrew Apple")
+    user2 = FactoryGirl.create(:user, :wca_id, name: "Bill Banana")
 
     registrations = []
 
-    registrations << FactoryGirl.create(:registration, competition: competition)
+    registrations << FactoryGirl.create(:registration, :accepted, user: user1, competition: competition)
     RanksAverage.create!(
       personId: registrations.last.personId,
       eventId: "333",
@@ -25,13 +27,30 @@ RSpec.describe "registrations/psych_sheet_event" do
       countryRank: 1,
     )
 
-    # Someone who has never competed before.
-    registrations << FactoryGirl.create(:registration, user: FactoryGirl.create(:user), competition: competition)
+    registrations << FactoryGirl.create(:registration, :accepted, user: user2, competition: competition)
+    RanksAverage.create!(
+      personId: registrations.last.personId,
+      eventId: "333",
+      best: "4242",
+      worldRank: 10,
+      continentRank: 10,
+      countryRank: 10,
+    )
+    RanksSingle.create!(
+      personId: registrations.last.personId,
+      eventId: "333",
+      best: "3334",
+      worldRank: 23,
+      continentRank: 23,
+      countryRank: 23,
+    )
 
-    # Someone who has not competed in 333 before.
-    registrations << FactoryGirl.create(:registration, competition: competition)
-    registrations.last.tied_previous = true
+    # Two users who have never competed before.
+    2.times do
+      registrations << FactoryGirl.create(:registration, :accepted, user: FactoryGirl.create(:user), competition: competition)
+    end
 
+    registrations = competition.psych_sheet_event(event)
     assign(:competition, competition)
     assign(:event, event)
     assign(:preferred_format, event.preferred_formats.first)
@@ -39,8 +58,9 @@ RSpec.describe "registrations/psych_sheet_event" do
 
     render
     expect(rendered).to have_css(".wca-results tbody tr:nth-child(1) .single", text: /\A\s*20.00\s*\z/)
-    expect(rendered).to have_css(".wca-results tbody tr:nth-child(2) .single", text: /\A\s*\z/)
+    expect(rendered).to have_css(".wca-results tbody tr:nth-child(2) .single", text: /\A\s*33.34\s*\z/)
+    expect(rendered).to have_css(".wca-results tbody tr:nth-child(2) td.pos.tied-previous", text: 1)
     expect(rendered).to have_css(".wca-results tbody tr:nth-child(3) .single", text: /\A\s*\z/)
-    expect(rendered).to have_css(".wca-results tbody tr:nth-child(3) td.pos.tied-previous")
+    expect(rendered).to have_css(".wca-results tbody tr:nth-child(4) .single", text: /\A\s*\z/)
   end
 end


### PR DESCRIPTION
I used joins to improve the performance in the controller. This seems much, much quicker now. It does rely on user_id being filled out in Preregs but now that all the old competitions have passed I think this is OK.

I also pulled out the looping from the controller as it needs to be done again in the view. I'm not sure if this is the best thing to do from a "rails" perspective.

Also some tests are now failing when using assigns:
`      get :psych_sheet_event, competition_id: competition.id, event_id: "444"
      registrations = assigns(:registrations)`

This seems to return nil. I'd love some help on how to test this.

Let me know your thoughts on the way I went about this and if it's worth finalising and promoting.