### PR TITLE
Update results model to use database joins in scopes - Fixes #890

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -599,11 +599,8 @@ class Competition < ActiveRecord::Base
 
   def winning_results
     light_results_from_relation(
-      results
-        .where(roundId: Round.final_rounds.map(&:id))
-        .where("pos = 1")
-        .where("best > 0")
-    ).sort_by { |r| r.event.rank }
+      results.winners
+    )
   end
 
   def person_ids_with_results

--- a/WcaOnRails/app/models/result.rb
+++ b/WcaOnRails/app/models/result.rb
@@ -5,8 +5,10 @@ class Result < ActiveRecord::Base
   belongs_to :competition, foreign_key: :competitionId
   belongs_to :person, -> { current }, primary_key: :wca_id, foreign_key: :personId
   belongs_to :round, foreign_key: :roundId
+  belongs_to :event, foreign_key: :eventId
 
-  scope :podium, -> { where(roundId: Round.final_rounds.map(&:id), pos: [1..3]).where("best > 0") }
+  scope :podium, -> { joins(:round).merge(Round.final_rounds).where(pos: [1..3]).where("best > 0") }
+  scope :winners, -> { joins(:round, :event).merge(Round.final_rounds).where("pos = 1 and best > 0").order("Events.rank") }
 
   def to_s(field)
     SolveTime.new(eventId, field, send(field)).clock_format


### PR DESCRIPTION
The podium scope was updated to join to the Rounds table.
A new winners scope was added which joins to the Rounds table for filtering
and the Events table for ordering.