### PR TITLE
Fix typo in function call

### DIFF
--- a/WcaOnRails/app/views/admin/_nav.html.erb
+++ b/WcaOnRails/app/views/admin/_nav.html.erb
@@ -2,7 +2,7 @@
   <div class="col-sm-4 col-md-3">
     <div class="list-group">
       <% competitions_view = "/competitions"
-         competitions_view += "?display=admin" if current_user.can_see_admin_competitions %>
+         competitions_view += "?display=admin" if current_user.can_see_admin_competitions? %>
       <% [
         { text: "Upload results", path: "/results/admin/upload_results.php", fa_icon: "upload" },
         { text: "Create competition", path: new_competition_path, fa_icon: "plus" },


### PR DESCRIPTION
Fix a typo in the `can_see_admin_competitions?` call, which is causing the crash @SAuroux has reported.