### PR TITLE
Fix highlighting and searching

### DIFF
--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -56,10 +56,10 @@ module ApplicationHelper
       index = text.index(phrase)
       index + phrase.length if index
     end.compact.max
-    excerpted = if first && last
+    excerpted = if first # At least one phrase matches the text.
                   excerpt(text, text[first..last], radius: WCA_EXCERPT_RADIUS)
                 else
-                  # If nothing matches the given phrase, just return the beginning.
+                  # If nothing matches the given phrases, just return the beginning.
                   truncate(text, length: WCA_EXCERPT_RADIUS)
                 end
     wca_highlight(excerpted, phrases)

--- a/WcaOnRails/app/models/post.rb
+++ b/WcaOnRails/app/models/post.rb
@@ -54,7 +54,7 @@ class Post < ActiveRecord::Base
   end
 
   def self.search(query, params: {})
-    posts = Post.where("world_readable = 1")
+    posts = Post.where(world_readable: true)
     query&.split&.each do |part|
       posts = posts.where("title LIKE :part OR body LIKE :part", part: "%#{part}%")
     end

--- a/WcaOnRails/app/models/post.rb
+++ b/WcaOnRails/app/models/post.rb
@@ -54,8 +54,11 @@ class Post < ActiveRecord::Base
   end
 
   def self.search(query, params: {})
-    sql_query = "%#{query}%"
-    Post.where("world_readable = 1 AND (title LIKE :sql_query OR body LIKE :sql_query)", sql_query: sql_query).order(created_at: :desc)
+    posts = Post.where("world_readable = 1")
+    query&.split&.each do |part|
+      posts = posts.where("title LIKE :part OR body LIKE :part", part: "%#{part}%")
+    end
+    posts.order(created_at: :desc)
   end
 
   def serializable_hash(options = nil)

--- a/WcaOnRails/app/views/search_results/index.html.erb
+++ b/WcaOnRails/app/views/search_results/index.html.erb
@@ -67,10 +67,10 @@
       <% @posts.each do |post| %>
         <div>
           <%= link_to post_path(post.slug) do %>
-            <h4><%= wca_highlight(post.title, @omni_query) %></h4>
+            <h4><%= wca_highlight(post.title, query_parts) %></h4>
           <% end %>
           <blockquote>
-            <%= wca_excerpt(md(post.body), @omni_query) %>
+            <%= wca_excerpt(md(post.body), query_parts) %>
           </blockquote>
         </div>
       <% end %>

--- a/WcaOnRails/app/views/search_results/index.html.erb
+++ b/WcaOnRails/app/views/search_results/index.html.erb
@@ -6,7 +6,8 @@
   <% if @omni_query.blank? %>
     <h3>Try searching for something!</h3>
   <% else %>
-    <% if !@competitions.empty? %>
+    <% query_parts = @omni_query.split %>
+    <% if @competitions.present? %>
       <h2><%= anchorable "Competitions" %></h2>
       <table class="table table-nonfluid">
         <tbody>
@@ -17,12 +18,12 @@
               </td>
               <td>
                 <%= link_to competition_path(competition) do %>
-                  <%= wca_highlight(competition.name, @omni_query) %>
+                  <%= wca_highlight(competition.name, query_parts) %>
                 <% end %>
               </td>
               <td>
-                <%= wca_highlight(competition.countryId, @omni_query) %>,
-                <%= wca_highlight(competition.cityName, @omni_query) %>
+                <%= wca_highlight(competition.countryId, query_parts) %>,
+                <%= wca_highlight(competition.cityName, query_parts) %>
               </td>
             </tr>
           <% end %>
@@ -31,7 +32,7 @@
       <%= paginate @competitions, param_name: :competitions_page, params: { anchor: "competitions" } %>
     <% end %>
 
-    <% if !@persons.empty? %>
+    <% if @persons.present? %>
       <h2>
         <%= anchorable "People" %> |
         <%= link_to icon("search", "Advanced search"), persons_path(search: params[:q]), class: "advanved-search" %>
@@ -44,11 +45,11 @@
                 <%= render "shared/user_avatar", user: (person.user || User.new) %>
               </td>
               <td>
-                <span class="wca-id"><%= wca_highlight(person.wca_id, @omni_query) %></span>
+                <span class="wca-id"><%= wca_highlight(person.wca_id, query_parts) %></span>
               </td>
               <td>
                 <%= link_to "/results/p.php?i=#{person.wca_id}" do %>
-                  <%= wca_highlight(person.name, @omni_query) %>
+                  <%= wca_highlight(person.name, query_parts) %>
                 <% end %>
               </td>
               <td>
@@ -61,7 +62,7 @@
       <%= paginate @persons, param_name: :people_page, params: { anchor: "people" } %>
     <% end %>
 
-    <% if !@posts.empty? %>
+    <% if @posts.present? %>
       <h2><%= anchorable "Posts" %></h2>
       <% @posts.each do |post| %>
         <div>

--- a/WcaOnRails/spec/helpers/application_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/application_helper_spec.rb
@@ -26,4 +26,12 @@ describe ApplicationHelper do
       expect(string).to eq '<a href="mailto:jfly@worldcubeassociation.org">Jeremy</a> and <a href="mailto:jonatan@worldcubeassociation.org">Jonatan O&#39;Klosko</a>'
     end
   end
+
+  describe "#wca_excerpt" do
+    it "handles multiple phrases correctly highlighting them" do
+      text = "A long text with a super word in the middle (directly here) followed by the rest of an awesome and peculiar sentence. What do you think?"
+      expected = "...t with a super word in the middle (directly here) <strong>followed</strong> by the rest of an awesome and peculiar sentence. What do you <strong>think</strong>?"
+      expect(helper.wca_excerpt(text, ["followed", "think"])).to eq expected
+    end
+  end
 end


### PR DESCRIPTION
This does a couple of things:
- Fixes highlighting of multi-part query like [this](https://www.worldcubeassociation.org/search?q=Jon%20sko) (as you can see it doesn't work now). I've fixed this by passing splitted query to the `wca_highlight`
- Enables more flexible search for `Post` by splitting one query into a couple. This implies changes to `wca_excerpt` method which now behaves as follows:
    - Finds first and last appearance of one of the query words
    - Gets all the text between them
    - Calls `excerpt` for this whole part
    - Highlights query words in the excerpted text

The text I've added should be a good example of this.
I hope the description makes sense.