### PR TITLE
Update to latest version of spring and update binstubs.

### DIFF
--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -378,7 +378,7 @@ GEM
       actionpack (~> 4.0)
       activemodel (~> 4.0)
     slop (3.6.0)
-    spring (1.4.3)
+    spring (1.7.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     sprockets (3.0.2)

--- a/WcaOnRails/bin/rails
+++ b/WcaOnRails/bin/rails
@@ -1,10 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 begin
-  spring_bin_path = File.expand_path('../spring', __FILE__)
-  load spring_bin_path
+  load File.expand_path('../spring', __FILE__)
 rescue LoadError => e
-  raise unless e.message.end_with? spring_bin_path, 'spring/binstub'
+  raise unless e.message.include?('spring')
 end
 APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'

--- a/WcaOnRails/bin/rake
+++ b/WcaOnRails/bin/rake
@@ -1,10 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 begin
-  spring_bin_path = File.expand_path('../spring', __FILE__)
-  load spring_bin_path
+  load File.expand_path('../spring', __FILE__)
 rescue LoadError => e
-  raise unless e.message.end_with? spring_bin_path, 'spring/binstub'
+  raise unless e.message.include?('spring')
 end
 require_relative '../config/boot'
 require 'rake'

--- a/WcaOnRails/bin/rspec
+++ b/WcaOnRails/bin/rspec
@@ -1,10 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 begin
-  spring_bin_path = File.expand_path('../spring', __FILE__)
-  load spring_bin_path
+  load File.expand_path('../spring', __FILE__)
 rescue LoadError => e
-  raise unless e.message.end_with? spring_bin_path, 'spring/binstub'
+  raise unless e.message.include?('spring')
 end
 require 'bundler/setup'
 load Gem.bin_path('rspec-core', 'rspec')

--- a/WcaOnRails/bin/spring
+++ b/WcaOnRails/bin/spring
@@ -9,7 +9,7 @@ unless defined?(Spring)
   require 'bundler'
 
   if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
-    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq }
+    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq.join(Gem.path_separator) }
     gem 'spring', match[1]
     require 'spring/binstub'
   end


### PR DESCRIPTION
I ran:

```
$ bundle update spring
$ bundle exec spring binstub --all
```

This should fix the bug where cron is failing on the production server:

```
Cron <cubing@production> (cd /home/cubing/worldcubeassociation.org/WcaOnRails; RACK_ENV=production bin/rake work:schedule)


/usr/lib/ruby/2.3.0/rubygems/dependency.rb:319:in `to_specs': Could not find 'spring' (= 1.4.3) among 121 total gem(s) (Gem::LoadError)
Checked in 'GEM_PATH=/home/cubing/.bundle/ruby/2.3.0:/home/cubing/.gem/ruby/2.3.0:/var/lib/gems/2.3.0:/usr/share/rubygems-integration/2.3.0:/usr/share/rubygems-integration/all', execute `gem env` for more information
        from /usr/lib/ruby/2.3.0/rubygems/dependency.rb:328:in `to_spec'
        from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_gem.rb:65:in `gem'
        from /home/cubing/worldcubeassociation.org/WcaOnRails/bin/spring:13:in `<top (required)>'
        from bin/rake:5:in `load'
        from bin/rake:5:in `<main>'
```