### PR TITLE
Escape users name in the json response on users#index

### DIFF
--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -25,8 +25,8 @@ class UsersController < ApplicationController
           rows: @users.limit(params[:limit]).offset(params[:offset]).map do |user|
             {
               wca_id: user.wca_id ? view_context.link_to(user.wca_id, "/results/p.php?i=#{user.wca_id}") : "",
-              name: user.name,
-              email: user.email,
+              name: ERB::Util.html_escape(user.name),
+              email: ERB::Util.html_escape(user.email),
               edit: view_context.link_to("Edit", edit_user_path(user)),
             }
           end,


### PR DESCRIPTION
Problem: an user can put some HTML in his name and we 'execute' it in the table on the users#index page.

This PR is the first thought I got but I'm open to any more clever solutions.
Apart from name the rest of attributes seem safe.

Basically the problem is as follows:
When we use bootstrap-table, we render some HTML in a JSON response (things happen using Ajax).
Rails doesn't escape this HTML automatically.
Bootstrap-table has an option for escaping HTML 'table-wide' but this is not what we want as we render links in tables.

Other solution than the one I've done is to create `users.json.erb` but this is a bit cumbersome I think.