### PR TITLE
Fix results_posted_at.

### DIFF
--- a/WcaOnRails/db/migrate/20160902230822_fix_results_posted_at.rb
+++ b/WcaOnRails/db/migrate/20160902230822_fix_results_posted_at.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class FixResultsPostedAt < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+      UPDATE Competitions
+      SET results_posted_at = (SELECT created_at
+        FROM posts
+        WHERE posts.title LIKE CONCAT('%wins ', Competitions.name,'%')
+        AND posts.created_at < '2016-04-19' AND posts.created_at > '2007-07-07')
+    SQL
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1059,3 +1059,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160831212003');
 
 INSERT INTO schema_migrations (version) VALUES ('20160901120254');
 
+INSERT INTO schema_migrations (version) VALUES ('20160902230822');
+


### PR DESCRIPTION
I wasn't happy with having results_posted_at being the competition end_date for all comps up to April 19th.
I'm not changing competitions before 2007-07-07 because posts were not very accurate at that time (it's only a handful of competitions)

Not sure if we should update the Results.updated_at field as well...