### PR TITLE
Demoted delegates wca id claim

### DIFF
--- a/WcaOnRails/app/mailers/wca_id_claim_mailer.rb
+++ b/WcaOnRails/app/mailers/wca_id_claim_mailer.rb
@@ -15,8 +15,9 @@ class WcaIdClaimMailer < ApplicationMailer
     @delegate = delegate
     mail(
       to: user.email,
-      reply_to: ["notifications@worldcubeassociation.org"],
-      subject: "The delegate to handle your WCA ID claim has been demoted"
+      cc: delegate.email,
+      reply_to: "notifications@worldcubeassociation.org",
+      subject: "Repeat your WCA ID claim"
     )
   end
 end

--- a/WcaOnRails/app/mailers/wca_id_claim_mailer.rb
+++ b/WcaOnRails/app/mailers/wca_id_claim_mailer.rb
@@ -17,7 +17,7 @@ class WcaIdClaimMailer < ApplicationMailer
       to: user.email,
       cc: delegate.email,
       reply_to: "notifications@worldcubeassociation.org",
-      subject: "Repeat your WCA ID claim"
+      subject: "Repeat your WCA ID claim",
     )
   end
 end

--- a/WcaOnRails/app/mailers/wca_id_claim_mailer.rb
+++ b/WcaOnRails/app/mailers/wca_id_claim_mailer.rb
@@ -10,13 +10,15 @@ class WcaIdClaimMailer < ApplicationMailer
     )
   end
 
-  def notify_user_of_delegate_demotion(user, delegate)
+  def notify_user_of_delegate_demotion(user, delegate, senior_delegate = nil)
     @user = user
     @delegate = delegate
+    reply_to = ["board@worldcubeassociation.org"]
+    reply_to << senior_delegate.email if senior_delegate
     mail(
       to: user.email,
-      cc: delegate.email,
-      reply_to: "notifications@worldcubeassociation.org",
+      cc: reply_to,
+      reply_to: reply_to,
       subject: "Repeat your WCA ID claim",
     )
   end

--- a/WcaOnRails/app/mailers/wca_id_claim_mailer.rb
+++ b/WcaOnRails/app/mailers/wca_id_claim_mailer.rb
@@ -9,4 +9,14 @@ class WcaIdClaimMailer < ApplicationMailer
       subject: "#{user_claiming_wca_id.email} just requested WCA ID #{user_claiming_wca_id.unconfirmed_wca_id}",
     )
   end
+
+  def notify_user_of_delegate_demotion(user, delegate)
+    @user = user
+    @delegate = delegate
+    mail(
+      to: user.email,
+      reply_to: ["notifications@worldcubeassociation.org"],
+      subject: "The delegate to handle your WCA ID claim has been demoted"
+    )
+  end
 end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -295,13 +295,9 @@ class User < ActiveRecord::Base
   after_save :remove_pending_wca_id_claims
   private def remove_pending_wca_id_claims
     if delegate_status_changed? && !delegate_status
-      User.where(delegate_id_to_handle_wca_id_claim: self.id).each do |user|
-        user.update(
-          delegate_id_to_handle_wca_id_claim: nil,
-          unconfirmed_wca_id: nil,
-          dob_verification: nil
-        )
-        WcaIdClaimMailer.notify_user_of_delegate_demotion(user, self).deliver_now
+      users_claiming_wca_id.each do |user|
+        user.update delegate_id_to_handle_wca_id_claim: nil, unconfirmed_wca_id: nil
+        WcaIdClaimMailer.notify_user_of_delegate_demotion(user, self).deliver_later
       end
     end
   end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -297,7 +297,8 @@ class User < ActiveRecord::Base
     if delegate_status_changed? && !delegate_status
       users_claiming_wca_id.each do |user|
         user.update delegate_id_to_handle_wca_id_claim: nil, unconfirmed_wca_id: nil
-        WcaIdClaimMailer.notify_user_of_delegate_demotion(user, self).deliver_later
+        senior_delegate = User.find_by_id(senior_delegate_id_was)
+        WcaIdClaimMailer.notify_user_of_delegate_demotion(user, self, senior_delegate).deliver_later
       end
     end
   end

--- a/WcaOnRails/app/views/wca_id_claim_mailer/notify_user_of_delegate_demotion.html.erb
+++ b/WcaOnRails/app/views/wca_id_claim_mailer/notify_user_of_delegate_demotion.html.erb
@@ -1,4 +1,4 @@
 <p>Hello <%= @user.name %></p>
 
-<p><%= @delegate.name %> - who you've picked to confirm your WCA ID is no longer delegate.</p>
-<p>Please repeat your claim here: <%= link_to "here", profile_claim_wca_id_url %>.</p>
+<p>Your WCA id claim could not be processed by <%= @delegate.name %>.</p>
+<p>Please make a new claim <%= link_to "here", profile_claim_wca_id_url %> choosing a different delegate.</p>

--- a/WcaOnRails/app/views/wca_id_claim_mailer/notify_user_of_delegate_demotion.html.erb
+++ b/WcaOnRails/app/views/wca_id_claim_mailer/notify_user_of_delegate_demotion.html.erb
@@ -1,0 +1,4 @@
+<p>Hello <%= @user.name %></p>
+
+<p><%= @delegate.name %> - who you've picked to confirm your WCA ID is no longer delegate.</p>
+<p>Please repeat your claim here: <%= link_to "here", profile_claim_wca_id_url %>.</p>

--- a/WcaOnRails/db/migrate/20160825124202_notify_users_of_delegates_demotion.rb
+++ b/WcaOnRails/db/migrate/20160825124202_notify_users_of_delegates_demotion.rb
@@ -1,0 +1,10 @@
+class NotifyUsersOfDelegatesDemotion < ActiveRecord::Migration
+  def change
+    User.where.not(unconfirmed_wca_id: nil).each do |user|
+      next if user.delegate_to_handle_wca_id_claim
+      demoted_delegate = User.find(user.delegate_id_to_handle_wca_id_claim)
+      user.update! delegate_id_to_handle_wca_id_claim: nil, unconfirmed_wca_id: nil
+      WcaIdClaimMailer.notify_user_of_delegate_demotion(user, demoted_delegate).deliver_later
+    end
+  end
+end

--- a/WcaOnRails/db/migrate/20160825124202_notify_users_of_delegates_demotion.rb
+++ b/WcaOnRails/db/migrate/20160825124202_notify_users_of_delegates_demotion.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class NotifyUsersOfDelegatesDemotion < ActiveRecord::Migration
   def change
     User.where.not(unconfirmed_wca_id: nil).each do |user|

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1061,3 +1061,4 @@ INSERT INTO schema_migrations (version) VALUES ('20160901120254');
 
 INSERT INTO schema_migrations (version) VALUES ('20160902230822');
 
+INSERT INTO schema_migrations (version) VALUES ('20160825124202');

--- a/WcaOnRails/spec/mailers/wca_id_claim_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/wca_id_claim_mailer_spec.rb
@@ -18,4 +18,24 @@ RSpec.describe WcaIdClaimMailer, type: :mailer do
       expect(mail.body.encoded).to match(edit_user_path(user_claiming_wca_id.id, anchor: "wca_id"))
     end
   end
+
+  describe "notify_user_of_delegate_demotion" do
+    let(:demoted_delegate) { FactoryGirl.create :user }
+    let(:user_claiming_wca_id) { FactoryGirl.create :user }
+    let(:mail) { WcaIdClaimMailer.notify_user_of_delegate_demotion(user_claiming_wca_id, demoted_delegate) }
+
+    it "sets appropriate headers" do
+      expect(mail.to).to eq [user_claiming_wca_id.email]
+      expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+      expect(mail.reply_to).to eq ["notifications@worldcubeassociation.org"]
+    end
+
+    it "renders body" do
+      expect(mail.subject).to eq "Repeat your WCA ID claim"
+      body = mail.body.encoded
+      expect(body).to match user_claiming_wca_id.name
+      expect(body).to match demoted_delegate.name
+      expect(body).to match profile_claim_wca_id_url
+    end
+  end
 end

--- a/WcaOnRails/spec/mailers/wca_id_claim_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/wca_id_claim_mailer_spec.rb
@@ -20,14 +20,20 @@ RSpec.describe WcaIdClaimMailer, type: :mailer do
   end
 
   describe "notify_user_of_delegate_demotion" do
+    let(:senior_delegate) { FactoryGirl.create :senior_delegate }
     let(:demoted_delegate) { FactoryGirl.create :user, name: "Sherlock Holmes" }
     let(:user_claiming_wca_id) { FactoryGirl.create :user, name: "Bilbo Baggins" }
     let(:mail) { WcaIdClaimMailer.notify_user_of_delegate_demotion(user_claiming_wca_id, demoted_delegate) }
+    let(:mail_with_senior) { WcaIdClaimMailer.notify_user_of_delegate_demotion(user_claiming_wca_id, demoted_delegate, senior_delegate) }
 
     it "sets appropriate headers" do
       expect(mail.to).to eq [user_claiming_wca_id.email]
       expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
-      expect(mail.reply_to).to eq ["notifications@worldcubeassociation.org"]
+      expect(mail.reply_to).to eq ["board@worldcubeassociation.org"]
+    end
+
+    it "replies to senior delegate as well if present" do
+      expect(mail_with_senior.reply_to).to eq ["board@worldcubeassociation.org", senior_delegate.email]
     end
 
     it "renders body" do

--- a/WcaOnRails/spec/mailers/wca_id_claim_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/wca_id_claim_mailer_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe WcaIdClaimMailer, type: :mailer do
   end
 
   describe "notify_user_of_delegate_demotion" do
-    let(:demoted_delegate) { FactoryGirl.create :user }
-    let(:user_claiming_wca_id) { FactoryGirl.create :user }
+    let(:demoted_delegate) { FactoryGirl.create :user, name: "Sherlock Holmes" }
+    let(:user_claiming_wca_id) { FactoryGirl.create :user, name: "Bilbo Baggins" }
     let(:mail) { WcaIdClaimMailer.notify_user_of_delegate_demotion(user_claiming_wca_id, demoted_delegate) }
 
     it "sets appropriate headers" do

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -319,7 +319,8 @@ RSpec.describe User, type: :model do
 
   describe "unconfirmed_wca_id" do
     let!(:person) { FactoryGirl.create :person, year: 1990, month: 1, day: 2 }
-    let!(:delegate) { FactoryGirl.create :delegate }
+    let!(:senior_delegate) { FactoryGirl.create :senior_delegate }
+    let!(:delegate) { FactoryGirl.create :delegate, senior_delegate: senior_delegate }
     let!(:user) do
       FactoryGirl.create(:user, unconfirmed_wca_id: person.wca_id,
                                 delegate_id_to_handle_wca_id_claim: delegate.id,
@@ -445,15 +446,15 @@ RSpec.describe User, type: :model do
 
     context "when the delegate to handle WCA ID claim is demoted" do
       it "sets delegate_id_to_handle_wca_id_claim and unconfirmed_wca_id to nil" do
-        delegate.update!(delegate_status: nil)
+        delegate.update!(delegate_status: nil, senior_delegate_id: nil)
         user.reload
         expect(user.delegate_id_to_handle_wca_id_claim).to eq nil
         expect(user.unconfirmed_wca_id).to eq nil
       end
 
       it "notifies the user via email" do
-        expect(WcaIdClaimMailer).to receive(:notify_user_of_delegate_demotion).with(user, delegate).and_call_original
-        delegate.update!(delegate_status: nil)
+        expect(WcaIdClaimMailer).to receive(:notify_user_of_delegate_demotion).with(user, delegate, senior_delegate).and_call_original
+        delegate.update!(delegate_status: nil, senior_delegate_id: nil)
       end
     end
   end


### PR DESCRIPTION
Fixes #827.
The solution is as follows:
- delegate status is change to nil (he's demoted)
- the appropriate attributes of the user are cleared
- the user receives a mail with appropriate information and is pleased to repeat the claim