### PR TITLE
Destroy delegate report when competition is destroyed

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -18,7 +18,7 @@ class Competition < ActiveRecord::Base
   has_many :organizers, through: :competition_organizers
   has_many :media, class_name: "CompetitionMedium", foreign_key: "competitionId", dependent: :delete_all
   has_many :tabs, -> { order(:display_order) }, dependent: :delete_all, class_name: "CompetitionTab"
-  has_one :delegate_report
+  has_one :delegate_report, dependent: :destroy
 
   CLONEABLE_ATTRIBUTES = %w(
     cityName

--- a/WcaOnRails/db/migrate/20160901120254_remove_delegate_reports_without_comps.rb
+++ b/WcaOnRails/db/migrate/20160901120254_remove_delegate_reports_without_comps.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RemoveDelegateReportsWithoutComps < ActiveRecord::Migration
   def change
     DelegateReport.all.reject(&:competition).each(&:destroy!)

--- a/WcaOnRails/db/migrate/20160901120254_remove_delegate_reports_without_comps.rb
+++ b/WcaOnRails/db/migrate/20160901120254_remove_delegate_reports_without_comps.rb
@@ -1,0 +1,5 @@
+class RemoveDelegateReportsWithoutComps < ActiveRecord::Migration
+  def change
+    DelegateReport.all.reject(&:competition).each(&:destroy!)
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1056,3 +1056,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160731181145');
 INSERT INTO schema_migrations (version) VALUES ('20160831212003');
 
 INSERT INTO schema_migrations (version) VALUES ('20160811013347');
+
+INSERT INTO schema_migrations (version) VALUES ('20160901120254');


### PR DESCRIPTION
As we create report on a competition creation, it makes sense to remove it when the competition is destroyed as well.