### PR TITLE
Upgrade to Mysql 5.6, which supports `COLLATE utf8_unicode_520_ci`

### DIFF
--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -71,7 +71,7 @@ rails_root = "#{repo_root}/WcaOnRails"
 
 #### Mysql
 mysql_service 'default' do
-  version '5.5'
+  version '5.6'
   initial_root_password secrets['mysql_password']
   # Force default socket to make rails happy
   socket "/var/run/mysqld/mysqld.sock"


### PR DESCRIPTION
This is part of #258.

I opted to only upgrade to mysql 5.6 because that's the latest version of our mysql cookbook that's tested on Ubuntu 14.04 according to https://supermarket.chef.io/cookbooks/mysql

![image](https://cloud.githubusercontent.com/assets/277474/18256313/7da4f89e-7368-11e6-86ea-40dba6475457.png)

@viroulep, could you take a look at this? I'd like to merge this up before you spin up a new server, if possible.

I'm testing right now that things still work in Vagrant.