### PR TITLE
Add option to sort by single and average in psych sheets - Fixes #295

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -38,7 +38,18 @@ class RegistrationsController < ApplicationController
   def psych_sheet_event
     @competition = competition_from_params
     @event = Event.find(params[:event_id])
-    @registrations = @competition.psych_sheet_event(@event)
+    @sort_by = params[:sort_by]
+    if @sort_by == @event.recommended_format.sort_by
+      @sort_by_second = @event.recommended_format.sort_by_second
+    elsif @sort_by == @event.recommended_format.sort_by_second
+      @sort_by_second = @event.recommended_format.sort_by
+      @sort_by = @event.recommended_format.sort_by_second
+    else
+      @sort_by = @event.recommended_format.sort_by
+      @sort_by_second = @event.recommended_format.sort_by_second
+    end
+
+    @registrations = @competition.psych_sheet_event(@event, @sort_by, @sort_by_second)
   end
 
   def index

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -666,7 +666,7 @@ class Competition < ActiveRecord::Base
     country ? Continent.find_by_id(country.continentId) : nil
   end
 
-  def psych_sheet_event(event)
+  def psych_sheet_event(event, sort_by, sort_by_second)
     joinsql = <<-ENDSQL
       join registration_events on registration_events.registration_id = Preregs.id
       join users on users.id = Preregs.user_id
@@ -688,7 +688,7 @@ class Competition < ActiveRecord::Base
       ifnull(RanksSingle.best, 0) single_best
     ENDSQL
 
-    sort_clause = "-#{event.recommended_format.sort_by}_rank desc, -#{event.recommended_format.sort_by_second}_rank desc, users.name"
+    sort_clause = "-#{sort_by}_rank desc, -#{sort_by_second}_rank desc, users.name"
 
     registrations = self.registrations.
                          accepted.
@@ -699,15 +699,15 @@ class Competition < ActiveRecord::Base
 
     prev_registration = nil
     registrations.each_with_index do |registration, i|
-      if event.recommended_format.sort_by == :single
+      if sort_by == 'single'
         rank = registration.single_rank
         prev_rank = prev_registration&.single_rank
       else
         rank = registration.average_rank
         prev_rank = prev_registration&.average_rank
       end
-      registration.tied_previous = (rank == prev_rank)
       break if !rank # hasn't competed in this event yet and all subsequent registrations too
+      registration.tied_previous = (rank == prev_rank)
       registration.pos = registration.tied_previous ? prev_registration.pos : i + 1
       prev_registration = registration
     end

--- a/WcaOnRails/app/views/registrations/psych_sheet_event.html.erb
+++ b/WcaOnRails/app/views/registrations/psych_sheet_event.html.erb
@@ -4,8 +4,11 @@
   <h2>
     <span class="cubing-icon icon-<%= @event.id %>"></span> <%= @event.name %> Psych Sheet
   </h2>
+  <p>
+  Sorted by: <%= @sort_by %>, sort by <a href="<%= competition_psych_sheet_event_path(@competition, @event.id) %>?sort_by=<%= @sort_by_second %>"><%= @sort_by_second %></a>
+  </p>
 
-  <%= wca_table table_class: "wca-results wca-results-sort-by-#{@event.recommended_format.sort_by.to_s}" do %>
+  <%= wca_table table_class: "wca-results wca-results-sort-by-#{@sort_by}" do %>
     <thead>
       <tr>
         <th class="pos">#</th>

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -371,26 +371,32 @@ RSpec.describe RegistrationsController do
       expect(registrations.map(&:accepted?).all?).to be true
     end
 
-    it "sorts 444 by average and handles ties" do
+    it "sorts 444 by single, and average, and handles ties" do
       registration1 = FactoryGirl.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
       FactoryGirl.create :ranks_average, rank: 10, best: 4242, eventId: "444", personId: registration1.personId
       FactoryGirl.create :ranks_single, rank: 20, best: 2000, eventId: "444", personId: registration1.personId
 
       registration2 = FactoryGirl.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
       FactoryGirl.create :ranks_average, rank: 10, best: 4242, eventId: "444", personId: registration2.personId
-      FactoryGirl.create :ranks_single, rank: 10, best: 2000, eventId: "444", personId: registration2.personId
+      FactoryGirl.create :ranks_single, rank: 10, best: 1900, eventId: "444", personId: registration2.personId
 
       registration3 = FactoryGirl.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
-      FactoryGirl.create :ranks_average, rank: 9, best: 4242, eventId: "444", personId: registration3.personId
+      FactoryGirl.create :ranks_average, rank: 9, best: 3232, eventId: "444", personId: registration3.personId
 
       registration4 = FactoryGirl.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
-      FactoryGirl.create :ranks_average, rank: 11, best: 4242, eventId: "444", personId: registration4.personId
+      FactoryGirl.create :ranks_average, rank: 11, best: 4545, eventId: "444", personId: registration4.personId
 
       get :psych_sheet_event, competition_id: competition.id, event_id: "444"
       registrations = assigns(:registrations)
       expect(registrations.map(&:id)).to eq [ registration3.id, registration2.id, registration1.id, registration4.id ]
       expect(registrations.map(&:pos)).to eq [ 1, 2, 2, 4 ]
       expect(registrations.map(&:tied_previous)).to eq [ false, false, true, false ]
+
+      get :psych_sheet_event, competition_id: competition.id, event_id: "444", sort_by: :single
+      registrations = assigns(:registrations)
+      expect(registrations.map(&:id)).to eq [ registration2.id, registration1.id, registration3.id, registration4.id ]
+      expect(registrations.map(&:pos)).to eq [ 1, 2, nil, nil ]
+      expect(registrations.map(&:tied_previous)).to eq [ false, false, nil, nil ]
     end
 
     it "handles missing average" do
@@ -468,6 +474,11 @@ RSpec.describe RegistrationsController do
       get :psych_sheet_event, competition_id: competition.id, event_id: "333bf"
       registrations = assigns(:registrations)
       expect(registrations.map(&:id)).to eq [ registration1.id, registration2.id ]
+      expect(registrations.map(&:pos)).to eq [ 1, 2 ]
+
+      get :psych_sheet_event, competition_id: competition.id, event_id: "333bf", sort_by: :average
+      registrations = assigns(:registrations)
+      expect(registrations.map(&:id)).to eq [ registration2.id, registration1.id ]
       expect(registrations.map(&:pos)).to eq [ 1, 2 ]
     end
 

--- a/WcaOnRails/spec/views/registrations/psych_sheet_event.html.erb_spec.rb
+++ b/WcaOnRails/spec/views/registrations/psych_sheet_event.html.erb_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe "registrations/psych_sheet_event" do
 
     assign(:competition, competition)
     assign(:event, event)
-    assign(:preferred_format, event.preferred_formats.first)
-    assign(:registrations, competition.psych_sheet_event(event))
+    assign(:preferred_format, event.recommended_format)
+    assign(:registrations, competition.psych_sheet_event(event, event.recommended_format.sort_by, event.recommended_format.sort_by_second))
 
     render
 


### PR DESCRIPTION
By default this sorts by the preferred format of the event. I've then added a small amount of text to show how this is sorted, with a link to sort by the other option. Here are some screenshots. Let me know what you think.

![sorted-by-single](https://cloud.githubusercontent.com/assets/4403168/18572725/f6579508-7c00-11e6-9981-030fa19fa8ff.png)

![sorted-by-average](https://cloud.githubusercontent.com/assets/4403168/18572729/fcebddde-7c00-11e6-80ca-300a83e6da9b.png)
