### PR TITLE
Fix a hidden N+1 query

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -54,7 +54,7 @@ class RegistrationsController < ApplicationController
 
   def index
     @competition = competition_from_params
-    @registrations = @competition.registrations.accepted.includes(:user, :registration_events)
+    @registrations = @competition.registrations.accepted.includes(:user, :registration_events, :events)
   end
 
   def edit

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -516,7 +516,7 @@ class Competition < ActiveRecord::Base
   # select events, unsaved events are still presented if
   # there are any validation issues on the form.
   def saved_and_unsaved_events
-    competition_events.reject(&:marked_for_destruction?).map(&:event).sort_by(&:rank)
+    competition_events.includes(:event).reject(&:marked_for_destruction?).map(&:event).sort_by(&:rank)
   end
 
   def nearby_competitions(days, distance)

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -33,10 +33,6 @@ class Registration < ActiveRecord::Base
     !pending?
   end
 
-  def events
-    registration_events.reject(&:marked_for_destruction?).map(&:event_object).sort_by(&:rank)
-  end
-
   def name
     user ? user.name : read_attribute(:name)
   end
@@ -93,7 +89,7 @@ class Registration < ActiveRecord::Base
   # select events, unsaved events are still presented if
   # there are any validation issues on the form.
   def saved_and_unsaved_events
-    registration_events.reject(&:marked_for_destruction?).map(&:event).sort_by(&:rank)
+    registration_events.includes(:event).reject(&:marked_for_destruction?).map(&:event).sort_by(&:rank)
   end
 
   def waiting_list_info

--- a/WcaOnRails/app/models/registration_event.rb
+++ b/WcaOnRails/app/models/registration_event.rb
@@ -5,12 +5,8 @@ class RegistrationEvent < ActiveRecord::Base
 
   validate :event_must_be_offered
   private def event_must_be_offered
-    if registration && !registration.competition.events.include?(event_object)
+    if registration && !registration.competition.events.include?(event)
       errors.add(:events, "invalid event id: #{event_id}")
     end
-  end
-
-  def event_object
-    Event.find(event_id)
   end
 end

--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -9,7 +9,7 @@
       <% else %>
         <h2><%= t 'registrations.list.approved_registrations' %></h2>
       <% end %>
-      <% registrations = @competition.registrations.public_send(status).includes(:user, :registration_events) %>
+      <% registrations = @competition.registrations.public_send(status).includes(:user, :registration_events, :events) %>
       <%= wca_table table_class: "registrations-table #{status}",
                     data: { toggle: "table", sort_name: "registration-date", select_item_name: "selected_registrations[]", click_to_select: "true" } do %>
         <thead>


### PR DESCRIPTION
Fixes #899.

I think all the "useless" selects we've seen on the edit_registrations page were created by the `map(&:event_object)` from `Registration.events` [here](https://github.com/cubing/worldcubeassociation.org/blob/fb29c4dfc1410e79cb4b4e372c5364a66aea63c5/WcaOnRails/app/models/registration.rb#L37).

IIRC, `marked_for_destruction?` should be use if we want to edit the events for a given registration, which is not the case here as we just want to read them.
Which lead me to the question: what do we need `Registration.events` for, as any view editing them will use [`saved_and_unsaved_events`](https://github.com/cubing/worldcubeassociation.org/blob/fb29c4dfc1410e79cb4b4e372c5364a66aea63c5/WcaOnRails/app/models/registration.rb#L95)?
I just went ahead and deleted the overriding method, and the N+1 query detector immediately spotted that we were doing something wrong, so it was easy to fix them.

So before merging this I'd like a feedback from @jonatanklosko or @pingskills to be sure all pages modifying the `registration_events` table use `Registration.saved_and_unsaved_events` ;)