### PR TITLE
Add ability to specify the reason when rejecting an avatar

### DIFF
--- a/WcaOnRails/app/assets/javascripts/avatars.js
+++ b/WcaOnRails/app/assets/javascripts/avatars.js
@@ -1,0 +1,6 @@
+onPage('avatars#index', function() {
+  $('.actions').on('change', function() {
+    var $rejectButton = $('input[value="reject"]');
+    $rejectButton.closest('.row').find('.rejection-reason').toggle($rejectButton.prop('checked'));
+  }).trigger('change');
+});

--- a/WcaOnRails/app/mailers/avatars_mailer.rb
+++ b/WcaOnRails/app/mailers/avatars_mailer.rb
@@ -1,0 +1,12 @@
+class AvatarsMailer < ApplicationMailer
+  def notify_user_of_avatar_rejection(user, reason)
+    @user = user
+    @reason = reason
+
+    mail(
+      to: user.email,
+      reply_to: "notifications@worldcubeassociation.org",
+      subject: "Your avatar has been rejected",
+    )
+  end
+end

--- a/WcaOnRails/app/views/admin/avatars/index.html.erb
+++ b/WcaOnRails/app/views/admin/avatars/index.html.erb
@@ -16,16 +16,16 @@
               <div class="col-sm-6">
                 <div class="pending-avatar">
                   <%= link_to image_tag(user.pending_avatar), user.pending_avatar.url, target: "_blank", class: "hide-new-window-icon" %>
-                  <div class="btn-group" data-toggle="buttons">
-                    <% key = "avatar-" + user.wca_id %>
+                  <div class="btn-group actions" data-toggle="buttons">
+                    <% name = "avatars[#{user.wca_id}][action]" %>
                     <label class="btn btn-default btn-success">
-                      <%= radio_button_tag(key, "approve") %> Approve
+                      <%= radio_button_tag(name, "approve") %> Approve
                     </label>
                     <label class="btn btn-default btn-danger">
-                      <%= radio_button_tag(key, "reject") %> Reject
+                      <%= radio_button_tag(name, "reject") %> Reject
                     </label>
                     <label class="btn btn-default active">
-                      <%= radio_button_tag(key, "defer", checked: true) %> Defer
+                      <%= radio_button_tag(name, "defer", checked: true) %> Defer
                     </label>
                   </div>
                 </div>
@@ -75,6 +75,11 @@
                     </a>
                   </div>
                 <% end %>
+              </div>
+              <div class="col-sm-6">
+                <%= text_area_tag "avatars[#{user.wca_id}][rejection_reason]", "",
+                                  class: "form-control rejection-reason",
+                                  placeholder: "Please provide the reason for rejection" %>
               </div>
             </div>
           </div>

--- a/WcaOnRails/app/views/admin/avatars/index.html.erb
+++ b/WcaOnRails/app/views/admin/avatars/index.html.erb
@@ -4,6 +4,18 @@
   <%= render layout: "nav" do %>
     <h1><%= yield(:title) %></h1>
 
+    <div class="well">
+      <h3>Guidelines</h3>
+      <ul>
+        <li>All avatars should be pictures of real persons.</li>
+        <li>The person shown must be the involved member (as far as can be judged).</li>
+        <li>If there is more than one person on the avatar, it should be clear who is the involved member.</li>
+        <li>The head of the involved member, not necessarily the full face, should be visible.</li>
+        <li>The avatar should not include texts other than regular background texts.</li>
+        <li>If the correct orientation of the picture is clear (portrait or landscape) the picture must be submitted in that correct orientation.</li>
+      </ul>
+    </div>
+
     <%= form_tag admin_avatars_path, class: 'are-you-sure' do |f| %>
       <% @users.each do |user| %>
         <div class="panel panel-default">

--- a/WcaOnRails/app/views/avatars_mailer/notify_user_of_avatar_rejection.html.erb
+++ b/WcaOnRails/app/views/avatars_mailer/notify_user_of_avatar_rejection.html.erb
@@ -1,0 +1,12 @@
+<p>Hello <%= @user.name %></p>
+
+<p>Your new avatar request has been rejected.</p>
+
+<% if @reason.present? %>
+  <p>
+    Here's the reason:
+    <blockquote><%= @reason %></blockquote>
+  </p>
+<% end %>
+
+<p>Please provide more suitable picture.</p>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -59,33 +59,15 @@
       <li><a href="#preferences" data-toggle="tab"><%= t '.preferences' %></a></li>
       <li><a href="#password" data-toggle="tab"><%= t '.password' %></a></li>
     <% end %>
+    <% if @user.wca_id.present? %>
+      <li><a href="#avatar" data-toggle="tab">Avatar</a></li>
+    <% end %>
   </ul>
 
   <div class="tab-content" id="edit-user-tabs">
     <div class="tab-pane" id="general">
-      <%= simple_form_for @user, html: { multipart: true, class: 'are-you-sure' } do |f| %>
+      <%= simple_form_for @user, html: { class: 'are-you-sure' } do |f| %>
         <%= hidden_field_tag "section", "general" %>
-        <% if @user.wca_id.present? %>
-            <div class="row">
-              <% if @user.avatar? %>
-                <div class="col-sm-6">
-                  <%= image_tag @user.avatar.url, class: "img-responsive center-block" %>
-                </div>
-              <% end %>
-              <div class="col-sm-6">
-                <% if @user.avatar? %>
-                  <%= f.input :remove_avatar, as: :boolean, disabled: !editable_fields.include?(:remove_avatar) %>
-                  <p>Your account thumbnail:</p>
-                  <%= link_to users_avatar_thumbnail_edit_path(@user) do %>
-                    <%= render "shared/user_avatar", user: @user, title: "Click to edit thumbnail", break_cache: true %>
-                  <% end %>
-                <% end %>
-
-                <%= f.input :pending_avatar, as: :file, disabled: !editable_fields.include?(:pending_avatar) %>
-                <%= f.hidden_field :pending_avatar_cache %>
-              </div>
-            </div>
-        <% end %>
 
         <%= f.input :name, disabled: !editable_fields.include?(:name) %>
         <%= f.input :dob, as: :date_picker, disabled: !editable_fields.include?(:dob) %>
@@ -189,6 +171,44 @@
           <%= f.submit t('.save'), class: "btn btn-primary" %>
         <% end %>
       </div>
+
+      <% if @user.wca_id.present? %>
+        <div class="tab-pane active" id="avatar">
+          <%= simple_form_for @user, html: { multipart: true, class: 'are-you-sure' } do |f| %>
+            <%= hidden_field_tag "section", "avatar" %>
+
+            <div class="row">
+              <% if @user.avatar? %>
+                <div class="col-sm-6">
+                  <%= image_tag @user.avatar.url, class: "img-responsive center-block" %>
+                </div>
+              <% end %>
+              <div class="col-sm-6">
+                <div class="well">
+                  <h3><%=t '.guidelines' %></h3>
+                  <ul>
+                    <% t('.avatar_guidelines').values.each do |guideline| %>
+                      <li><%= guideline %></li>
+                    <% end %>
+                  </ul>
+                </div>
+                <% if @user.avatar? %>
+                  <%= f.input :remove_avatar, as: :boolean, disabled: !editable_fields.include?(:remove_avatar) %>
+                  <p>Your account thumbnail:</p>
+                  <%= link_to users_avatar_thumbnail_edit_path(@user) do %>
+                    <%= render "shared/user_avatar", user: @user, title: "Click to edit thumbnail", break_cache: true %>
+                  <% end %>
+                <% end %>
+
+                <%= f.input :pending_avatar, as: :file, disabled: !editable_fields.include?(:pending_avatar) %>
+                <%= f.hidden_field :pending_avatar_cache %>
+
+                <%= f.submit t('.save'), class: "btn btn-primary" %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
 
   </div>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -276,6 +276,15 @@ en:
           assigned: "you have a WCA ID assigned"
           registered: "you have registered for a competition"
       save: "Save"
+      guidelines: "Guidelines"
+      avatar_guidelines:
+        1: "All avatars should be pictures of real persons."
+        2: "The person shown must be you."
+        3: "If there is more than one person on the avatar, it should be clear who of them is you."
+        4: "Your head, but not necessarily the full face, should be visible."
+        5: "The avatar must not include texts other than regular background texts."
+        6: "The avatar must be submitted in correct orientation."
+
     errors:
       not_found: "not found"
       already_assigned: "already assigned to a different user"

--- a/WcaOnRails/spec/mailers/avatars_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/avatars_mailer_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe AvatarsMailer, type: :mailer do
+  describe "notify_user_of_avatar_rejection" do
+    let(:user) { FactoryGirl.create :user }
+    let(:rejection_reason) { "The avatar must not include texts other than regular background texts." }
+    let(:mail) { AvatarsMailer.notify_user_of_avatar_rejection(user, rejection_reason) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq "Your avatar has been rejected"
+      expect(mail.to).to eq [user.email]
+      expect(mail.reply_to).to eq ["notifications@worldcubeassociation.org"]
+      expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match user.name
+      expect(mail.body.encoded).to match rejection_reason
+    end
+  end
+end

--- a/WcaOnRails/spec/mailers/previews/avatars_mailer_preview.rb
+++ b/WcaOnRails/spec/mailers/previews/avatars_mailer_preview.rb
@@ -1,0 +1,8 @@
+# Preview all emails at http://localhost:3000/rails/mailers/avatars_mailer
+class AvatarsMailerPreview < ActionMailer::Preview
+  def notify_user_of_avatar_rejection
+    user = User.first
+    reason = "The avatar must not include texts other than regular background texts."
+    AvatarsMailer.notify_user_of_avatar_rejection(user, reason)
+  end
+end


### PR DESCRIPTION
Fixes #799.
When we check the *Reject* option, a textarea appears like so:

![reject-reason](https://cloud.githubusercontent.com/assets/17034772/17451922/dbcb1f90-5b6a-11e6-950d-63cfd3b3c916.png)

After submitting the form, an email will be sent automatically and will have this form:

> Hello [User name]
> 
> Your new avatar request has been rejected.
> 
> Here's the reason:
>     [The reason we've typed in the textarea]
> Please provide more suitable picture.