### PR TITLE
Change default location for `bundle install`

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -54,7 +54,6 @@ gem 'rack-cors', require: 'rack/cors'
 gem 'api-pagination'
 gem 'delayed_job_active_record'
 gem 'daemons'
-gem 'i18n-tasks', '~> 0.9.5'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-autosize'
@@ -72,6 +71,7 @@ group :development, :test do
 
   gem 'byebug'
   gem 'web-console'
+  gem 'i18n-tasks', '~> 0.9.5'
 end
 
 group :development do

--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -323,12 +323,14 @@ template "#{repo_root}/webroot/results/includes/_config.php" do
 end
 
 #### Initialize rails gems/database
-execute "bundle install --without none" do
+execute "bundle install #{'--deployment --without development test' if rails_env == 'production'} --path /home/#{username}/.bundle" do
+  user username
   cwd rails_root
   environment({
     "RACK_ENV" => rails_env,
   })
 end
+
 if node.chef_environment.start_with?("development")
   db_setup_lockfile = '/tmp/rake-db-setup-run'
   execute "bundle exec rake db:setup" do

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,7 +29,7 @@ rebuild_rails() {
     else
       export RAILS_ENV=development
     fi
-    bundle install --without none
+    bundle install
     bundle exec rake assets:clean assets:precompile
 
     # Note that we are intentionally not automating database migrations.


### PR DESCRIPTION
Fixes #840.

Make `username` do the `bundle install` to `~/.bundle`.

Also toggle the [deployment](http://bundler.io/man/bundle-install.1.html#DEPLOYMENT-MODE) flag when installing in production.
(the man says it "optimizes" for deployment, so let's do it...)

I set the path to `/home/user/.bundle` instead of `vendor/bundle`:
- to avoid potential conflict when using the same repo for both local and vagrant development
- because for some reason it makes running `bundle exec` extremely slow (when ran from inside the VM, with gems installed on the filesystem shared with the host). `strace`-ing it shows an insane amount of `open` syscall, so I guess it's the source of the slow down, but I don't know exactly why: both @jfly and I have a ssd and for him it's not awfully slow. He probably got a Ferrari while I have a Lada.