### PR TITLE
Fix error messages when confirming a competition - Fixes #243

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -86,14 +86,14 @@ class Competition < ActiveRecord::Base
   validate :must_have_at_least_one_event, if: :confirmed_or_visible?
   def must_have_at_least_one_event
     if events.length == 0
-      errors.add(:eventSpecs, "Competition must have at least one event")
+      errors.add(:eventSpecs, "must contain at least one event for this competition")
     end
   end
 
   validate :must_have_at_least_one_delegate, if: :confirmed_or_visible?
   def must_have_at_least_one_delegate
     if delegate_ids.length == 0
-      errors.add(:delegate_ids, "Competition must have at least one WCA delegate")
+      errors.add(:delegate_ids, "must contain at least one WCA delegate")
     end
   end
 
@@ -439,11 +439,11 @@ class Competition < ActiveRecord::Base
     valid_dates = true
     unless Date.valid_date? year, month, day
       valid_dates = false
-      errors.add(:start_date, "Invalid start date.")
+      errors.add(:start_date, "is invalid")
     end
     unless Date.valid_date? @endYear, endMonth, endDay
       valid_dates = false
-      errors.add(:end_date, "Invalid end date.")
+      errors.add(:end_date, "is invalid")
     end
     unless valid_dates
       # There's no use continuing validation at this point.


### PR DESCRIPTION
I've updated the error messages of eventSpecs, WCA delegate(s), Start date, and End date so that they read better. Here's what they now look like:

![error-message](https://cloud.githubusercontent.com/assets/4403168/16385338/be89283c-3ccf-11e6-9af6-99edd358a886.png)

Let me know what you think.