### PR TITLE
Fix img margin for WCA's logo in navigation.

### DIFF
--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -28,7 +28,7 @@
             <li><a href="/forum/" class="top-nav"><%= icon('comments') %> <%= t '.forum' %></a></li>
             <li class="divider"></li>
             <li><a href="<%= score_tools_path %>"><%= icon('wrench') %> <%= t '.tools' %></a></li>
-            <li><a href="<%= logo_path %>"><%= image_tag('wca_logo.svg', width: '16px') %> <%= t '.logo' %></a></li>
+            <li><a href="<%= logo_path %>"><%= image_tag('wca_logo.svg', width: '16px', class: 'fa') %> <%= t '.logo' %></a></li>
           </ul>
         </li>
         <li class="dropdown">


### PR DESCRIPTION
Fixes #855.

Since we want this img to behave like a fa icon I figured it would be just fine to add the `fa` class to it.