### PR TITLE
Same N+1 fix for do_actions_for_selected...

### DIFF
--- a/WcaOnRails/app/views/registrations/do_actions_for_selected.js.erb
+++ b/WcaOnRails/app/views/registrations/do_actions_for_selected.js.erb
@@ -41,6 +41,6 @@ $registrationsTable.find('tr.selected').removeClass('selected');
 
 // Update registration table footers with summary info
 <% [:pending, :accepted].each do |status| %>
-  <% registrations = @competition.registrations.send(status) %>
+  <% registrations = @competition.registrations.includes(:events, :user).send(status) %>
   $<%= status %>Table.find('tfoot').replaceWith('<%=j render "edit_registrations_table_footer", registrations: registrations %>');
 <% end %>

--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -9,7 +9,7 @@
       <% else %>
         <h2><%= t 'registrations.list.approved_registrations' %></h2>
       <% end %>
-      <% registrations = @competition.registrations.public_send(status).includes(:user, :registration_events, :events) %>
+      <% registrations = @competition.registrations.public_send(status).includes(:user, :events) %>
       <%= wca_table table_class: "registrations-table #{status}",
                     data: { toggle: "table", sort_name: "registration-date", select_item_name: "selected_registrations[]", click_to_select: "true" } do %>
         <thead>


### PR DESCRIPTION
The `edit_registrations_table_footer` is also rendered from `do_actions_for_selected.js.erb`, so we need to fix the N+1 query there too...
Also the automatic tool don't notice it, but I don't think we need to include `registration_events` for this view anymore, since we get all our data through `events`.

Merging this immediately as it should have been part of #902, and because @timhabermaas reported the same performance issue on this action in #899.