### PR TITLE
Display # of registrations before deleting them

### DIFF
--- a/WcaOnRails/app/assets/javascripts/registrations.js
+++ b/WcaOnRails/app/assets/javascripts/registrations.js
@@ -21,7 +21,8 @@ onPage('registrations#edit_registrations', function() {
   showHideActions();
 
   $('button[value=delete-selected]').on("click", function(e) {
-    if(!confirm("Are you sure you want to delete the selected registrations?")) {
+    var $selectedRows = $registrationsTable.find("tr.selected");
+    if(!confirm("Delete the " + $selectedRows.length + " selected registrations?")) {
       e.preventDefault();
     }
   });


### PR DESCRIPTION
Display the number of registrations about to get deleted in the confirmation message.
This could help preventing accidental registrations deletions by making the organizer/delegate aware of how many of them are being deleted.
