### PR TITLE
First iteration on performance issues on edit registrations page

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -98,7 +98,7 @@ group :test do
   gem 'test_after_commit'
 end
 
+gem 'newrelic_rpm'
 group :production do
   gem 'unicorn'
-  gem 'newrelic_rpm'
 end

--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -27,6 +27,19 @@ class RegistrationsController < ApplicationController
 
   def edit_registrations
     @competition = competition_from_params
+    @registered_event_matrix = {}
+    comp_event_ids = @competition.event_ids.to_a
+    [:pending, :accepted].each do |status|
+      @registered_event_matrix[status] = @competition.registrations.public_send(status).includes(:registration_events).map do |reg|
+        comp_event_ids.map do |event_id|
+          if reg.registration_events.map(&:event_id).include?(event_id)
+            1
+          else
+            0
+          end
+        end
+      end
+    end
   end
 
   def psych_sheet

--- a/WcaOnRails/app/views/registrations/_edit_registrations_table_footer.html.erb
+++ b/WcaOnRails/app/views/registrations/_edit_registrations_table_footer.html.erb
@@ -6,8 +6,9 @@
     <% country_count = registrations.map(&:countryId).uniq.length %>
     <td><%= country_count %> <%= t('registrations.list.country').pluralize(country_count) %></td>
     <td></td>
-    <% @competition.events.each do |event| %>
-      <td><%= registrations.select { |r| r.events.include?(event) }.length %></td>
+    <% transposed = @registered_event_matrix[status].transpose %>
+    <% @competition.events.each_with_index do |event, i| %>
+      <td><%= transposed[i].reduce(0, :+) %></td>
     <% end %>
     <td></td>
     <td>

--- a/WcaOnRails/app/views/registrations/_header.html.erb
+++ b/WcaOnRails/app/views/registrations/_header.html.erb
@@ -1,0 +1,27 @@
+        <thead>
+          <tr>
+            <th data-checkbox="true"></th>
+            <th></th>
+            <th class="wca-id" data-sortable="true"><%= t 'common.user.wca_id' %></th>
+            <th class="name" data-sortable="true"><%= t 'activerecord.attributes.registration.name' %></th>
+            <th class="countryId" data-sortable="true"><%= t 'common.user.citizen_of' %></th>
+            <th class="birthday" data-sortable="true"><%= t 'activerecord.attributes.registration.birthday' %></th>
+            <% @competition.events.each do |event| %>
+              <th>
+                <span title="<%= event.name %>"
+                      class="cubing-icon icon-<%= event.id %>"
+                      data-toggle="tooltip"
+                      data-placement="bottom"
+                      data-container="body">
+                </span>
+              </th>
+            <% end %>
+            <th class="registration-date" data-sortable="true" data-field="registration-date"><%= t 'registrations.list.registered' %></th>
+            <th class="guests"><%= t 'activerecord.attributes.registration.guests' %></th>
+            <th class="comments"><%= t 'activerecord.attributes.registration.comments' %></th>
+            <th></th>
+
+            <!-- Extra column for .table-greedy-last-column -->
+            <th></th>
+          </tr>
+        </thead>

--- a/WcaOnRails/app/views/registrations/_row.html.erb
+++ b/WcaOnRails/app/views/registrations/_row.html.erb
@@ -1,0 +1,54 @@
+<tr id="registration-<%= registration.id %>" class="<%= registration.pending? ? "registration-pending" : "" %> <%= registration.accepted? ? "registration-accepted" : "" %>">
+  <td></td>
+
+  <td>
+    <%= link_to t('registrations.list.edit'), edit_registration_path(registration) %>
+  </td>
+
+  <td class="wca-id">
+    <% if registration.wca_id %>
+      <%= render "shared/wca_id", wca_id: registration.wca_id %>
+    <% end %>
+  </td>
+
+  <td class="name"><%= registration.name %></td>
+  <td class="countryId"><%= registration.countryId %></td>
+  <td class="birthday"><%= registration.birthday %></td>
+  <% @competition.events.each_with_index do |event, i| %>
+    <td>
+      <% if registration_events[i] == 1 %>
+        <span title="<%= event.name %>"
+              class="cubing-icon icon-<%= event.id %>"
+              data-toggle="tooltip"
+              data-placement="bottom"
+              data-container="body">
+        </span>
+      <% end %>
+    </td>
+  <% end %>
+  <td>
+    <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.created_at %>">
+      <%= registration.created_at.to_date %>
+    </span>
+  </td>
+  <td class="guests">
+    <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.guests %> <%= registration.guests_old %>">
+      <%= registration.guests %>
+      <% #https://github.com/cubing/worldcubeassociation.org/issues/403 %>
+      <%= registration.guests_old %>
+    </span>
+  </td>
+  <td class="comments">
+    <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.comments %>">
+      <%= registration.comments %>
+    </span>
+  </td>
+  <td>
+    <%= mail_to registration.email, target: "_blank", class: "hide-new-window-icon" do %>
+      <span class="glyphicon glyphicon-envelope"></span>
+    <% end %>
+  </td>
+
+  <!-- Extra column for .table-greedy-last-column -->
+  <td></td>
+</tr>

--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -12,94 +12,15 @@
       <% registrations = @competition.registrations.public_send(status).includes(:user, :registration_events) %>
       <%= wca_table table_class: "registrations-table #{status}",
                     data: { toggle: "table", sort_name: "registration-date", select_item_name: "selected_registrations[]", click_to_select: "true" } do %>
-        <thead>
-          <tr>
-            <th data-checkbox="true"></th>
-            <th></th>
-            <th class="wca-id" data-sortable="true"><%= t 'common.user.wca_id' %></th>
-            <th class="name" data-sortable="true"><%= t 'activerecord.attributes.registration.name' %></th>
-            <th class="countryId" data-sortable="true"><%= t 'common.user.citizen_of' %></th>
-            <th class="birthday" data-sortable="true"><%= t 'activerecord.attributes.registration.birthday' %></th>
-            <% @competition.events.each do |event| %>
-              <th>
-                <span title="<%= event.name %>"
-                      class="cubing-icon icon-<%= event.id %>"
-                      data-toggle="tooltip"
-                      data-placement="bottom"
-                      data-container="body">
-                </span>
-              </th>
-            <% end %>
-            <th class="registration-date" data-sortable="true" data-field="registration-date"><%= t 'registrations.list.registered' %></th>
-            <th class="guests"><%= t 'activerecord.attributes.registration.guests' %></th>
-            <th class="comments"><%= t 'activerecord.attributes.registration.comments' %></th>
-            <th></th>
 
-            <!-- Extra column for .table-greedy-last-column -->
-            <th></th>
-          </tr>
-        </thead>
-
+        <%= render "header" %>
         <tbody>
-          <% registrations.each do |registration| %>
-            <tr id="registration-<%= registration.id %>" class="<%= registration.pending? ? "registration-pending" : "" %> <%= registration.accepted? ? "registration-accepted" : "" %>">
-              <td></td>
-
-              <td>
-                <%= link_to t('registrations.list.edit'), edit_registration_path(registration) %>
-              </td>
-
-              <td class="wca-id">
-                <% if registration.wca_id %>
-                  <%= render "shared/wca_id", wca_id: registration.wca_id %>
-                <% end %>
-              </td>
-
-              <td class="name"><%= registration.name %></td>
-              <td class="countryId"><%= registration.countryId %></td>
-              <td class="birthday"><%= registration.birthday %></td>
-              <% @competition.events.each do |event| %>
-                <td>
-                  <% if registration.events.include?(event) %>
-                    <span title="<%= event.name %>"
-                          class="cubing-icon icon-<%= event.id %>"
-                          data-toggle="tooltip"
-                          data-placement="bottom"
-                          data-container="body">
-                    </span>
-                  <% end %>
-                </td>
-              <% end %>
-              <td>
-                <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.created_at %>">
-                  <%= registration.created_at.to_date %>
-                </span>
-              </td>
-              <td class="guests">
-                <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.guests %> <%= registration.guests_old %>">
-                  <%= registration.guests %>
-                  <% #https://github.com/cubing/worldcubeassociation.org/issues/403 %>
-                  <%= registration.guests_old %>
-                </span>
-              </td>
-              <td class="comments">
-                <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.comments %>">
-                  <%= registration.comments %>
-                </span>
-              </td>
-              <td>
-                <%= mail_to registration.email, target: "_blank", class: "hide-new-window-icon" do %>
-                  <span class="glyphicon glyphicon-envelope"></span>
-                <% end %>
-              </td>
-
-              <!-- Extra column for .table-greedy-last-column -->
-              <td></td>
-            </tr>
+          <% registrations.each_with_index do |registration, i| %>
+            <%= render "row", registration: registration, registration_events: @registered_event_matrix[status][i] %>
           <% end %>
         </tbody>
 
-        <%= render "edit_registrations_table_footer", registrations: registrations %>
+        <%= render "edit_registrations_table_footer", registrations: registrations, status: status %>
       <% end %>
     <% end %>
 


### PR DESCRIPTION
See #899.

With ~200 registrations (using modified development seeds) for a competition I get the following numbers for http://localhost:3000/competitions/MyComp5002018/edit/registrations using the production environment (timed using network tab in Chrome):
```
master: 9.7s, 10.2s, 9.6s, 9.7s
this branch: 585ms, 516ms, 522ms, 517ms
```

There are still a bunch of SQL calls to the `countries` table which we should remove as well, but at least this PR should fix the production errors.

What I did: Create a matrix of the form `{0,1}^(|events| x |registrations|)` before rendering the form. `1` means the competitor has registered for that event, `0` means he didn't. This representation had the advantage that I could reuse it for the footer (where we count the number of people who've registered for each event) by simply transposing the matrix and summing over each row.