### PR TITLE
Update markercluster images url

### DIFF
--- a/WcaOnRails/vendor/assets/javascripts/markerclusterer.js
+++ b/WcaOnRails/vendor/assets/javascripts/markerclusterer.js
@@ -188,8 +188,12 @@ function MarkerClusterer(map, opt_markers, opt_options) {
  * @private
  */
 MarkerClusterer.prototype.MARKER_CLUSTER_IMAGE_PATH_ =
-    'https://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/' +
-    'images/m';
+    // Before:
+    // 'https://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/' +
+    // 'images/m';
+    // Workaround:
+    'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/images/m';
+    // See: https://github.com/googlemaps/js-marker-clusterer/issues/55#issuecomment-231219368
 
 
 /**


### PR DESCRIPTION
Fixes #860.

Issue: googlemaps/js-marker-clusterer/issues/55
Fix: https://github.com/googlemaps/js-marker-clusterer/issues/55#issuecomment-231219368

Another possibility is so set the imagePath when creating a new MarkerCluster (see [this comment](https://github.com/googlemaps/js-marker-clusterer/issues/55#issuecomment-222005594)) but as the URL is broken I think it makes sense to change it globally.