### PR TITLE
In the Result -> Person association, always look for the current person (subId 1)

### DIFF
--- a/WcaOnRails/app/models/result.rb
+++ b/WcaOnRails/app/models/result.rb
@@ -2,7 +2,7 @@ class Result < ActiveRecord::Base
   self.table_name = "Results"
 
   belongs_to :competition, foreign_key: :competitionId
-  belongs_to :person, primary_key: :wca_id, foreign_key: :personId
+  belongs_to :person, -> { current }, primary_key: :wca_id, foreign_key: :personId
 
   scope :podium, -> { where(roundId: Round.final_rounds.map(&:id), pos: [1..3]).where("best > 0") }
 

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -578,4 +578,20 @@ RSpec.describe Competition do
       expect(competition.website).to eq "https://external.website.com"
     end
   end
+
+  context "competitors" do
+    let!(:competition) { FactoryGirl.build(:competition) }
+
+    it "works" do
+      FactoryGirl.create_list :result, 2, competition: competition
+      expect(competition.competitors.count).to eq 2
+    end
+
+    it "handles competitors with multiple subIds" do
+      person_with_sub_ids = FactoryGirl.create :person_with_multiple_sub_ids
+      FactoryGirl.create :result, competition: competition, person: person_with_sub_ids
+      FactoryGirl.create :result, competition: competition
+      expect(competition.competitors.count).to eq 2
+    end
+  end
 end

--- a/WcaOnRails/spec/models/result_spec.rb
+++ b/WcaOnRails/spec/models/result_spec.rb
@@ -54,4 +54,15 @@ RSpec.describe Result do
       expect(result.to_s :best).to eq "3/3 ?:??:??"
     end
   end
+
+  describe "person association" do
+    it "always looks for subId 1" do
+      person1 = FactoryGirl.create :person_with_multiple_sub_ids
+      person2 = Person.find_by!(wca_id: person1.wca_id, subId: 2)
+      result1 = FactoryGirl.create :result, person: person1
+      result2 = FactoryGirl.create :result, person: person2
+      expect(result1.person).to eq person1
+      expect(result2.person).to eq person1
+    end
+  end
 end


### PR DESCRIPTION
This fixes #776, but in a slightly different way from what @jonatanklosko suggested:

> I think I have a clean solution for this. By the way I can imagine other bugs linked with this. Basically I'd try to change this: https://github.com/cubing/worldcubeassociation.org/blob/master/WcaOnRails/app/models/competition.rb#L13 to `{ distinct.current }`. I don't have ability to check it out as I'm not at home, so it would be really nice if someone could try this and make a PR if this works =) I think it's worth solving fast to let Oliver post the report ASAP.

I opted to do this inside of Result, rather than Competition, because I think it would make sense for us to eventually make WCA IDs unique in the Persons table (and have a PastPersons table for old citizenships/names/genders), and this feels more in line with that hypothetical future: only one human being did this result in competition.