### PR TITLE
Ensure uniqueness of person's wca_id from factory

### DIFF
--- a/WcaOnRails/spec/factories/persons.rb
+++ b/WcaOnRails/spec/factories/persons.rb
@@ -1,7 +1,10 @@
 FactoryGirl.define do
   factory :person do
-    sequence :wca_id do |n|
-      "%04iFLEI%02i" % [2003 + (n / 100), n % 100]
+    wca_id do
+      mid = ('A'..'Z').to_a.sample(4).join
+      "2016#{mid}01".tap do |id|
+        id.next! while Person.exists?(wca_id: id)
+      end
     end
     subId 1
     name { Faker::Name.name }


### PR DESCRIPTION
I've no idea why haven't I done this so far.
I was always annoyed by the fact that crating person (and others using it) with FactoryGirl in console fails:
```ruby
2.3.0 :001 > FactoryGirl.create :person
   (0.2ms)  BEGIN
  SQL (1.9ms)  INSERT INTO `rails_persons` (`wca_id`, `name`, `countryId`, `gender`, `year`, `month`, `day`) VALUES ('2003FLEI01', 'Marion Gleichner DVM', 'Afghanistan', 'm', 1966, 4, 4)
Mysql2::Error: Duplicate entry '2003FLEI01-1' for key 'index_Persons_on_id_and_subId': INSERT INTO `rails_persons` (`wca_id`, `name`, `countryId`, `gender`, `year`, `month`, `day`) VALUES ('2003FLEI01', 'Marion Gleichner DVM', 'Afghanistan', 'm', 1966, 4, 4)
   (33.7ms)  ROLLBACK
ActiveRecord::RecordNotUnique: Mysql2::Error: Duplicate entry '2003FLEI01-1' for key 'index_Persons_on_id_and_subId': INSERT INTO `rails_persons` (`wca_id`, `name`, `countryId`, `gender`, `year`, `month`, `day`) VALUES ('2003FLEI01', 'Marion Gleichner DVM', 'Afghanistan', 'm', 1966, 4, 4)
```
We use FactoryGirl in seeds so I guess the track of sequence is lost somehow.
This makes the ids unique *all of the time* and also randomizes them a bit more.