### PR TITLE
Enable table icon in the SimpleMDE

### DIFF
--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -223,7 +223,7 @@ $(function() {
       },
       toolbar: [
         'bold', 'italic', 'heading',
-        '|', 'quote', 'unordered-list', 'ordered-list',
+        '|', 'quote', 'unordered-list', 'ordered-list', 'table',
         '|', 'link', 'image',
         {
           name: 'map',


### PR DESCRIPTION
We already support rendering tables but I think that many people don't know that they can use them so It would be good to enable the option in the SimpleMDE. Also I've asked Ron and he likes this =)