### PR TITLE
Doesn't use escaped HTML as the location query

### DIFF
--- a/WcaOnRails/app/helpers/markdown_helper.rb
+++ b/WcaOnRails/app/helpers/markdown_helper.rb
@@ -11,8 +11,8 @@ module MarkdownHelper
     def postprocess(full_document)
       # Support embed Google Maps
       full_document.gsub!(/map\(([^)]*)\)/) do
-        google_maps_url = "https://www.google.com/maps/embed/v1/place?key=#{ENVied.GOOGLE_MAPS_API_KEY}&q=#{URI.escape($1)}"
-        "<iframe width='600' height='450' frameborder='0' style='border:0' src='#{google_maps_url}'></iframe>"
+        google_maps_url = "https://www.google.com/maps/embed/v1/place?key=#{ENVied.GOOGLE_MAPS_API_KEY}&q=#{URI.escape(CGI.unescapeHTML($1))}"
+        "<iframe width='600' height='450' frameborder='0' style='border:0' src=\"#{google_maps_url}\"></iframe>"
       end
 
       # Support embed YouTube videos


### PR DESCRIPTION
The problem in #763 was about disabled embed maps API.
But there was a map with prime sign inside the query (') that caused a problem as well. This sign is escaped as HTML by the markdown renderer before we encode it for the url, thus we end up with `&%2339;` instead of `'` as the part of the query. The solution is to unescape the piece of text we want to encode as the url part.