### PR TITLE
Associate a country to a competition.

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -71,7 +71,7 @@ class CompetitionsController < ApplicationController
     @recent_selected = params[:state] == "recent"
 
     @years = ["all years"] + Competition.where(showAtAll: true).pluck(:year).uniq.select { |y| y <= Date.today.year }.sort!.reverse!
-    @competitions = Competition.where(showAtAll: true).order(:year, :month, :day)
+    @competitions = Competition.where(showAtAll: true).order(:year, :month, :day).includes(:country)
 
     if @present_selected
       @competitions = @competitions.where("CAST(CONCAT(year,'-',endMonth,'-',endDay) as Datetime) >= ?", Date.today)
@@ -89,7 +89,7 @@ class CompetitionsController < ApplicationController
     end
 
     unless params[:region] == "all"
-      @competitions = @competitions.select { |competition| competition.belongs_to_region?(params[:region]) }
+      @competitions = @competitions.includes(:continent).select { |competition| competition.belongs_to_region?(params[:region]) }
     end
 
     if params[:search].present?

--- a/WcaOnRails/app/views/competitions/_admin_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_admin_index_table.html.erb
@@ -33,7 +33,7 @@
           <tr>
             <td>
               <i class="flag f16 <%= competition.country.iso2.downcase %>"></i><%= link_to competition.cellName, competition_path(competition) %>
-              <br /><strong><%= competition.country_name %></strong>, <%= competition.cityName %>
+              <br /><strong><%= competition.country.name_in(:en) %></strong>, <%= competition.cityName %>
             </td>
             <td class="admin-delegate">
               <%= users_to_sentence competition.delegates %>

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -5,7 +5,7 @@
       <dd><%= wca_date_range(competition.start_date, competition.end_date) %></dd>
 
       <dt><%= t '.city' %></dt>
-      <dd><%= competition.cityName %>, <%= competition.country_name %></dd>
+      <dd><%= competition.cityName %>, <%= competition.country.name %></dd>
 
       <dt><%= t '.venue' %></dt>
       <dd><%=md competition.venue %></dd>

--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -25,7 +25,7 @@
           <%= link_to competition.cellName, competition_path(competition) %>
         </p>
         <p class="location">
-          <strong><%= competition.country_name %></strong>, <%= competition.cityName %>
+          <strong><%= competition.country.name %></strong>, <%= competition.cityName %>
         </p>
         <div class="venue-link">
           <%=md(competition.venue, target_blank: true) %>

--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -29,7 +29,7 @@
               data-toggle="tooltip" data-placement="top" data-container="body"
               title="<%= competition_message_for_user(competition, current_user) unless past %>">
             <td><%= link_to competition.name, competition_path(competition) %></td>
-            <td><%= competition.cityName %>, <%= competition.country_name %></td>
+            <td><%= competition.cityName %>, <%= competition.country.name %></td>
             <td><%= wca_date_range(competition.start_date, competition.end_date) %></td>
             <td>
               <% if registration %>

--- a/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
@@ -13,7 +13,7 @@
 
   <div>
     <strong>Location</strong>
-    <%= competition.cityName %>, <%= competition.country_name %>
+    <%= competition.cityName %>, <%= competition.country.name_in(:en) %>
     <%= link_to_google_maps_place competition.venueAddress, competition.latitude_degrees, competition.longitude_degrees %>
   </div>
 


### PR DESCRIPTION
This is a performance PR again.

I succeeded in running newrelic locally and noticed what @timhabermaas was talking about in #903: the `/competitions` fires a lot of mysql.find on countries (one per competition actually...) so I looked a bit into it, and associating a country to a competition revealed the N+1 query.

The performance improvement is not significant on my computer (~100 finds on countries are evaluated to 70ms) out of a ~1200ms total load time (It may be more significant on prod). There may be some more room for improvements, but they would be in the rendering and not on the mysql side.

I noticed we initially had a check in competition.country, is there any case where the competition would not have a country which is not in the db?

Note: the `/competitions/mine` also has the same issue on `country` and `delegate_report`, this is less annoying but could still be an issue for people with a lot of comps. However the way the competitions are retrieved [here](https://github.com/cubing/worldcubeassociation.org/blob/89f37a7c479063e5a1b789056e1b10e7ef40e216/WcaOnRails/app/controllers/competitions_controller.rb#L323) makes the changes awkward: it leads to unused eager loading in pages using `User` without using their comps. So I did not included them.