### PR TITLE
Fix a migration due to some db bugs

### DIFF
--- a/WcaOnRails/db/migrate/20160825124202_notify_users_of_delegates_demotion.rb
+++ b/WcaOnRails/db/migrate/20160825124202_notify_users_of_delegates_demotion.rb
@@ -3,9 +3,12 @@ class NotifyUsersOfDelegatesDemotion < ActiveRecord::Migration
   def change
     User.where.not(unconfirmed_wca_id: nil).each do |user|
       next if user.delegate_to_handle_wca_id_claim
-      demoted_delegate = User.find(user.delegate_id_to_handle_wca_id_claim)
-      user.update! delegate_id_to_handle_wca_id_claim: nil, unconfirmed_wca_id: nil
-      WcaIdClaimMailer.notify_user_of_delegate_demotion(user, demoted_delegate).deliver_later
+      demoted_delegate = User.find_by_id(user.delegate_id_to_handle_wca_id_claim)
+      # See why we need this `if` statement: https://github.com/cubing/worldcubeassociation.org/issues/889
+      if demoted_delegate
+        user.update! delegate_id_to_handle_wca_id_claim: nil, unconfirmed_wca_id: nil
+        WcaIdClaimMailer.notify_user_of_delegate_demotion(user, demoted_delegate).deliver_later
+      end
     end
   end
 end


### PR DESCRIPTION
A migration I've just done failed, I wouldn't expect this:
```
rb(main):007:0> User.where(delegate_id_to_handle_wca_id_claim: nil).where.not(unconfirmed_wca_id: nil).count
   (90.9ms)  SELECT COUNT(*) FROM `users` WHERE `users`.`delegate_id_to_handle_wca_id_claim` IS NULL AND (`users`.`unconfirmed_wca_id` IS NOT NULL)
=> 2596
irb(main):008:0> 
```