### PR TITLE
Allow organizers to reply directly to registered user after receiving notification about his registration

### DIFF
--- a/WcaOnRails/app/mailers/registrations_mailer.rb
+++ b/WcaOnRails/app/mailers/registrations_mailer.rb
@@ -7,11 +7,9 @@ class RegistrationsMailer < ApplicationMailer
     if to.length > 0
       mail(
         to: to,
-        reply_to: registration.competition.managers.map(&:email),
+        reply_to: [registration.user.email],
         subject: "#{registration.name} just registered for #{registration.competition.name}"
       )
-    else
-      nil
     end
   end
 

--- a/WcaOnRails/spec/mailers/registrations_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/registrations_mailer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RegistrationsMailer, type: :mailer do
 
       expect(mail.subject).to eq("#{registration.name} just registered for #{registration.competition.name}")
       expect(mail.to).to eq([delegate1.email])
-      expect(mail.reply_to).to eq(competition_without_organizers.managers.map(&:email))
+      expect(mail.reply_to).to eq([registration.user.email])
       expect(mail.from).to eq(["notifications@worldcubeassociation.org"])
     end
 


### PR DESCRIPTION
From Ron:

> Would it be possible and suitable to set the competitor's mail address as the reply mail address for registration mails to organizers?
> 
> Now an organizer receives an email when a new competitor registers for one of his competitions.
> But if something is wrong in the registration, it is a bit of a hassle to contact the competitor.
> 
> Example:
> For the first competition in Algeria, 70% of the new competitors did not write their names correctly capitalized. Some also used a dob with year 2016.
> The organizer and the delegate cannot change the name or dob of these new competitors. (These are accounts of the website and they do not have access to change that.)
> Instead they have to contact the competitor. So then first they have to go to the competition admin page, copy the mail address and then paste it in their mail program.
> 
> It would be easier if an organizer could reply all to the registration mail directly.
> Then the reply would go to the competitor and the organiser could just say "please correct your name to .... then reply to this mail".
> 
> What do you think about this?