### PR TITLE
Teach jquery.are-you-sure to ignore disabled inputs.

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -6,6 +6,7 @@ onPage('competitions#edit, competitions#update, competitions#admin_edit, competi
   $('input[name="competition[generate_website]"]').on('change', function() {
     var generateWebsite = this.checked;
     $('div.competition_external_website').toggle(!generateWebsite);
+    $('input#competition_external_website').prop('disabled', generateWebsite);
   }).trigger('change');
 });
 

--- a/WcaOnRails/vendor/assets/javascripts/jquery.are-you-sure.js
+++ b/WcaOnRails/vendor/assets/javascripts/jquery.are-you-sure.js
@@ -68,13 +68,27 @@
       $field.data('ays-orig', getValue($field));
     };
 
-    var checkForm = function(evt) {
+    // Oftentimes, forms have some javascript that runs immediately when fields change.
+    // It makes sense to wait for those events to run (and possibly dirty or clean the form)
+    // before we check to see if the form is dirty. -JFLY
+    var checkForm = function(evt) {//JFLY
+      var that = this;
+      setTimeout(function() {//JFLY
+        checkFormNow.call(that, evt);//JFLY
+      }, 0);//JFLY
+    };//JFLY
+    var checkFormNow = function(evt) {
 
       var isFieldDirty = function($field) {
         var origValue = $field.data('ays-orig');
         if (undefined === origValue) {
           return false;
         }
+        if($field.is(":disabled")) {//JFLY
+          // Disabled fields cannot be dirty, as they won't
+          // submit anything to the server.
+          return false;//JFLY
+        }//JFLY
         if($field.data('ays-ignore-float-close')) {//JFLY
           var delta = parseFloat(getValue($field)) - parseFloat(origValue);//JFLY
           return delta > 1e-5;//JFLY


### PR DESCRIPTION
This was really bothering me. This is an alternative fix for #790 (see PR #790
for the original fix). I chose to go to the effort of tweaking [jquery.AreYouSure](https://github.com/codedance/jquery.AreYouSure) because the project appears to be abandonded (last commit September 2014), and I didn't really like the fix in #794 (see my comment [here](https://github.com/cubing/worldcubeassociation.org/pull/794#issuecomment-237382058))

It's surprising to me that the are-you-sure library tries to react to forms changing, rather than
checking for dirtyness at the time the user tried to navigate away from
the page. Checking whenever the form changes is tricky because disabling
a field doesn't cause an event to fire, but it *does* change the
dirtiness of a form (disabled fields aren't submitted, so they shouldn't
be considered dirty).