### PR TITLE
Fix the Factory call to not create name that have to be html-escaped

### DIFF
--- a/WcaOnRails/spec/mailers/avatars_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/avatars_mailer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe AvatarsMailer, type: :mailer do
   describe "notify_user_of_avatar_rejection" do
-    let(:user) { FactoryGirl.create :user }
+    let(:user) { FactoryGirl.create :user, name: "Sherlock Holmes" }
     let(:rejection_reason) { "The avatar must not include texts other than regular background texts." }
     let(:mail) { AvatarsMailer.notify_user_of_avatar_rejection(user, rejection_reason) }
 


### PR DESCRIPTION
This has just happened to @viroulep:
```
Failures:

  1) AvatarsMailer notify_user_of_avatar_rejection renders the body

     Failure/Error: expect(mail.body.encoded).to match user.name

       expected "<html>\r\n  <body>\r\n    <p>Hello Mrs. Daniela O&#39;Conner</p>\r\n\r\n<p>Your new avatar request has been rejected.</p>\r\n\r\n  <p>\r\n    Here's the reason:\r\n    <blockquote>The avatar must not include texts other than regular background texts.</blockquote>\r\n  </p>\r\n\r\n<p>Please provide more suitable picture.</p>\r\n\r\n  </body>\r\n</html>\r\n" to match "Mrs. Daniela O'Conner"

       Diff:

       @@ -1,2 +1,16 @@

       -Mrs. Daniela O'Conner

       +<html>

       +  <body>

       +    <p>Hello Mrs. Daniela O&#39;Conner</p>

       +

       +<p>Your new avatar request has been rejected.</p>

       +

       +  <p>

       +    Here's the reason:

       +    <blockquote>The avatar must not include texts other than regular background texts.</blockquote>

       +  </p>

       +

       +<p>Please provide more suitable picture.</p>

       +

       +  </body>

       +</html>
```
The fix is to create a user with name that doesn't have any characters that could be escaped (like `'`).