### PR TITLE
Fix google maps include url

### DIFF
--- a/WcaOnRails/app/views/layouts/application.html.erb
+++ b/WcaOnRails/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
   <%= javascript_include_tag 'application' %>
 
   <% if content_for :include_gmaps %>
-    <script type="text/javascript" src='//maps.google.com/maps/api/js?libraries=places&callback=wca._onGoogleMapsLoaded&<%= ENVied.GOOGLE_MAPS_API_KEY %>'></script>
+    <script type="text/javascript" src='//maps.google.com/maps/api/js?libraries=places&callback=wca._onGoogleMapsLoaded&key=<%= ENVied.GOOGLE_MAPS_API_KEY %>'></script>
   <% end %>
 
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Console logs Google Maps API Key error. I've no idea how things have been working well (embed maps for example).