### PR TITLE
Override i18n-country-translations

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -24,6 +24,8 @@ en:
     XA: "Multiple Countries (Asia)"
     XE: "Multiple Countries (Europe)"
     XS: "Multiple Countries (South America)"
+    MO: "Macao"
+    HK: "Hong Kong"
   continents:
     AfR: "Africa"
     AsR: "Asia"

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -24,6 +24,8 @@ fr:
     XA: "Pays multiple (Asie)"
     XE: "Pays multiple (Europe)"
     XS: "Pays multiple (Amérique du Sud)"
+    MO: "Macau"
+    HK: "Hong Kong"
   continents:
     AfR: "Afrique"
     AsR: "Asie"


### PR DESCRIPTION
Looks like simply adding them to the locales works.
I'm not sure why I couldn't get it to work last time but there it just works fine!